### PR TITLE
No boost

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
     - clang
 before_install:
   # install boost and root
-  - sudo apt-get -y install libboost1.54-all-dev root-system
+  - sudo apt-get -y install root-system
 install:
   # create dedicated build folder
   - cd .. && mkdir build && cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,19 +84,6 @@ SET(GF_INC_DIRS
 #    $ENV{VALGRINDDIR}/include/
 )
 
-#search for boost, provide some information to user
-FIND_PACKAGE(Boost)
-IF (Boost_FOUND)
-    INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIR})
-    MESSAGE("-- Boost is found at: ${Boost_INCLUDE_DIR}")
-    INSTALL( DIRECTORY ${GF_INC_DIRS}
-    	DESTINATION ${INCLUDE_OUTPUT_DIRECTORY}
-	    PATTERN ".svn" EXCLUDE 
-	 )
-ELSE()
-    MESSAGE(SEND_ERROR " Boost was not found on your system, required for GENFIT.")
-ENDIF()
-
 
 IF(NOT CMAKE_BUILD_TYPE)
   SET(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING

--- a/GBL/include/GblFitterInfo.h
+++ b/GBL/include/GblFitterInfo.h
@@ -40,10 +40,7 @@
 #include "AbsHMatrix.h"
 
 #include <vector>
-
-#ifndef __CINT__
-#include <boost/scoped_ptr.hpp>
-#endif
+#include <memory>
 
 
 namespace genfit {
@@ -268,8 +265,8 @@ namespace genfit {
     TMatrixD hMatrix_;
     
     #ifndef __CINT__
-    mutable boost::scoped_ptr<MeasuredStateOnPlane> fittedStateBwd_; //!  cache
-    mutable boost::scoped_ptr<MeasuredStateOnPlane> fittedStateFwd_; //!  cache    
+    mutable std::unique_ptr<MeasuredStateOnPlane> fittedStateBwd_; //!  cache
+    mutable std::unique_ptr<MeasuredStateOnPlane> fittedStateFwd_; //!  cache
     #else
     class MeasuredStateOnPlane* fittedStateBwd_; //!  cache
     class MeasuredStateOnPlane* fittedStateFwd_; //!  cache    

--- a/GBL/src/GFGbl.cc
+++ b/GBL/src/GFGbl.cc
@@ -523,7 +523,7 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool resortH
       // Covariance matrix of measurement
       TMatrixDSym raw_cov = raw_meas->getRawHitCov();
       // Projection matrix from repository state to measurement coords
-      boost::scoped_ptr<const AbsHMatrix> HitHMatrix(raw_meas->constructHMatrix(rep));
+      std::unique_ptr<const AbsHMatrix> HitHMatrix(raw_meas->constructHMatrix(rep));
       // Residual between measured position and reference track position
       TVectorD residual = -1. * (raw_coor - HitHMatrix->Hv(state));
 

--- a/GBL/src/GblFitter.cc
+++ b/GBL/src/GblFitter.cc
@@ -77,7 +77,6 @@
 #include <TVectorDfwd.h>
 #include <TMatrixT.h>
 #include <TVector3.h>
-//#include "boost/algorithm/string.hpp"
 
 //#define DEBUG
 
@@ -153,8 +152,7 @@ void GblFitter::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool res
   int fitRes = 0;
   std::vector<std::string> gblIterations;
   gblIterations.push_back(m_gblInternalIterations);
-  //boost::split(gblIterations, m_gblInternalIterations, boost::is_any_of(","), boost::token_compress_off);
-  
+
   // Iterations and updates of fitter infos and fit status
   // ------------------------------------------------------------------- 
   for (unsigned int iIter = 0; iIter < m_externalIterations; iIter++) {

--- a/README.build
+++ b/README.build
@@ -5,9 +5,6 @@ To create the library, create a build directory and change into it. E.g.
  
 Now create the Makefiles by invoking:
   cmake ..
- 
-On some systems with an older boost version, you instead might have to type (cf. http://stackoverflow.com/questions/9948375/cmake-find-package-succeeds-but-returns-wrong-path):
-  cmake .. -DBoost_NO_BOOST_CMAKE=ON
 
 And build:
   make

--- a/core/include/DetPlane.h
+++ b/core/include/DetPlane.h
@@ -36,9 +36,7 @@
 #include <TObject.h>
 #include <TVector3.h>
 
-#ifndef __CINT__
-#include <boost/scoped_ptr.hpp>
-#endif
+#include <memory>
 
 
 namespace genfit {
@@ -188,7 +186,7 @@ class DetPlane : public TObject {
   TVector3 v_;
 
 #ifndef __CINT__
-  boost::scoped_ptr<AbsFinitePlane> finitePlane_; // Ownership
+  std::unique_ptr<AbsFinitePlane> finitePlane_; // Ownership
 #else
   class AbsFinitePlane* finitePlane_; //! Shut ROOT up, this class has a custom streamer.
 #endif

--- a/core/include/MeasuredStateOnPlane.h
+++ b/core/include/MeasuredStateOnPlane.h
@@ -29,6 +29,7 @@
 
 #include <TMatrixDSym.h>
 
+#include <cassert>
 
 namespace genfit {
 

--- a/core/include/MeasurementOnPlane.h
+++ b/core/include/MeasurementOnPlane.h
@@ -30,6 +30,7 @@
 #include <TMatrixD.h>
 
 #include <cmath>
+#include <memory>
 
 
 namespace genfit {
@@ -93,7 +94,7 @@ class MeasurementOnPlane : public MeasuredStateOnPlane {
  protected:
 
 #ifndef __CINT__
-  boost::scoped_ptr<const AbsHMatrix> hMatrix_; // Ownership
+  std::unique_ptr<const AbsHMatrix> hMatrix_; // Ownership
 #else
   const AbsHMatrix* hMatrix_; //! Ownership. Projection matrix
 #endif

--- a/core/include/SharedMaterialPropertiesPtr.h
+++ b/core/include/SharedMaterialPropertiesPtr.h
@@ -26,16 +26,14 @@
 
 #include "MaterialProperties.h"
 
-#ifndef __CINT__
-#include <boost/shared_ptr.hpp>
-#endif
+#include <memory>
 
 
 
 namespace genfit {
 
 #ifndef __CINT__
-typedef boost::shared_ptr< const genfit::MaterialProperties > SharedMaterialPropertiesPtr;
+typedef std::shared_ptr< const genfit::MaterialProperties > SharedMaterialPropertiesPtr;
 #else
 class SharedMaterialPropertiesPrt;
 #endif

--- a/core/include/SharedPlanePtr.h
+++ b/core/include/SharedPlanePtr.h
@@ -26,9 +26,7 @@
 
 #include "DetPlane.h"
 
-#ifndef __CINT__
-#include <boost/shared_ptr.hpp>
-#endif
+#include <memory>
 
 
 namespace genfit {
@@ -40,7 +38,7 @@ namespace genfit {
  * The DetPlane will automatically be deleted, if no owner remains.
  */
 #ifndef __CINT__
-typedef boost::shared_ptr< genfit::DetPlane > SharedPlanePtr;
+typedef std::shared_ptr< genfit::DetPlane > SharedPlanePtr;
 #else
 class SharedPlanePtr;
 #endif

--- a/core/include/StateOnPlane.h
+++ b/core/include/StateOnPlane.h
@@ -30,6 +30,8 @@
 #include <TObject.h>
 #include <TVectorD.h>
 
+#include <cassert>
+
 
 namespace genfit {
 

--- a/core/include/TrackPoint.h
+++ b/core/include/TrackPoint.h
@@ -33,10 +33,6 @@
 #include <vector>
 #include <memory>
 
-#ifndef __CINT__
-#include <boost/scoped_ptr.hpp>
-#endif
-
 
 namespace genfit {
 
@@ -149,7 +145,7 @@ class TrackPoint : public TObject {
   std::vector< AbsFitterInfo* > vFitterInfos_; //!
 
 #ifndef __CINT__
-  boost::scoped_ptr<ThinScatterer> thinScatterer_; // Ownership
+  std::unique_ptr<ThinScatterer> thinScatterer_; // Ownership
 #else
   class ThinScatterer* thinScatterer_;
 #endif

--- a/eventDisplay/src/EventDisplay.cc
+++ b/eventDisplay/src/EventDisplay.cc
@@ -54,8 +54,7 @@
 #include <TVectorD.h>
 #include <TSystem.h>
 
-#include "boost/scoped_ptr.hpp"
-
+#include <memory>
 
 ClassImp(genfit::EventDisplay)
 
@@ -308,12 +307,12 @@ void EventDisplay::drawEvent(unsigned int id, bool resetCam) {
     }
 
 
-    boost::scoped_ptr<Track> refittedTrack(nullptr);
+    std::unique_ptr<Track> refittedTrack(nullptr);
     if (refit_) {
 
       std::cout << "Refit track:" << std::endl;
 
-      boost::scoped_ptr<AbsKalmanFitter> fitter;
+      std::unique_ptr<AbsKalmanFitter> fitter;
       switch (fitterId_) {
         case SimpleKalman:
           fitter.reset(new KalmanFitter(nMaxIter_, dPVal_));

--- a/fitters/include/DAF.h
+++ b/fitters/include/DAF.h
@@ -27,6 +27,7 @@
 
 #include <vector>
 #include <map>
+#include <memory>
 
 
 namespace genfit {
@@ -124,7 +125,7 @@ class DAF : public AbsKalmanFitter {
 			// where time may be used in the fit.  Zeroth
 			// entry is not used.
 #ifndef __CINT__
-  boost::scoped_ptr<AbsKalmanFitter> kalman_;
+  std::unique_ptr<AbsKalmanFitter> kalman_;
 #else
   AbsKalmanFitter* kalman_;
 #endif

--- a/fitters/include/KalmanFitter.h
+++ b/fitters/include/KalmanFitter.h
@@ -25,9 +25,7 @@
 
 #include "AbsKalmanFitter.h"
 
-#ifndef __CINT__
-#include <boost/scoped_ptr.hpp>
-#endif
+#include <memory>
 
 
 namespace genfit {
@@ -71,7 +69,7 @@ class KalmanFitter : public AbsKalmanFitter {
       const AbsTrackRep* rep, double& chi2, double& ndf, int direction);
 
 #ifndef __CINT__
-  boost::scoped_ptr<MeasuredStateOnPlane> currentState_;
+  std::unique_ptr<MeasuredStateOnPlane> currentState_;
 #else
   MeasuredStateOnPlane* currentState_;
 #endif

--- a/fitters/include/KalmanFitterInfo.h
+++ b/fitters/include/KalmanFitterInfo.h
@@ -32,9 +32,7 @@
 
 #include <vector>
 
-#ifndef __CINT__
-#include <boost/scoped_ptr.hpp>
-#endif
+#include <memory>
 
 
 namespace genfit {
@@ -117,13 +115,13 @@ class KalmanFitterInfo : public AbsFitterInfo {
 
 #ifndef __CINT__
   //! Reference state. Used by KalmanFitterRefTrack.
-  boost::scoped_ptr<ReferenceStateOnPlane> referenceState_; // Ownership
-  boost::scoped_ptr<MeasuredStateOnPlane> forwardPrediction_; // Ownership
-  boost::scoped_ptr<KalmanFittedStateOnPlane> forwardUpdate_; // Ownership
-  boost::scoped_ptr<MeasuredStateOnPlane> backwardPrediction_; // Ownership
-  boost::scoped_ptr<KalmanFittedStateOnPlane> backwardUpdate_; // Ownership
-  mutable boost::scoped_ptr<MeasuredStateOnPlane> fittedStateUnbiased_; //!  cache
-  mutable boost::scoped_ptr<MeasuredStateOnPlane> fittedStateBiased_; //!  cache
+  std::unique_ptr<ReferenceStateOnPlane> referenceState_; // Ownership
+  std::unique_ptr<MeasuredStateOnPlane> forwardPrediction_; // Ownership
+  std::unique_ptr<KalmanFittedStateOnPlane> forwardUpdate_; // Ownership
+  std::unique_ptr<MeasuredStateOnPlane> backwardPrediction_; // Ownership
+  std::unique_ptr<KalmanFittedStateOnPlane> backwardUpdate_; // Ownership
+  mutable std::unique_ptr<MeasuredStateOnPlane> fittedStateUnbiased_; //!  cache
+  mutable std::unique_ptr<MeasuredStateOnPlane> fittedStateBiased_; //!  cache
 #else
   class ReferenceStateOnPlane* referenceState_;
   class MeasuredStateOnPlane* forwardPrediction_;

--- a/fitters/src/KalmanFitterRefTrack.cc
+++ b/fitters/src/KalmanFitterRefTrack.cc
@@ -29,8 +29,6 @@
 #include "KalmanFitterInfo.h"
 #include "KalmanFitStatus.h"
 
-#include "boost/scoped_ptr.hpp"
-
 #include <TDecompChol.h>
 #include <Math/ProbFunc.h>
 

--- a/fitters/src/KalmanFitterRefTrack.cc
+++ b/fitters/src/KalmanFitterRefTrack.cc
@@ -353,7 +353,7 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
 
   // declare stuff
   KalmanFitterInfo* prevFitterInfo(nullptr);
-  boost::scoped_ptr<MeasuredStateOnPlane> firstBackwardUpdate;
+  std::unique_ptr<MeasuredStateOnPlane> firstBackwardUpdate;
 
   ReferenceStateOnPlane* referenceState(nullptr);
   ReferenceStateOnPlane* prevReferenceState(nullptr);
@@ -579,7 +579,7 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
 
 
       // do extrapolation and set reference state infos
-      boost::scoped_ptr<StateOnPlane> stateToExtrapolate(nullptr);
+      std::unique_ptr<StateOnPlane> stateToExtrapolate(nullptr);
       if (prevFitterInfo == nullptr) { // first measurement
         if (debugLvl_ > 0) {
           debugOut << "prevFitterInfo == nullptr \n";


### PR DESCRIPTION
C++11 features the pointers which are used from boost [1]. They can be substituted and the dependency to boost will be gone.

[1]
boost::shared_ptr to std::shared_ptr
boost::scoped_ptr to std::unique_ptr