### PR TITLE
Increase ThinScatterer ClassDef because the member changed.

### DIFF
--- a/core/include/ThinScatterer.h
+++ b/core/include/ThinScatterer.h
@@ -56,7 +56,7 @@ class ThinScatterer : public TObject {
 
 
  public:
-  ClassDef(ThinScatterer, 1)
+  ClassDef(ThinScatterer, 2)
 
 };
 


### PR DESCRIPTION
This was forgotten when the MaterialProperties class was simplified to the Material struct.