### PR TITLE
Fix two minor issues with compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,8 +137,8 @@ SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS} -O3 -g3")
 # include directories 
 INCLUDE_DIRECTORIES( 
 	BEFORE 
-	${GF_INC_DIRS}
-	${ROOT_INCLUDE_DIRS})
+	${ROOT_INCLUDE_DIRS}
+	${GF_INC_DIRS})
 
 
 # add a target to generate API documentation with Doxygen

--- a/test/unitTests/main.cc
+++ b/test/unitTests/main.cc
@@ -68,6 +68,11 @@ enum e_testStatus {
   kException
 };
 
+// c++11 has isnan as a function in std namespace and gcc 5.3 will not accept
+// it without it unless imported
+#if __cplusplus > 199711L
+using std::isnan;
+#endif
 
 void handler(int sig) {
   void *array[10];


### PR DESCRIPTION
First, make sure that the include paths are in correct order and genfit includes are found before anything else.

Secondly, fix a c++11 problem with gcc5.3: isnan is no longer a macro but a function in std namespace