### PR TITLE
Changed to use floating-point version of fabs in DAF

### DIFF
--- a/fitters/src/DAF.cc
+++ b/fitters/src/DAF.cc
@@ -131,7 +131,7 @@ void DAF::processTrackWithRep(Track* tr, const AbsTrackRep* rep, bool resortHits
     try{
       converged = calcWeights(tr, rep, betas_.at(iBeta));
       if (!converged && iBeta >= minIterations_-1 &&
-          status->getBackwardPVal() != 0 && abs(lastPval - status->getBackwardPVal()) < this->deltaPval_) {
+          status->getBackwardPVal() != 0 && fabs(lastPval - status->getBackwardPVal()) < this->deltaPval_) {
         if (debugLvl_ > 0) {
           debugOut << "converged by Pval = " << status->getBackwardPVal() << " even though weights changed at iBeta = " << iBeta << std::endl;
         }


### PR DESCRIPTION
The abs() method was used for floating point input values, which resulted in the output of abs being truncated to 0.0 for all values < 1.0. This in turn renders the early termination value deltaP useless, because the comparison in the fixed line is always smaller than deltaP's default of 0.001. Furthermore, we observed that different compiler versions/libraries interpret abs() differently. While GCC5 (with the Belle II software stack) used the integer version ::abs(), GCC6 stared to use the floating point version std::abs()

This PR fixes this ambiguity by using the fabs() method which is always properly interpreted as the floating point abs. On the Belle II track fitting side, the implications of the changed DAF behaviour are understood and will be applied with a custom deltaP setting: 
https://agira.desy.de/browse/BII-1712 (sorry, Belle II internal link)