### PR TITLE
changed order of parameters in DAF Constructor

### DIFF
--- a/fitters/include/DAF.h
+++ b/fitters/include/DAF.h
@@ -59,11 +59,11 @@ class DAF : public AbsKalmanFitter {
    *
    * @param useRefKalman If false, use KalmanFitter as fitter.
    */
-  DAF(bool useRefKalman = true, double deltaWeight = 1e-3, double deltaPval = 1e-3);
+  DAF(bool useRefKalman = true, double deltaPval = 1e-3, double deltaWeight = 1e-3);
   /**
    * @brief Create DAF. Use the provided AbsKalmanFitter as fitter.
    */
-  DAF(AbsKalmanFitter* kalman, double deltaWeight = 1e-3, double deltaPval = 1e-3);
+  DAF(AbsKalmanFitter* kalman, double deltaPval = 1e-3, double deltaWeight = 1e-3);
   ~DAF() {};
 
   //! Process a track using the DAF.


### PR DESCRIPTION
The Constructors in DAF.cc use a different parameter naming as in the header file DAF.h. deltaPval and deltaWeight is swapped. This is very error prone if users want to pass custom values for deltaPval and deltaWeight to the constructor, as actually the other value will be set.

This PR fixes the order and will not affect working code, as the ordering is kept the same in the actual implementation, merely the names are changed in the .h file.