### PR TITLE
Issue #38 Exceptions instead of Assertions

### DIFF
--- a/core/include/Track.h
+++ b/core/include/Track.h
@@ -290,7 +290,7 @@ class Track : public TObject {
 
   void Print(const Option_t* = "") const;
 
-  bool checkConsistency() const;
+  void checkConsistency() const;
 
  private:
 

--- a/core/src/AbsFitter.cc
+++ b/core/src/AbsFitter.cc
@@ -33,8 +33,7 @@ void AbsFitter::processTrack(Track* tr, bool resortHits) {
       processTrackWithRep(tr, tr->getTrackRep(i), false);
   }
 
-  // self check
-  assert(tr->checkConsistency());
+  tr->checkConsistency();
 }
 
 } /* End of namespace genfit */

--- a/core/src/Track.cc
+++ b/core/src/Track.cc
@@ -1288,6 +1288,8 @@ void Track::checkConsistency() const {
   }
 
   if (covSeed_.Max() == 0.) {
+    // Nota bene: The consistency is not set to false when this occurs, because it does not break the consistency of
+    // the track. However, when something else fails we keep this as additional error information.
     failures << "Track::checkConsistency(): Warning: covSeed_ is zero" << std::endl;
     //consistent = false;
   }

--- a/core/src/Track.cc
+++ b/core/src/Track.cc
@@ -1291,7 +1291,6 @@ void Track::checkConsistency() const {
     // Nota bene: The consistency is not set to false when this occurs, because it does not break the consistency of
     // the track. However, when something else fails we keep this as additional error information.
     failures << "Track::checkConsistency(): Warning: covSeed_ is zero" << std::endl;
-    //consistent = false;
   }
 
   // check if correct number of fitStatuses

--- a/core/src/Track.cc
+++ b/core/src/Track.cc
@@ -68,8 +68,7 @@ Track::Track(const TrackCand& trackCand, const MeasurementFactory<AbsMeasurement
   // fill cache
   fillPointsWithMeasurement();
 
-  // self test
-  assert(checkConsistency());
+  checkConsistency();
 }
 
 void
@@ -123,7 +122,7 @@ Track::Track(const Track& rhs) :
   cardinalRep_(rhs.cardinalRep_), mcTrackId_(rhs.mcTrackId_), timeSeed_(rhs.timeSeed_),
   stateSeed_(rhs.stateSeed_), covSeed_(rhs.covSeed_)
 {
-  assert(rhs.checkConsistency());
+  rhs.checkConsistency();
 
   std::map<const AbsTrackRep*, AbsTrackRep*> oldRepNewRep;
 
@@ -145,8 +144,7 @@ Track::Track(const Track& rhs) :
 
   fillPointsWithMeasurement();
 
-  // self test
-  assert(checkConsistency());
+  checkConsistency();
 }
 
 Track& Track::operator=(Track other) {
@@ -158,8 +156,7 @@ Track& Track::operator=(Track other) {
 
   fillPointsWithMeasurement();
 
-  // self test
-  assert(checkConsistency());
+  checkConsistency();
 
   return *this;
 }
@@ -1272,58 +1269,59 @@ void Track::Print(const Option_t* option) const {
 }
 
 
-bool Track::checkConsistency() const {
+void Track::checkConsistency() const {
 
-  bool retVal(true);
+  bool consistent = true;
+  std::stringstream failures;
 
   std::map<const AbsTrackRep*, const KalmanFitterInfo*> prevFis;
 
   // check if seed is 6D
   if (stateSeed_.GetNrows() != 6) {
-    errorOut << "Track::checkConsistency(): stateSeed_ dimension != 6" << std::endl;
-    retVal = false;
+    failures << "Track::checkConsistency(): stateSeed_ dimension != 6" << std::endl;
+    consistent = false;
   }
 
   if (covSeed_.GetNrows() != 6) {
-    errorOut << "Track::checkConsistency(): covSeed_ dimension != 6" << std::endl;
-    retVal = false;
+    failures << "Track::checkConsistency(): covSeed_ dimension != 6" << std::endl;
+    consistent = false;
   }
 
   if (covSeed_.Max() == 0.) {
-    errorOut << "Track::checkConsistency(): Warning: covSeed_ is zero" << std::endl;
-    //retVal = false;
+    failures << "Track::checkConsistency(): Warning: covSeed_ is zero" << std::endl;
+    //consistent = false;
   }
 
   // check if correct number of fitStatuses
   if (fitStatuses_.size() != trackReps_.size()) {
-    errorOut << "Track::checkConsistency(): Number of fitStatuses is != number of TrackReps " << std::endl;
-    retVal = false;
+    failures << "Track::checkConsistency(): Number of fitStatuses is != number of TrackReps " << std::endl;
+    consistent = false;
   }
 
   // check if cardinalRep_ is in range of trackReps_
   if (trackReps_.size() && cardinalRep_ >= trackReps_.size()) {
-    errorOut << "Track::checkConsistency(): cardinalRep id " << cardinalRep_ << " out of bounds" << std::endl;
-    retVal = false;
+    failures << "Track::checkConsistency(): cardinalRep id " << cardinalRep_ << " out of bounds" << std::endl;
+    consistent = false;
   }
 
   for (std::vector<AbsTrackRep*>::const_iterator rep = trackReps_.begin(); rep != trackReps_.end(); ++rep) {
     // check for nullptr
     if ((*rep) == nullptr) {
-      errorOut << "Track::checkConsistency(): TrackRep is nullptr" << std::endl;
-      retVal = false;
+      failures << "Track::checkConsistency(): TrackRep is nullptr" << std::endl;
+      consistent = false;
     }
 
     // check for valid pdg code
     TParticlePDG* particle = TDatabasePDG::Instance()->GetParticle((*rep)->getPDG());
     if (particle == nullptr) {
-      errorOut << "Track::checkConsistency(): TrackRep pdg ID " << (*rep)->getPDG() << " is not valid" << std::endl;
-      retVal = false;
+      failures << "Track::checkConsistency(): TrackRep pdg ID " << (*rep)->getPDG() << " is not valid" << std::endl;
+      consistent = false;
     }
 
     // check if corresponding FitStatus is there
     if (fitStatuses_.find(*rep) == fitStatuses_.end() and fitStatuses_.find(*rep)->second != nullptr) {
-      errorOut << "Track::checkConsistency(): No FitStatus for Rep or FitStatus is nullptr" << std::endl;
-      retVal = false;
+      failures << "Track::checkConsistency(): No FitStatus for Rep or FitStatus is nullptr" << std::endl;
+      consistent = false;
     }
   }
 
@@ -1331,13 +1329,13 @@ bool Track::checkConsistency() const {
   for (std::vector<TrackPoint*>::const_iterator tp = trackPoints_.begin(); tp != trackPoints_.end(); ++tp) {
     // check for nullptr
     if ((*tp) == nullptr) {
-      errorOut << "Track::checkConsistency(): TrackPoint is nullptr" << std::endl;
-      retVal = false;
+      failures << "Track::checkConsistency(): TrackPoint is nullptr" << std::endl;
+      consistent = false;
     }
     // check if trackPoint points back to this track
     if ((*tp)->getTrack() != this) {
-      errorOut << "Track::checkConsistency(): TrackPoint does not point back to this track" << std::endl;
-      retVal = false;
+      failures << "Track::checkConsistency(): TrackPoint does not point back to this track" << std::endl;
+      consistent = false;
     }
 
     // check rawMeasurements
@@ -1345,13 +1343,13 @@ bool Track::checkConsistency() const {
     for (std::vector<AbsMeasurement*>::const_iterator m = rawMeasurements.begin(); m != rawMeasurements.end(); ++m) {
       // check for nullptr
       if ((*m) == nullptr) {
-        errorOut << "Track::checkConsistency(): Measurement is nullptr" << std::endl;
-        retVal = false;
+        failures << "Track::checkConsistency(): Measurement is nullptr" << std::endl;
+        consistent = false;
       }
       // check if measurement points back to TrackPoint
       if ((*m)->getTrackPoint() != *tp) {
-        errorOut << "Track::checkConsistency(): Measurement does not point back to correct TrackPoint" << std::endl;
-        retVal = false;
+        failures << "Track::checkConsistency(): Measurement does not point back to correct TrackPoint" << std::endl;
+        consistent = false;
       }
     }
 
@@ -1360,8 +1358,8 @@ bool Track::checkConsistency() const {
     for (std::vector<AbsFitterInfo*>::const_iterator fi = fitterInfos.begin(); fi != fitterInfos.end(); ++fi) {
       // check for nullptr
       if ((*fi) == nullptr) {
-        errorOut << "Track::checkConsistency(): FitterInfo is nullptr. TrackPoint: " << *tp << std::endl;
-        retVal = false;
+        failures << "Track::checkConsistency(): FitterInfo is nullptr. TrackPoint: " << *tp << std::endl;
+        consistent = false;
       }
 
       // check if fitterInfos point to valid TrackReps in trackReps_
@@ -1372,13 +1370,13 @@ bool Track::checkConsistency() const {
         }
       }
       if (mycount ==  0) {
-        errorOut << "Track::checkConsistency(): fitterInfo points to TrackRep which is not in Track" << std::endl;
-        retVal = false;
+        failures << "Track::checkConsistency(): fitterInfo points to TrackRep which is not in Track" << std::endl;
+        consistent = false;
       }
 
       if (!( (*fi)->checkConsistency(&(this->getFitStatus((*fi)->getRep())->getPruneFlags())) ) ) {
-        errorOut << "Track::checkConsistency(): FitterInfo not consistent. TrackPoint: " << *tp << std::endl;
-        retVal = false;
+        failures << "Track::checkConsistency(): FitterInfo not consistent. TrackPoint: " << *tp << std::endl;
+        consistent = false;
       }
 
       if (dynamic_cast<KalmanFitterInfo*>(*fi) != nullptr) {
@@ -1388,10 +1386,10 @@ bool Track::checkConsistency() const {
           double len = static_cast<KalmanFitterInfo*>(*fi)->getReferenceState()->getForwardSegmentLength();
           double prevLen = prevFis[(*fi)->getRep()]->getReferenceState()->getBackwardSegmentLength();
           if (fabs(prevLen + len) > 1E-10 ) {
-            errorOut << "Track::checkConsistency(): segment lengths of reference states for rep " << (*fi)->getRep() << " (id " << getIdForRep((*fi)->getRep()) << ") at TrackPoint " << (*tp) << " don't match" << std::endl;
-            errorOut << prevLen << " + " << len << " = " << prevLen + len << std::endl;
-            errorOut << "TrackPoint " << *tp << ", FitterInfo " << *fi << ", rep " << getIdForRep((*fi)->getRep()) << std::endl;
-            retVal = false;
+            failures << "Track::checkConsistency(): segment lengths of reference states for rep " << (*fi)->getRep() << " (id " << getIdForRep((*fi)->getRep()) << ") at TrackPoint " << (*tp) << " don't match" << std::endl;
+            failures << prevLen << " + " << len << " = " << prevLen + len << std::endl;
+            failures << "TrackPoint " << *tp << ", FitterInfo " << *fi << ", rep " << getIdForRep((*fi)->getRep()) << std::endl;
+            consistent = false;
           }
         }
 
@@ -1415,20 +1413,22 @@ bool Track::checkConsistency() const {
   }
 
   if (trackPointsWithMeasurement.size() != trackPointsWithMeasurement_.size()) {
-    errorOut << "Track::checkConsistency(): trackPointsWithMeasurement_ has incorrect size" << std::endl;
-    retVal = false;
+    failures << "Track::checkConsistency(): trackPointsWithMeasurement_ has incorrect size" << std::endl;
+    consistent = false;
   }
 
   for (unsigned int i = 0; i < trackPointsWithMeasurement.size(); ++i) {
     if (trackPointsWithMeasurement[i] != trackPointsWithMeasurement_[i]) {
-      errorOut << "Track::checkConsistency(): trackPointsWithMeasurement_ is not correct" << std::endl;
-      errorOut << "has         id " << i << ", address " << trackPointsWithMeasurement_[i] << std::endl;
-      errorOut << "should have id " << i << ", address " << trackPointsWithMeasurement[i] << std::endl;
-      retVal = false;
+      failures << "Track::checkConsistency(): trackPointsWithMeasurement_ is not correct" << std::endl;
+      failures << "has         id " << i << ", address " << trackPointsWithMeasurement_[i] << std::endl;
+      failures << "should have id " << i << ", address " << trackPointsWithMeasurement[i] << std::endl;
+      consistent = false;
     }
   }
 
-  return retVal;
+  if (not consistent) {
+    throw genfit::Exception(failures.str(), __LINE__, __FILE__);
+  }
 }
 
 

--- a/eventDisplay/src/EventDisplay.cc
+++ b/eventDisplay/src/EventDisplay.cc
@@ -301,11 +301,12 @@ void EventDisplay::drawEvent(unsigned int id, bool resetCam) {
       continue;
 
     Track* track = events_[id]->at(i);
-    if (! track->checkConsistency()){
-      std::cerr<<"track is not consistent"<<std::endl;
+    try {
+      track->checkConsistency();
+    } catch (genfit::Exception& e) {
+      std::cerr<< e.getExcString() <<std::endl;
       continue;
     }
-
 
     std::unique_ptr<Track> refittedTrack(nullptr);
     if (refit_) {
@@ -365,8 +366,10 @@ void EventDisplay::drawEvent(unsigned int id, bool resetCam) {
       int microseconds = 1000000*(endcputime.tv_sec - startcputime.tv_sec) + (endcputime.tv_usec - startcputime.tv_usec);
       std::cout << "it took " << double(microseconds) /  1000 << " ms of CPU to fit the track\n";
 
-      if (! refittedTrack->checkConsistency()){
-        std::cerr<<"refittedTrack is not consistent"<<std::endl;
+      try {
+        refittedTrack->checkConsistency();
+      } catch (genfit::Exception& e) {
+        std::cerr<< e.getExcString() <<std::endl;
         continue;
       }
 

--- a/test/fitterTests/main.cc
+++ b/test/fitterTests/main.cc
@@ -444,7 +444,7 @@ int main() {
         delete secondRep;
       //if (debug) fitTrack->Print("C");
 
-      assert(fitTrack->checkConsistency());
+      fitTrack->checkConsistency();
       //fitTrack->addTrackRep(rep->clone()); // check if everything works fine with more than one rep
 
       // add measurements
@@ -456,7 +456,7 @@ int main() {
         else
           fitTrack->insertPoint(new genfit::TrackPoint(measurements[i], fitTrack));
 
-        assert(fitTrack->checkConsistency());
+        fitTrack->checkConsistency();
         //if (debug) fitTrack->Print("C");
       }
 
@@ -471,8 +471,8 @@ int main() {
         }
       }
 
-      assert(fitTrack->checkConsistency());
-      assert(secondTrack->checkConsistency());
+      fitTrack->checkConsistency();
+      secondTrack->checkConsistency();
 
       //if (debug) fitTrack->Print();
 
@@ -536,8 +536,8 @@ int main() {
         fitTrack->getFitStatus(rep)->Print();
       }
 
-      assert(fitTrack->checkConsistency());
-      assert(secondTrack->checkConsistency());
+      fitTrack->checkConsistency();
+      secondTrack->checkConsistency();
 
 #ifndef VALGRIND
       if (!onlyDisplayFailed && iEvent < 1000) {
@@ -716,7 +716,7 @@ int main() {
 
         for (unsigned int i=0; i<1; ++i) {
           genfit::Track trClone(*fitTrack);
-          assert(trClone.checkConsistency());
+          trClone.checkConsistency();
 
           bool first(false), last(false);
 
@@ -739,10 +739,11 @@ int main() {
 
             trClone.prune(opt);
 
-            if (!trClone.checkConsistency()) {
+            try {
+              trClone.checkConsistency();
+            } catch (genfit::Exception& e) {
               trClone.getFitStatus()->getPruneFlags().Print();
             }
-            //trClone.getFitStatus()->getPruneFlags().Print();
 
             //std::cout<<"get stCloneFirst ";
             genfit::MeasuredStateOnPlane stCloneFirst = trClone.getFittedState();

--- a/test/measurementFactoryExample/main.cc
+++ b/test/measurementFactoryExample/main.cc
@@ -158,8 +158,7 @@ int main() {
       continue;
     }
 
-    //check
-    assert(fitTrack.checkConsistency());
+    fitTrack.checkConsistency();
 
 
     if (iEvent < 1000) {

--- a/test/minimalFittingExample/main.cc
+++ b/test/minimalFittingExample/main.cc
@@ -132,13 +132,13 @@ int main() {
     }
 
     //check
-    assert(fitTrack.checkConsistency());
+    fitTrack.checkConsistency();
 
     // do the fit
     fitter->processTrack(&fitTrack);
 
     //check
-    assert(fitTrack.checkConsistency());
+    fitTrack.checkConsistency();
 
 
     if (iEvent < 1000) {

--- a/test/minimalFittingExample/main2.cc
+++ b/test/minimalFittingExample/main2.cc
@@ -90,7 +90,7 @@ int main() {
 
 
   //check
-  assert(fitTrack.checkConsistency());
+  fitTrack.checkConsistency();
 
   // do the fit
   fitter->processTrack(&fitTrack);
@@ -99,7 +99,7 @@ int main() {
   fitTrack.getFittedState().Print();
 
   //check
-  assert(fitTrack.checkConsistency());
+  fitTrack.checkConsistency();
 
 
   display->addEvent(&fitTrack);


### PR DESCRIPTION
Let checkConsistency throw instead of returning a boolean to allow exception handling instead of assertions.