### PR TITLE
Travis: add ROOT 5 testing and fix that, bump ROOT 6. Enforce C++11. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ notifications:
   email:
     on_success: change
     on_failure: always
+env:
+  matrix:
+    - ROOT_VERSION=root_v6.08.00.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
+    - ROOT_VERSION=root_v5.34.36.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
 compiler: gcc
 addons:
   apt:
@@ -14,8 +18,8 @@ addons:
     - clang
 before_install:
   # install root
-  - wget https://root.cern.ch/download/root_v6.06.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
-  - tar xvzf root_v6.06.08.Linux-ubuntu14-x86_64-gcc4.8.tar.gz
+  - wget https://root.cern.ch/download/${ROOT_VERSION}
+  - tar xvzf ${ROOT_VERSION}
   - source root/bin/thisroot.sh
 install:
   # create dedicated build folder

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,11 +97,10 @@ ENDIF(NOT CMAKE_BUILD_TYPE)
 #SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
 
 include(CheckCXXCompilerFlag)
-SET(CPP_STANDARD c++03)
-# ROOT 6 requires C++11 support, enforced via headers
-IF (ROOT_found_version GREATER 59900)
-    SET(CPP_STANDARD c++11)
-ENDIF()
+
+# C++11 support is required by the codebase, and in any case enforced if ROOT 6 is used.
+SET(CPP_STANDARD c++11)
+
 MESSAGE(STATUS "Using C++ standard ${CPP_STANDARD}.")
 check_cxx_compiler_flag(-std=${CPP_STANDARD} HAS_STD_FLAG)
 check_cxx_compiler_flag(--std=${CPP_STANDARD} HAS_STD_FLAG_ALTERNATIVE)

--- a/core/src/TrackPoint.cc
+++ b/core/src/TrackPoint.cc
@@ -24,6 +24,7 @@
 #include "KalmanFitterInfo.h"
 #include "IO.h"
 
+#include <algorithm>
 #include <TBuffer.h>
 
 namespace genfit {

--- a/test/makeGeom.C
+++ b/test/makeGeom.C
@@ -41,11 +41,11 @@ void makeGeom()
 
 
    TGeoMedium *vacuum = gGeoManager->GetMedium("vacuum");
-   assert(vacuum!=nullptr);
+   assert(vacuum!=NULL);
    TGeoMedium *air = gGeoManager->GetMedium("air");
-   assert(air!=nullptr);
+   assert(air!=NULL);
    TGeoMedium *sil = gGeoManager->GetMedium("silicon");
-   assert(sil!=nullptr);
+   assert(sil!=NULL);
 
    TGeoVolume *top = gGeoManager->MakeBox("TOPPER", air, 1000., 1000., 1000.);
    gGeoManager->SetTopVolume(top); // mandatory !


### PR DESCRIPTION
GenFit master was broken for a while with ROOT 5 since C++11 features were used, but C++11 was only enforced as a standard if compiled against ROOT 6. 

This two commit series adds: 
- Travis testing for both ROOT 5 and ROOT 6. ROOT 6 version is bumped. 
- Always require C++11, GenFit itself needs this by now. 
- Add a missing include (which is exposed via `TBuffer.h` in ROOT 6, but not in ROOT 5). 
- Use `NULL` instead of `nullptr` in the asserts in the testing-macro for ROOT 5 compatibility. No other adaptions were needed. 

This fixes compilation with ROOT 5 and ensures it stays tested. 