### PR TITLE
Next try with isnan: let's see if it works in C++03 with std::

### DIFF
--- a/test/unitTests/main.cc
+++ b/test/unitTests/main.cc
@@ -68,12 +68,6 @@ enum e_testStatus {
   kException
 };
 
-// c++11 has isnan as a function in std namespace and gcc 5.3 will not accept
-// it without it unless imported
-#if __cplusplus > 199711L
-using std::isnan;
-#endif
-
 void handler(int sig) {
   void *array[10];
   size_t size;
@@ -158,7 +152,7 @@ e_testStatus isCovMatrix(TMatrixTBase<double>& cov) {
 
   for (int i=0; i<cov.GetNrows(); ++i) {
     for (int j=0; j<cov.GetNcols(); ++j) {
-       if (isnan(cov(i,j))) {
+       if (std::isnan(cov(i,j))) {
          std::cout << "isCovMatrix: element isnan\n";
          return kFailed;
        }


### PR DESCRIPTION
As pointed out in #12 the previous fix for a compilation on gcc 5.3 does not work with gcc 4.9 and c++11.

This pull request basically reverts #10 and adds std:: to the isnan call. Testet on Ubuntu 14.04 and 16.04 with gcc 4.8, 4.9, 5.2 each with ROOT 6 (for c++11) and ROOT 5.34 (for c++03) so hopefully this should work everywhere.