### PR TITLE
Make use of lower C++ standard level by default (--std=c++0x)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ IF(NOT CMAKE_BUILD_TYPE)
       FORCE)
 ENDIF(NOT CMAKE_BUILD_TYPE)
 
-SET(CPP_STANDARD c++11)
+SET(CPP_STANDARD c++0x)
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=${CPP_STANDARD} -Wall -pthread -pedantic -Wno-long-long -Wshadow -Werror=overloaded-virtual")
 
 SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -O0 -g")

--- a/core/src/TrackPoint.cc
+++ b/core/src/TrackPoint.cc
@@ -277,8 +277,8 @@ void TrackPoint::Streamer(TBuffer &R__b)
       for (size_t i = 0; i < rawMeasurements_.size(); ++i) {
         rawMeasurements_[i]->setTrackPoint(this);
       }
-      for (auto& trackRepIDWithFitterInfo : vFitterInfos_) {
-        AbsFitterInfo* fitterInfo = trackRepIDWithFitterInfo.second;
+      for (auto trackRepIDWithFitterInfo = vFitterInfos_.begin(); trackRepIDWithFitterInfo != vFitterInfos_.end(); ++trackRepIDWithFitterInfo) {
+        AbsFitterInfo* fitterInfo = trackRepIDWithFitterInfo->second;
         if (fitterInfo)
           fitterInfo->setTrackPoint(this);
       }
@@ -318,10 +318,10 @@ void TrackPoint::Streamer(TBuffer &R__b)
 
 void TrackPoint::fixupRepsForReading()
 {
-  for (auto& trackRepIDWithFitterInfo : vFitterInfos_) {
+  for (auto trackRepIDWithFitterInfo = vFitterInfos_.begin(); trackRepIDWithFitterInfo != vFitterInfos_.end(); ++trackRepIDWithFitterInfo) {
     // The map is filled such that i corresponds to the id of the TrackRep.
-    const unsigned int id = trackRepIDWithFitterInfo.first;
-    AbsFitterInfo* fitterInfo = trackRepIDWithFitterInfo.second;
+    const unsigned int id = trackRepIDWithFitterInfo->first;
+    AbsFitterInfo* fitterInfo = trackRepIDWithFitterInfo->second;
 
     // May not have FitterInfos for all reps.
     if (!fitterInfo)


### PR DESCRIPTION
Currently there are only two lines in the GenFit codebase which make use of "beyond the c++0x" features. Reducing the C++ level will let to compile the GenFit with old gcc versions.
My particular interest is to compile GenFit on the SLC6 system (system gcc version is 4.4.7).
I have also tested the proposed changes with gcc 5.3.0 an 6.3.0.