### PR TITLE
Add missing const to Getter functions

### DIFF
--- a/fitters/include/DAF.h
+++ b/fitters/include/DAF.h
@@ -81,7 +81,7 @@ class DAF : public AbsKalmanFitter {
   //! Set the probability cut for the weight calculation for the hits for a specific measurement dimensionality.
   void addProbCut(const double prob_cut, const int measDim);
 
-  const std::vector<double>& getBetas() {return betas_;}
+  const std::vector<double>& getBetas() const {return betas_;}
 
   /** @brief Configure the annealing scheme.
    *

--- a/fitters/include/KalmanFitterInfo.h
+++ b/fitters/include/KalmanFitterInfo.h
@@ -74,7 +74,7 @@ class KalmanFitterInfo : public AbsFitterInfo {
   const MeasuredStateOnPlane& getFittedState(bool biased = true) const;
   //! Get unbiased (default) or biased residual from ith measurement.
   MeasurementOnPlane getResidual(unsigned int iMeasurement = 0, bool biased = false, bool onlyMeasurementErrors = true) const; // calculate residual, track and measurement errors are added if onlyMeasurementErrors is false
-  double getSmoothedChi2(unsigned int iMeasurement = 0);
+  double getSmoothedChi2(unsigned int iMeasurement = 0) const;
 
   bool hasMeasurements() const {return getNumMeasurements() > 0;}
   bool hasReferenceState() const {return (referenceState_.get() != nullptr);}

--- a/fitters/src/KalmanFitterInfo.cc
+++ b/fitters/src/KalmanFitterInfo.cc
@@ -347,7 +347,7 @@ MeasurementOnPlane KalmanFitterInfo::getResidual(unsigned int iMeasurement, bool
 }
 
 
-double KalmanFitterInfo::getSmoothedChi2(unsigned int iMeasurement) {
+double KalmanFitterInfo::getSmoothedChi2(unsigned int iMeasurement) const {
   const MeasurementOnPlane& res = getResidual(iMeasurement, true, false);
 
   TMatrixDSym Rinv;


### PR DESCRIPTION
Getter functions should (usually) not change the object and should therefore be constant

Needed to do stuff like this:
```C++
std::vector<const genfit::KalmanFitterInfo*> kalmanFitterInfos;
...
kalmanFitterInfos[i]->getSmoothedChi2();
```
This won't compile without the member function being marked `const`