### PR TITLE
Remove RAVE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,43 +36,6 @@ ENDIF()
 
 FIND_PACKAGE(Eigen3 REQUIRED NO_MODULE)
 
-# either, the environment variable RAVEPATH has to be specified, and RAVE's pkgConfig will be used to determine everything we need
-# or, RAVE_LDFLAGS, RAVE_INCLUDE_DIRS and RAVE_CFLAGS have to be set via the command-line
-
-
-IF(DEFINED ENV{RAVEPATH})
-	MESSAGE("Environment variable RAVEPATH is set. Try to build GFRave.") 
-	# get compiler flags from rave
-	INCLUDE(FindPkgConfig)
-	SET(ENV{PKG_CONFIG_PATH} $ENV{RAVEPATH})
-	pkg_search_module(RAVE rave REQUIRED)
-	
-	SET(RAVE True)
-ELSEIF(DEFINED RAVE_LDFLAGS)
-	IF(DEFINED RAVE_INCLUDE_DIRS)
-		IF(DEFINED RAVE_CFLAGS)
-			MESSAGE("RAVE_LDFLAGS, RAVE_INCLUDE_DIRS and RAVE_CFLAGS are set. Try to build GFRave.") 
-			SET(RAVE True)
-		ENDIF()
-	ENDIF()
-ELSE()
-   	MESSAGE("You did not define the environment variable RAVEPATH which is needed to find rave. GFRave will not be built.") 
-ENDIF()
-
-IF(DEFINED RAVE)
-	# turn comma separated lists into space separated strings
-	string (REPLACE ";" " " RAVE_LDFLAGS_STR "${RAVE_LDFLAGS}")
-	string (REPLACE ";" " " RAVE_INCLUDE_DIRS_STR "${RAVE_INCLUDE_DIRS}")
-	string (REPLACE ";" " " RAVE_CFLAGS_STR "${RAVE_CFLAGS}")
-
-	SET (CMAKE_CXX_FLAGS ${RAVE_CFLAGS_STR})
-	
-	SET(GF_INC_DIRS
-		./GFRave/include/
-	)
-	
-	AUX_SOURCE_DIRECTORY( ./GFRave/src  library_sources )
-ENDIF()
 
 # Set GENFIT include directories
 SET(GF_INC_DIRS
@@ -273,37 +236,13 @@ ROOT_GENERATE_DICTIONARY(
 )
 SET(library_sources "${CMAKE_CURRENT_BINARY_DIR}/utilitiesRootDict.cc" "${library_sources}")
 
-if(DEFINED RAVE)
-	SET(GFRAVE_DICTIONARY_SOURCES
-			${CMAKE_CURRENT_SOURCE_DIR}/GFRave/include/GFRaveTrackParameters.h
-			${CMAKE_CURRENT_SOURCE_DIR}/GFRave/include/GFRaveVertex.h
-	)
-	ROOT_GENERATE_DICTIONARY(
-			"${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME}"
-			"${GFRAVE_DICTIONARY_SOURCES}"
-			"${CMAKE_CURRENT_SOURCE_DIR}/core/include;${CMAKE_CURRENT_SOURCE_DIR}/GFRave/include"
-			"${CMAKE_CURRENT_SOURCE_DIR}/GFRave/src/GFRaveLinkDef.h"
-			"${CMAKE_CURRENT_BINARY_DIR}/GFRaveRootDict.cc"
-	)
-	SET(library_sources "${CMAKE_CURRENT_BINARY_DIR}/GFRaveRootDict.cc" "${library_sources}")
-endif()
-
 
 # install
 ADD_SHARED_LIBRARY( ${PROJECT_NAME} ${library_sources})
 INSTALL(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${LIBRARY_OUTPUT_DIRECTORY})
 
 # link ROOT libraries
-if(DEFINED RAVE)
-	TARGET_LINK_LIBRARIES(
-			${PROJECT_NAME}
-			${ROOT_LIBS}
-			${RAVE_LDFLAGS_STR}
-			-I${RAVE_INCLUDE_DIRS_I}
-  	)
-else()
-	TARGET_LINK_LIBRARIES(${PROJECT_NAME} ${ROOT_LIBS})
-endif()
+TARGET_LINK_LIBRARIES(${PROJECT_NAME} ${ROOT_LIBS})
 
 
 ADD_CUSTOM_TARGET( tests )
@@ -314,10 +253,6 @@ ADD_GENFIT_TEST( minimalFittingExample2    test/minimalFittingExample/main2.cc)
 ADD_GENFIT_TEST( measurementFactoryExample test/measurementFactoryExample/main.cc)
 ADD_GENFIT_TEST( streamerTest              test/streamerTest/main.cc)
 ADD_GENFIT_TEST( unitTests                 test/unitTests/main.cc)
-IF(DEFINED RAVE)
-  ADD_GENFIT_TEST( vertexingTest           test/vertexingTest/main.cc)
-  ADD_GENFIT_TEST( vertexingTestRead       test/vertexingTest/read.cc)
-ENDIF()
 
 
 FIND_PACKAGE(GTest)


### PR DESCRIPTION
Hi all!

Sorry if this is insane/stupid/wrong, I don't know about all the internals in Genfit2. However, I realised my problems compiling Genfit (see #77 for reference) do not occur as long as I don't use *rave*; By default, I have my `RAVEPATH` set and rave installed -- it used to be necessary in the old FOPI days etc.
I don't know whether Genfit still relies on rave somewhere, but as far as I can see, the [travis script](https://github.com/GenFit/GenFit/blob/master/.travis.yml) does not compile/install/set rave anywhere. If my conclusion is correct that setting rave is not necessary (but might break things, even though I don't understand why), I think it would be good/correct to remove RAVE from the *CMake*. It's a bit weird now, since you do get a warning about a missing RAVEPATH, but at least for me, it will only compile if I ignore the warning ...

Cheers,

Philipp