### PR TITLE
Fixing the track point streamer

### DIFF
--- a/core/include/TrackPoint.h
+++ b/core/include/TrackPoint.h
@@ -137,12 +137,12 @@ class TrackPoint : public TObject {
   std::map< const AbsTrackRep*, AbsFitterInfo* > fitterInfos_; //! Ownership over FitterInfos
 
   /**
-   * The following vector is read while streaming.  After reading the
+   * The following map is read while streaming.  After reading the
    * TrackPoint, the Track's streamer will call fixupRepsForReading,
-   * and this vector will be translated into the map fitterInfos. The
-   * vector is indexed by the ids of the corresponding TrackReps.
+   * and this map will be translated into the map fitterInfos. The
+   * map is indexed by the ids of the corresponding TrackReps.
    */
-  std::vector< AbsFitterInfo* > vFitterInfos_; //!
+  std::map<unsigned int, AbsFitterInfo*> vFitterInfos_; //!
 
 #ifndef __CINT__
   std::unique_ptr<ThinScatterer> thinScatterer_; // Ownership


### PR DESCRIPTION
During basf2 development, a bug in the TrackPoint::Streamer was found, which leads to a crash (see https://agira.desy.de/browse/BII-1836 if you have access).
In short: The Streamer silently assumes, that there is a continuous list of track representations (with continuous integer-valued ids from 0 to n-1) in each track point fit status. This may not be true for multiple hypothesis fitting, because some of the hypothesis may fail.