### PR TITLE
Dynamic throw specifications are deprecated and removed in C++17 

### DIFF
--- a/core/include/Exception.h
+++ b/core/include/Exception.h
@@ -55,7 +55,7 @@ class Exception : public std::exception {
    * @param file sourcefile in which the exception is created. Can be set through __FILE__ macro.
    */
   Exception(std::string excString, int line, std::string  file);
-  virtual ~Exception() throw();
+  virtual ~Exception() noexcept;
 
   //! Set fatal flag.
   void setFatal (bool b=true){fatal_=b;}
@@ -70,7 +70,7 @@ class Exception : public std::exception {
   void info();
 
   //! Standard error message handling for exceptions. use like "std::cerr << e.what();"
-  virtual const char* what() const throw();
+  virtual const char* what() const noexcept;
 
   std::string getExcString(){return excString_;}
 

--- a/core/src/Exception.cc
+++ b/core/src/Exception.cc
@@ -34,7 +34,7 @@ Exception::Exception(std::string excString, int line, std::string  file) :
   errorMessage_ = ErrMsgStream.str();
 }
 
-Exception::~Exception() throw() {
+Exception::~Exception() noexcept {
 }
 
 void Exception::setNumbers(std::string _numbersLabel,
@@ -49,7 +49,7 @@ void Exception::setMatrices(std::string _matricesLabel,
   matrices_ = _matrices;
 }
 
-const char* Exception::what() const throw(){
+const char* Exception::what() const noexcept{
   return errorMessage_.c_str();
 }
 


### PR DESCRIPTION
Original by M. Ritter for basf2.