### PR TITLE
TravisCI with ROOT6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,10 @@ addons:
     - clang
 before_install:
   # install boost and root
-  - sudo apt-get -y install libboost1.54-all-dev root-system
+  - sudo apt-get -y install libboost1.54-all-dev
+  - wget https://root.cern.ch/download/root_v6.06.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
+  - tar xvzf root_v6.06.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
+  - source root/bin/thisroot.sh
 install:
   # create dedicated build folder
   - cd .. && mkdir build && cd build


### PR DESCRIPTION
I checked the environment of TravisCI and it turns out that the ROOT6 binary provided at https://root.cern.ch/content/release-60608 is compatible with it. This allows us to run the integration build against the new ROOT version, which is also used at e.g. Belle II.
