### PR TITLE
Added a function to reset the fit result for a given rep

### DIFF
--- a/core/include/Track.h
+++ b/core/include/Track.h
@@ -259,6 +259,15 @@ class Track : public TObject {
   //! get time of flight in ns between to trackPoints (if nullptr, for cardinal rep)
   double getTOF(AbsTrackRep* rep = nullptr, int startId = 0, int endId = -1) const;
 
+  /**
+   * Delete the fit status and all the FitStates of the TrackPoints
+   * for the given hypothesis.
+   * This is equal to resetting the track for the rep, so another fit
+   * can start from scratch.
+   * Useful if you have changed some seeds.
+   */
+  void deleteFittedState(const genfit::AbsTrackRep* rep); 
+
   //! Construct a new TrackCand containing the hit IDs of the measurements
   /**
    * The idea is hat you can get a TrackCand for storing the hit IDs after a track has been fitted.

--- a/core/src/Track.cc
+++ b/core/src/Track.cc
@@ -505,6 +505,20 @@ void Track::deletePoint(int id) {
 void Track::insertMeasurement(AbsMeasurement* measurement, int id) {
   insertPoint(new TrackPoint(measurement, this), id);
 }
+  
+void Track::deleteFittedState(const genfit::AbsTrackRep* rep) {
+  if(hasFitStatus(rep)) {
+    delete fitStatuses_.at(rep);
+    fitStatuses_.erase(rep);
+  }
+
+  // delete FitterInfos related to the deleted TrackRep
+  for (const auto& trackPoint : trackPoints_) {
+    if(trackPoint->hasFitterInfo(rep)) {
+      trackPoint->deleteFitterInfo(rep);
+    }
+  }
+}
 
 
 void Track::mergeTrack(const Track* other, int id) {


### PR DESCRIPTION
This is different to just deleting the rep, because the rep pointers are not invalidated.

Useful if you want to refit a given hypothesis from scratch (e.g. because some external inputs have changed).