### PR TITLE
Use override Keyword

### DIFF
--- a/GBL/include/GFGbl.h
+++ b/GBL/include/GFGbl.h
@@ -117,7 +117,7 @@ namespace genfit {
      * Performs fit on a Track.
      * Hit resorting currently NOT supported.
      */
-    void processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool resortHits = false);
+    void processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool resortHits = false) override;
     
     
   public:

--- a/GBL/include/GblFitStatus.h
+++ b/GBL/include/GblFitStatus.h
@@ -46,7 +46,7 @@ namespace genfit {
     
     virtual ~GblFitStatus() {};
     
-    virtual FitStatus* clone() const {return new GblFitStatus(*this);}
+    virtual FitStatus* clone() const override {return new GblFitStatus(*this);}
     
     void setCurvature(bool useCurvature) {curvatureFlag_ = useCurvature;}
     bool hasCurvature() { return curvatureFlag_; }
@@ -62,7 +62,7 @@ namespace genfit {
     void setIsFittedWithReferenceTrack(bool fittedWithReferenceTrack = true) {fittedWithReferenceTrack_ = fittedWithReferenceTrack;}
     void setTrackLen(double trackLen) {trackLen_ = trackLen;}
     
-    virtual void Print(const Option_t* = "") const {;}
+    virtual void Print(const Option_t* = "") const override {;}
     
   protected:
     
@@ -76,7 +76,7 @@ namespace genfit {
     
   public:
     
-    ClassDef(GblFitStatus, 1)
+    ClassDefOverride(GblFitStatus, 1)
     
   };
   

--- a/GBL/include/GblFitter.h
+++ b/GBL/include/GblFitter.h
@@ -152,7 +152,7 @@ namespace genfit {
      * Hit resorting currently supported (use only if necessary /wire chamber/ ... will 
      * extrapolate along whole track to sort the hits).
      */
-    void processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool resortHits = false);
+    void processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool resortHits = false) override;
     
     /**
      * @brief Propagate seed, populate track with scatterers

--- a/GBL/include/GblFitterInfo.h
+++ b/GBL/include/GblFitterInfo.h
@@ -153,7 +153,7 @@ namespace genfit {
      *                  If false, for backward
      * @return const genfit::MeasuredStateOnPlane&
      */
-    const MeasuredStateOnPlane& getFittedState(bool afterKink = true) const;
+    const MeasuredStateOnPlane& getFittedState(bool afterKink = true) const override;
 
     /**
      * @brief Get the residual
@@ -169,7 +169,7 @@ namespace genfit {
      *                              If false, diagonalized residual error incl. correlation from track fit is returned.
      * @return genfit::MeasurementOnPlane
      */
-    MeasurementOnPlane getResidual(unsigned int = 0, bool = false, bool onlyMeasurementErrors = true) const;
+    MeasurementOnPlane getResidual(unsigned int = 0, bool = false, bool onlyMeasurementErrors = true) const override;
     
     /**
      * @brief Get kink (residual) with diagonalized covariance (2D)
@@ -223,26 +223,26 @@ namespace genfit {
     void recalculateJacobian(GblFitterInfo* prevFitterInfo);
     
     virtual ~GblFitterInfo() {;}
-    virtual GblFitterInfo* clone() const;
-    bool hasMeasurements() const {return trackPoint_->hasRawMeasurements();}
-    bool hasReferenceState() const {return (refPrediction_(0) != 0.);}
-    bool hasForwardPrediction() const {return hasReferenceState();}
-    bool hasBackwardPrediction() const {return hasReferenceState();}
-    bool hasForwardUpdate() const {return hasForwardPrediction();}
-    bool hasBackwardUpdate() const {return hasBackwardPrediction();}
-    bool hasUpdate(int direction) const {if (direction < 0) return hasBackwardPrediction(); return hasForwardPrediction();}
+    virtual GblFitterInfo* clone() const override;
+    bool hasMeasurements() const override {return trackPoint_->hasRawMeasurements();}
+    bool hasReferenceState() const override {return (refPrediction_(0) != 0.);}
+    bool hasForwardPrediction() const override {return hasReferenceState();}
+    bool hasBackwardPrediction() const override {return hasReferenceState();}
+    bool hasForwardUpdate() const override {return hasForwardPrediction();}
+    bool hasBackwardUpdate() const override {return hasBackwardPrediction();}
+    bool hasUpdate(int direction) const override {if (direction < 0) return hasBackwardPrediction(); return hasForwardPrediction();}
     bool hasPredictionsAndUpdates() const {return (hasForwardPrediction() && hasBackwardPrediction() && hasForwardUpdate() && hasBackwardUpdate());}
 
-    void deleteForwardInfo() {;}
-    void deleteBackwardInfo() {;}
+    void deleteForwardInfo() override {;}
+    void deleteBackwardInfo() override {;}
     void deletePredictions() {
       deleteBackwardInfo();
       deleteForwardInfo();
     }
-    void deleteReferenceInfo() {;} // Empty because we really do not want to delete reference without a new one
-    void deleteMeasurementInfo() {;} // We do not keep the measurements
-    virtual void Print(const Option_t* = "") const;
-    virtual bool checkConsistency(const genfit::PruneFlags* = nullptr) const;
+    void deleteReferenceInfo() override {;} // Empty because we really do not want to delete reference without a new one
+    void deleteMeasurementInfo() override {;} // We do not keep the measurements
+    virtual void Print(const Option_t* = "") const override;
+    virtual bool checkConsistency(const genfit::PruneFlags* = nullptr) const override;
        
   private:
     TMatrixD jacobian_;
@@ -269,7 +269,7 @@ namespace genfit {
     
   public:
     
-    ClassDef(GblFitterInfo, 1)
+    ClassDefOverride(GblFitterInfo, 1)
     
   };
   

--- a/core/include/MeasuredStateOnPlane.h
+++ b/core/include/MeasuredStateOnPlane.h
@@ -50,7 +50,7 @@ class MeasuredStateOnPlane : public StateOnPlane {
   void swap(MeasuredStateOnPlane& other); // nothrow
 
   virtual ~MeasuredStateOnPlane() {}
-  virtual MeasuredStateOnPlane* clone() const {return new MeasuredStateOnPlane(*this);}
+  virtual MeasuredStateOnPlane* clone() const override {return new MeasuredStateOnPlane(*this);}
 
 
   const TMatrixDSym& getCov() const {return cov_;}
@@ -74,14 +74,14 @@ class MeasuredStateOnPlane : public StateOnPlane {
   void setPosMomCov(const TVectorD& state6, const TMatrixDSym& cov6x6) {getRep()->setPosMomCov(*this, state6, cov6x6);}
 
 
-  virtual void Print(Option_t* option = "") const;
+  virtual void Print(Option_t* option = "") const override;
 
  protected:
 
   TMatrixDSym cov_;
 
  public:
-  ClassDef(MeasuredStateOnPlane,1)
+  ClassDefOverride(MeasuredStateOnPlane,1)
 
 };
 

--- a/core/include/MeasurementOnPlane.h
+++ b/core/include/MeasurementOnPlane.h
@@ -68,7 +68,7 @@ class MeasurementOnPlane : public MeasuredStateOnPlane {
   void setHMatrix(const AbsHMatrix* hMatrix) {hMatrix_.reset(hMatrix);}
   void setWeight(double weight) {weight_ = fmax(weight, 1.E-10);}
 
-  void Print(Option_t* option = "") const ;
+  void Print(Option_t* option = "") const override ;
 
  private:
   TVector3 getPos() const;
@@ -97,7 +97,7 @@ class MeasurementOnPlane : public MeasuredStateOnPlane {
   double weight_;
 
  public:
-  ClassDef(MeasurementOnPlane,1)
+  ClassDefOverride(MeasurementOnPlane,1)
 
 };
 

--- a/fitters/include/DAF.h
+++ b/fitters/include/DAF.h
@@ -68,7 +68,7 @@ class DAF : public AbsKalmanFitter {
   ~DAF() {};
 
   //! Process a track using the DAF.
-  void processTrackWithRep(Track* tr, const AbsTrackRep* rep, bool resortHits = false);
+  void processTrackWithRep(Track* tr, const AbsTrackRep* rep, bool resortHits = false) override;
 
   /** @brief Set the probability cut for the weight calculation for the hits.
    *
@@ -90,16 +90,16 @@ class DAF : public AbsKalmanFitter {
    */
   void setAnnealingScheme(double bStart, double bFinal, unsigned int nSteps);
 
-  void setMaxIterations(unsigned int n) {maxIterations_ = n; betas_.resize(maxIterations_,betas_.back());}
+  void setMaxIterations(unsigned int n) override {maxIterations_ = n; betas_.resize(maxIterations_,betas_.back());}
 
   //! If all weights change less than delta between two iterations, the fit is regarded as converged.
   void setConvergenceDeltaWeight(double delta) {deltaWeight_ = delta;}
 
   AbsKalmanFitter* getKalman() const {return kalman_.get();}
 
-  virtual void setMaxFailedHits(int val) {getKalman()->setMaxFailedHits(val);}
+  virtual void setMaxFailedHits(int val) override {getKalman()->setMaxFailedHits(val);}
 
-  virtual void setDebugLvl(unsigned int lvl = 1) {AbsFitter::setDebugLvl(lvl); if (lvl > 1) getKalman()->setDebugLvl(lvl-1);}
+  virtual void setDebugLvl(unsigned int lvl = 1) override {AbsFitter::setDebugLvl(lvl); if (lvl > 1) getKalman()->setDebugLvl(lvl-1);}
 
  private:
 
@@ -121,7 +121,7 @@ class DAF : public AbsKalmanFitter {
 
  public:
 
-  ClassDef(DAF,2)
+  ClassDefOverride(DAF,2)
 
 };
 

--- a/fitters/include/KalmanFitStatus.h
+++ b/fitters/include/KalmanFitStatus.h
@@ -43,7 +43,7 @@ class KalmanFitStatus : public FitStatus {
 
   virtual ~KalmanFitStatus() {};
 
-  virtual FitStatus* clone() const {return new KalmanFitStatus(*this);}
+  virtual FitStatus* clone() const override {return new KalmanFitStatus(*this);}
 
   unsigned int getNumIterations() const {return numIterations_;}
   bool isFittedWithDaf() const {return fittedWithDaf_;}
@@ -66,7 +66,7 @@ class KalmanFitStatus : public FitStatus {
   void setForwardNdf(double fNdf) {fNdf_ = fNdf;}
   void setBackwardNdf(double bNdf) {FitStatus::setNdf(bNdf);}
 
-  virtual void Print(const Option_t* = "") const;
+  virtual void Print(const Option_t* = "") const override;
 
  protected:
 
@@ -82,7 +82,7 @@ class KalmanFitStatus : public FitStatus {
 
  public:
 
-  ClassDef(KalmanFitStatus, 1)
+  ClassDefOverride(KalmanFitStatus, 1)
 
 };
 

--- a/fitters/include/KalmanFitter.h
+++ b/fitters/include/KalmanFitter.h
@@ -55,7 +55,7 @@ class KalmanFitter : public AbsKalmanFitter {
   ~KalmanFitter() {}
 
   //! Hit resorting currently NOT supported.
-  void processTrackWithRep(Track* tr, const AbsTrackRep* rep, bool resortHits = false);
+  void processTrackWithRep(Track* tr, const AbsTrackRep* rep, bool resortHits = false) override;
 
   //! process only a part of the track. Can also be used to process the track only in backward direction.
   //! Does not alter the FitStatus and does not do multiple iterations.
@@ -73,7 +73,7 @@ class KalmanFitter : public AbsKalmanFitter {
   bool squareRootFormalism_;
 
  public:
-  ClassDef(KalmanFitter,1)
+  ClassDefOverride(KalmanFitter,1)
 
 };
 

--- a/fitters/include/KalmanFitterInfo.h
+++ b/fitters/include/KalmanFitterInfo.h
@@ -49,7 +49,7 @@ class KalmanFitterInfo : public AbsFitterInfo {
   KalmanFitterInfo(const TrackPoint* trackPoint, const AbsTrackRep* rep);
   virtual ~KalmanFitterInfo();
 
-  virtual KalmanFitterInfo* clone() const;
+  virtual KalmanFitterInfo* clone() const override;
 
   ReferenceStateOnPlane* getReferenceState() const {return referenceState_.get();}
   MeasuredStateOnPlane* getForwardPrediction() const {return forwardPrediction_.get();}
@@ -71,18 +71,18 @@ class KalmanFitterInfo : public AbsFitterInfo {
   //! Are the weights fixed?
   bool areWeightsFixed() const {return fixWeights_;}
   //! Get unbiased or biased (default) smoothed state.
-  const MeasuredStateOnPlane& getFittedState(bool biased = true) const;
+  const MeasuredStateOnPlane& getFittedState(bool biased = true) const override;
   //! Get unbiased (default) or biased residual from ith measurement.
-  MeasurementOnPlane getResidual(unsigned int iMeasurement = 0, bool biased = false, bool onlyMeasurementErrors = true) const; // calculate residual, track and measurement errors are added if onlyMeasurementErrors is false
+  MeasurementOnPlane getResidual(unsigned int iMeasurement = 0, bool biased = false, bool onlyMeasurementErrors = true) const override; // calculate residual, track and measurement errors are added if onlyMeasurementErrors is false
   double getSmoothedChi2(unsigned int iMeasurement = 0) const;
 
-  bool hasMeasurements() const {return getNumMeasurements() > 0;}
-  bool hasReferenceState() const {return (referenceState_.get() != nullptr);}
-  bool hasForwardPrediction() const {return (forwardPrediction_.get()  != nullptr);}
-  bool hasBackwardPrediction() const {return (backwardPrediction_.get() != nullptr);}
-  bool hasForwardUpdate() const {return (forwardUpdate_.get() != nullptr);}
-  bool hasBackwardUpdate() const {return (backwardUpdate_.get() != nullptr);}
-  bool hasUpdate(int direction) const {if (direction < 0) return hasBackwardUpdate(); return hasForwardUpdate();}
+  bool hasMeasurements() const override {return getNumMeasurements() > 0;}
+  bool hasReferenceState() const override {return (referenceState_.get() != nullptr);}
+  bool hasForwardPrediction() const override {return (forwardPrediction_.get()  != nullptr);}
+  bool hasBackwardPrediction() const override {return (backwardPrediction_.get() != nullptr);}
+  bool hasForwardUpdate() const override {return (forwardUpdate_.get() != nullptr);}
+  bool hasBackwardUpdate() const override {return (backwardUpdate_.get() != nullptr);}
+  bool hasUpdate(int direction) const override {if (direction < 0) return hasBackwardUpdate(); return hasForwardUpdate();}
   bool hasPredictionsAndUpdates() const {return (hasForwardPrediction() && hasBackwardPrediction() && hasForwardUpdate() && hasBackwardUpdate());}
 
   void setReferenceState(ReferenceStateOnPlane* referenceState);
@@ -98,17 +98,17 @@ class KalmanFitterInfo : public AbsFitterInfo {
   //! Set weights of measurements.
   void setWeights(const std::vector<double>&);
   void fixWeights(bool arg = true) {fixWeights_ = arg;}
-  void setRep(const AbsTrackRep* rep);
+  void setRep(const AbsTrackRep* rep) override;
 
-  void deleteForwardInfo();
-  void deleteBackwardInfo();
+  void deleteForwardInfo() override;
+  void deleteBackwardInfo() override;
   void deletePredictions();
-  void deleteReferenceInfo() {setReferenceState(nullptr);}
-  void deleteMeasurementInfo();
+  void deleteReferenceInfo() override {setReferenceState(nullptr);}
+  void deleteMeasurementInfo() override;
 
-  virtual void Print(const Option_t* = "") const;
+  virtual void Print(const Option_t* = "") const override;
 
-  virtual bool checkConsistency(const genfit::PruneFlags* = nullptr) const;
+  virtual bool checkConsistency(const genfit::PruneFlags* = nullptr) const override;
 
  private:
 
@@ -139,7 +139,7 @@ class KalmanFitterInfo : public AbsFitterInfo {
 
  public:
 
-  ClassDef(KalmanFitterInfo,1)
+  ClassDefOverride(KalmanFitterInfo,1)
 
 };
 

--- a/fitters/include/KalmanFitterRefTrack.h
+++ b/fitters/include/KalmanFitterRefTrack.h
@@ -50,7 +50,7 @@ class KalmanFitterRefTrack : public AbsKalmanFitter {
    */
   TrackPoint* fitTrack(Track* tr, const AbsTrackRep* rep, double& chi2, double& ndf, int direction);
 
-  void processTrackWithRep(Track* tr, const AbsTrackRep* rep, bool resortHits = false);
+  void processTrackWithRep(Track* tr, const AbsTrackRep* rep, bool resortHits = false) override;
 
   /** @brief Prepare the track
    *
@@ -109,7 +109,7 @@ class KalmanFitterRefTrack : public AbsKalmanFitter {
   bool squareRootFormalism_;
 
  public:
-  ClassDef(KalmanFitterRefTrack, 1)
+  ClassDefOverride(KalmanFitterRefTrack, 1)
 
 };
 

--- a/fitters/include/ReferenceStateOnPlane.h
+++ b/fitters/include/ReferenceStateOnPlane.h
@@ -87,7 +87,7 @@ class ReferenceStateOnPlane : public StateOnPlane {
   void resetForward();
   void resetBackward();
 
-  virtual void Print(Option_t* option = "") const;
+  virtual void Print(Option_t* option = "") const override;
 
  protected:
 
@@ -103,7 +103,7 @@ class ReferenceStateOnPlane : public StateOnPlane {
 
  public:
 
-  ClassDef(ReferenceStateOnPlane,1)
+  ClassDefOverride(ReferenceStateOnPlane,1)
 
 };
 

--- a/measurements/include/FullMeasurement.h
+++ b/measurements/include/FullMeasurement.h
@@ -47,20 +47,20 @@ class FullMeasurement : public AbsMeasurement {
 
   virtual ~FullMeasurement() {;}
 
-  virtual AbsMeasurement* clone() const {return new FullMeasurement(*this);}
+  virtual AbsMeasurement* clone() const override {return new FullMeasurement(*this);}
 
-  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const;
+  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const override;
 
-  virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const;
+  virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const override;
 
-  virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const;
+  virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const override;
 
  protected:
   SharedPlanePtr plane_;   //! This is persistent, but '!' makes ROOT shut up.
 
  public:
 
-  ClassDef(FullMeasurement,1)
+  ClassDefOverride(FullMeasurement,1)
 
 };
 

--- a/measurements/include/HMatrixU.h
+++ b/measurements/include/HMatrixU.h
@@ -40,22 +40,22 @@ class HMatrixU : public AbsHMatrix {
 
   HMatrixU() {;}
 
-  const TMatrixD& getMatrix() const;
+  const TMatrixD& getMatrix() const override;
 
-  TVectorD Hv(const TVectorD& v) const;
+  TVectorD Hv(const TVectorD& v) const override;
 
-  TMatrixD MHt(const TMatrixDSym& M) const;
-  TMatrixD MHt(const TMatrixD& M) const;
+  TMatrixD MHt(const TMatrixDSym& M) const override;
+  TMatrixD MHt(const TMatrixD& M) const override;
 
-  void HMHt(TMatrixDSym& M) const;
+  void HMHt(TMatrixDSym& M) const override;
 
-  virtual HMatrixU* clone() const {return new HMatrixU(*this);}
+  virtual HMatrixU* clone() const override {return new HMatrixU(*this);}
 
-  virtual bool isEqual(const AbsHMatrix& other) const {return (dynamic_cast<const HMatrixU*>(&other) != nullptr);}
+  virtual bool isEqual(const AbsHMatrix& other) const override {return (dynamic_cast<const HMatrixU*>(&other) != nullptr);}
 
-  virtual void Print(const Option_t* = "") const;
+  virtual void Print(const Option_t* = "") const override;
 
-  ClassDef(HMatrixU,1)
+  ClassDefOverride(HMatrixU,1)
 
 };
 

--- a/measurements/include/HMatrixUV.h
+++ b/measurements/include/HMatrixUV.h
@@ -43,22 +43,22 @@ class HMatrixUV : public AbsHMatrix {
 
   HMatrixUV() {;}
 
-  const TMatrixD& getMatrix() const;
+  const TMatrixD& getMatrix() const override;
 
-  TVectorD Hv(const TVectorD& v) const;
+  TVectorD Hv(const TVectorD& v) const override;
 
-  TMatrixD MHt(const TMatrixDSym& M) const;
-  TMatrixD MHt(const TMatrixD& M) const;
+  TMatrixD MHt(const TMatrixDSym& M) const override;
+  TMatrixD MHt(const TMatrixD& M) const override;
 
-  void HMHt(TMatrixDSym& M) const;
+  void HMHt(TMatrixDSym& M) const override;
 
-  virtual HMatrixUV* clone() const {return new HMatrixUV(*this);}
+  virtual HMatrixUV* clone() const override {return new HMatrixUV(*this);}
 
-  virtual bool isEqual(const AbsHMatrix& other) const {return (dynamic_cast<const HMatrixUV*>(&other) != nullptr);}
+  virtual bool isEqual(const AbsHMatrix& other) const override {return (dynamic_cast<const HMatrixUV*>(&other) != nullptr);}
 
-  virtual void Print(const Option_t* = "") const;
+  virtual void Print(const Option_t* = "") const override;
 
-  ClassDef(HMatrixUV,1)
+  ClassDefOverride(HMatrixUV,1)
 
 };
 

--- a/measurements/include/HMatrixV.h
+++ b/measurements/include/HMatrixV.h
@@ -40,22 +40,22 @@ class HMatrixV : public AbsHMatrix {
 
   HMatrixV() {;}
 
-  const TMatrixD& getMatrix() const;
+  const TMatrixD& getMatrix() const override;
 
-  TVectorD Hv(const TVectorD& v) const;
+  TVectorD Hv(const TVectorD& v) const override;
 
-  TMatrixD MHt(const TMatrixDSym& M) const;
-  TMatrixD MHt(const TMatrixD& M) const;
+  TMatrixD MHt(const TMatrixDSym& M) const override;
+  TMatrixD MHt(const TMatrixD& M) const override;
 
-  void HMHt(TMatrixDSym& M) const;
+  void HMHt(TMatrixDSym& M) const override;
 
-  virtual HMatrixV* clone() const {return new HMatrixV(*this);}
+  virtual HMatrixV* clone() const override {return new HMatrixV(*this);}
 
-  virtual bool isEqual(const AbsHMatrix& other) const {return (dynamic_cast<const HMatrixV*>(&other) != nullptr);}
+  virtual bool isEqual(const AbsHMatrix& other) const override {return (dynamic_cast<const HMatrixV*>(&other) != nullptr);}
 
-  virtual void Print(const Option_t* = "") const;
+  virtual void Print(const Option_t* = "") const override;
 
-  ClassDef(HMatrixV,1)
+  ClassDefOverride(HMatrixV,1)
 
 };
 

--- a/measurements/include/PlanarMeasurement.h
+++ b/measurements/include/PlanarMeasurement.h
@@ -49,15 +49,15 @@ class PlanarMeasurement : public AbsMeasurement {
 
   virtual ~PlanarMeasurement() {;}
 
-  virtual AbsMeasurement* clone() const {return new PlanarMeasurement(*this);}
+  virtual AbsMeasurement* clone() const override {return new PlanarMeasurement(*this);}
 
   int getPlaneId() const {return planeId_;}
 
-  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const;
+  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const override;
 
-  virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const;
+  virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const override;
 
-  virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const;
+  virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const override;
 
   virtual void setPlane(const SharedPlanePtr& physicalPlane, int planeId = -1) {physicalPlane_ = physicalPlane; planeId_ = planeId;}
 
@@ -76,7 +76,7 @@ class PlanarMeasurement : public AbsMeasurement {
 
  public:
 
-  ClassDef(PlanarMeasurement,1)
+  ClassDefOverride(PlanarMeasurement,1)
 
 };
 

--- a/measurements/include/SpacepointMeasurement.h
+++ b/measurements/include/SpacepointMeasurement.h
@@ -52,7 +52,7 @@ class SpacepointMeasurement : public AbsMeasurement {
 
   virtual ~SpacepointMeasurement() {;}
 
-  virtual AbsMeasurement* clone() const {return new SpacepointMeasurement(*this);}
+  virtual AbsMeasurement* clone() const override {return new SpacepointMeasurement(*this);}
 
   /**
    * @brief Contruct the virtual detector plane
@@ -64,11 +64,11 @@ class SpacepointMeasurement : public AbsMeasurement {
    *  E.g. if the covariance is very oblate, the plane will be almost defined by the covariance shape.
    *  If the covariance is very prolate, the behaviour will be very similar to the ProlateSpacepointHit.
    */
-  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const;
+  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const override;
 
-  virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const;
+  virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const override;
 
-  virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const;
+  virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const override;
 
   /// false: project 3D cov onto DetPlane. true: cut 3D cov with DetPlane
   bool getWeightedPlaneConstruction() const     { return weightedPlaneContruction_; }
@@ -87,7 +87,7 @@ class SpacepointMeasurement : public AbsMeasurement {
   TMatrixDSym G_; //! inverse of 3x3 cov
   bool cutCov_; // false: project 3D cov onto DetPlane. true: cut 3D cov with DetPlane (default)
 
-  ClassDef(SpacepointMeasurement,3)
+  ClassDefOverride(SpacepointMeasurement,3)
 };
 
 } /* End of namespace genfit */

--- a/measurements/include/WireMeasurement.h
+++ b/measurements/include/WireMeasurement.h
@@ -57,9 +57,9 @@ class WireMeasurement : public AbsMeasurement {
 
   virtual ~WireMeasurement() {;}
 
-  virtual AbsMeasurement* clone() const {return new WireMeasurement(*this);}
+  virtual AbsMeasurement* clone() const override {return new WireMeasurement(*this);}
 
-  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const;
+  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const override;
 
   /**  Hits with a small drift distance get a higher weight, whereas hits with
     * big drift distances become weighted down.
@@ -71,9 +71,9 @@ class WireMeasurement : public AbsMeasurement {
     * trajectory, whereas the wire position for hits with large drift radii is further away
     * from the trajectory and will therefore bias the fit if not weighted down.
     */
-  virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const;
+  virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const override;
 
-  virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const;
+  virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const override;
 
   /** Set maximum drift distance. This is used to calculate the start weights of the two
    * measurementsOnPlane.
@@ -87,8 +87,8 @@ class WireMeasurement : public AbsMeasurement {
    */
   void setLeftRightResolution(int lr);
 
-  virtual bool isLeftRightMeasurement() const {return true;}
-  virtual int getLeftRightResolution() const {return leftRight_;}
+  virtual bool isLeftRightMeasurement() const override {return true;}
+  virtual int getLeftRightResolution() const override {return leftRight_;}
 
   double getMaxDistance(){return maxDistance_;}
 
@@ -99,7 +99,7 @@ class WireMeasurement : public AbsMeasurement {
 
  public:
 
-  ClassDef(WireMeasurement, 2)
+  ClassDefOverride(WireMeasurement, 2)
 
 };
 

--- a/measurements/include/WireMeasurementNew.h
+++ b/measurements/include/WireMeasurementNew.h
@@ -61,9 +61,9 @@ class WireMeasurementNew : public AbsMeasurement {
 
   virtual ~WireMeasurementNew() {;}
 
-  virtual WireMeasurementNew* clone() const {return new WireMeasurementNew(*this);}
+  virtual WireMeasurementNew* clone() const override {return new WireMeasurementNew(*this);}
 
-  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const;
+  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const override;
 
   /**  Hits with a small drift distance get a higher weight, whereas hits with
     * big drift distances become weighted down.
@@ -75,9 +75,9 @@ class WireMeasurementNew : public AbsMeasurement {
     * trajectory, whereas the wire position for hits with large drift radii is further away
     * from the trajectory and will therefore bias the fit if not weighted down.
     */
-  virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const;
+  virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const override;
 
-  virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const;
+  virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const override;
 
   /** Reset the wire end points.
    */
@@ -98,7 +98,7 @@ class WireMeasurementNew : public AbsMeasurement {
 
   virtual bool isLeftRigthMeasurement() const {return true;}
   double getMaxDistance(){return maxDistance_;}
-  int getLeftRightResolution() const {return leftRight_;}
+  int getLeftRightResolution() const override {return leftRight_;}
 
  protected:
 
@@ -109,7 +109,7 @@ class WireMeasurementNew : public AbsMeasurement {
 
  public:
 
-  ClassDef(WireMeasurementNew, 1)
+  ClassDefOverride(WireMeasurementNew, 1)
 
 };
 

--- a/measurements/include/WirePointMeasurement.h
+++ b/measurements/include/WirePointMeasurement.h
@@ -56,18 +56,18 @@ class WirePointMeasurement : public WireMeasurement {
 
   virtual ~WirePointMeasurement() {;}
 
-  virtual AbsMeasurement* clone() const {return new WirePointMeasurement(*this);}
+  virtual AbsMeasurement* clone() const override {return new WirePointMeasurement(*this);}
 
-  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const;
+  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const override;
 
-  virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const;
+  virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const override;
 
-  virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const;
+  virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const override;
 
 
  public:
 
-  ClassDef(WirePointMeasurement,1)
+  ClassDefOverride(WirePointMeasurement,1)
 
 };
 

--- a/measurements/include/WireTrackCandHit.h
+++ b/measurements/include/WireTrackCandHit.h
@@ -43,7 +43,7 @@ class WireTrackCandHit : public TrackCandHit {
 
   virtual ~WireTrackCandHit() {;}
 
-  virtual WireTrackCandHit* clone() const {return new WireTrackCandHit(*this);}
+  virtual WireTrackCandHit* clone() const override {return new WireTrackCandHit(*this);}
 
   // Accessors
   int getLeftRightResolution() const {return leftRight_;}
@@ -61,7 +61,7 @@ class WireTrackCandHit : public TrackCandHit {
     else leftRight_ = 1;
   }
 
-  virtual void Print(Option_t* option = "") const;
+  virtual void Print(Option_t* option = "") const override;
 
 
  protected:
@@ -79,7 +79,7 @@ class WireTrackCandHit : public TrackCandHit {
 
  public:
 
-  ClassDef(WireTrackCandHit, 2)
+  ClassDefOverride(WireTrackCandHit, 2)
 
 };
 

--- a/trackReps/include/RKTrackRep.h
+++ b/trackReps/include/RKTrackRep.h
@@ -82,12 +82,12 @@ class RKTrackRep : public AbsTrackRep {
 
   virtual ~RKTrackRep();
 
-  virtual AbsTrackRep* clone() const {return new RKTrackRep(*this);}
+  virtual AbsTrackRep* clone() const override {return new RKTrackRep(*this);}
 
   virtual double extrapolateToPlane(StateOnPlane& state,
       const SharedPlanePtr& plane,
       bool stopAtBoundary = false,
-      bool calcJacobianNoise = false) const;
+      bool calcJacobianNoise = false) const override;
 
   using AbsTrackRep::extrapolateToLine;
 
@@ -95,12 +95,12 @@ class RKTrackRep : public AbsTrackRep {
       const TVector3& linePoint,
       const TVector3& lineDirection,
       bool stopAtBoundary = false,
-      bool calcJacobianNoise = false) const;
+      bool calcJacobianNoise = false) const override;
 
   virtual double extrapolateToPoint(StateOnPlane& state,
       const TVector3& point,
       bool stopAtBoundary = false,
-      bool calcJacobianNoise = false) const {
+      bool calcJacobianNoise = false) const override {
     return extrapToPoint(state, point, nullptr, stopAtBoundary, calcJacobianNoise);
   }
 
@@ -108,7 +108,7 @@ class RKTrackRep : public AbsTrackRep {
       const TVector3& point,
       const TMatrixDSym& G, // weight matrix (metric)
       bool stopAtBoundary = false,
-      bool calcJacobianNoise = false) const {
+      bool calcJacobianNoise = false) const override {
     return extrapToPoint(state, point, &G, stopAtBoundary, calcJacobianNoise);
   }
 
@@ -117,7 +117,7 @@ class RKTrackRep : public AbsTrackRep {
       const TVector3& linePoint = TVector3(0.,0.,0.),
       const TVector3& lineDirection = TVector3(0.,0.,1.),
       bool stopAtBoundary = false,
-      bool calcJacobianNoise = false) const;
+      bool calcJacobianNoise = false) const override;
 
   
   virtual double extrapolateToCone(StateOnPlane& state,
@@ -125,56 +125,56 @@ class RKTrackRep : public AbsTrackRep {
       const TVector3& linePoint = TVector3(0.,0.,0.),
       const TVector3& lineDirection = TVector3(0.,0.,1.),
       bool stopAtBoundary = false,
-      bool calcJacobianNoise = false) const;
+      bool calcJacobianNoise = false) const override ;
 
   virtual double extrapolateToSphere(StateOnPlane& state,
       double radius,
       const TVector3& point = TVector3(0.,0.,0.),
       bool stopAtBoundary = false,
-      bool calcJacobianNoise = false) const;
+      bool calcJacobianNoise = false) const override;
 
   virtual double extrapolateBy(StateOnPlane& state,
       double step,
       bool stopAtBoundary = false,
-      bool calcJacobianNoise = false) const;
+      bool calcJacobianNoise = false) const override;
 
 
-  unsigned int getDim() const {return 5;}
+  unsigned int getDim() const override {return 5;}
 
-  virtual TVector3 getPos(const StateOnPlane& state) const;
+  virtual TVector3 getPos(const StateOnPlane& state) const override;
 
-  virtual TVector3 getMom(const StateOnPlane& state) const;
-  virtual void getPosMom(const StateOnPlane& state, TVector3& pos, TVector3& mom) const;
+  virtual TVector3 getMom(const StateOnPlane& state) const override;
+  virtual void getPosMom(const StateOnPlane& state, TVector3& pos, TVector3& mom) const override;
 
-  virtual double getMomMag(const StateOnPlane& state) const;
-  virtual double getMomVar(const MeasuredStateOnPlane& state) const;
+  virtual double getMomMag(const StateOnPlane& state) const override;
+  virtual double getMomVar(const MeasuredStateOnPlane& state) const override;
 
-  virtual TMatrixDSym get6DCov(const MeasuredStateOnPlane& state) const;
-  virtual void getPosMomCov(const MeasuredStateOnPlane& state, TVector3& pos, TVector3& mom, TMatrixDSym& cov) const;
-  virtual double getCharge(const StateOnPlane& state) const;
-  virtual double getQop(const StateOnPlane& state) const {return state.getState()(0);}
+  virtual TMatrixDSym get6DCov(const MeasuredStateOnPlane& state) const override;
+  virtual void getPosMomCov(const MeasuredStateOnPlane& state, TVector3& pos, TVector3& mom, TMatrixDSym& cov) const override;
+  virtual double getCharge(const StateOnPlane& state) const override;
+  virtual double getQop(const StateOnPlane& state) const override {return state.getState()(0);}
   double getSpu(const StateOnPlane& state) const;
-  double getTime(const StateOnPlane& state) const;
+  double getTime(const StateOnPlane& state) const override;
 
-  virtual void getForwardJacobianAndNoise(TMatrixD& jacobian, TMatrixDSym& noise, TVectorD& deltaState) const;
+  virtual void getForwardJacobianAndNoise(TMatrixD& jacobian, TMatrixDSym& noise, TVectorD& deltaState) const override;
 
-  virtual void getBackwardJacobianAndNoise(TMatrixD& jacobian, TMatrixDSym& noise, TVectorD& deltaState) const;
+  virtual void getBackwardJacobianAndNoise(TMatrixD& jacobian, TMatrixDSym& noise, TVectorD& deltaState) const override;
 
-  std::vector<genfit::MatStep> getSteps() const;
+  std::vector<genfit::MatStep> getSteps() const override;
 
-  virtual double getRadiationLenght() const;
+  virtual double getRadiationLenght() const override;
 
-  virtual void setPosMom(StateOnPlane& state, const TVector3& pos, const TVector3& mom) const;
-  virtual void setPosMom(StateOnPlane& state, const TVectorD& state6) const;
-  virtual void setPosMomErr(MeasuredStateOnPlane& state, const TVector3& pos, const TVector3& mom, const TVector3& posErr, const TVector3& momErr) const;
-  virtual void setPosMomCov(MeasuredStateOnPlane& state, const TVector3& pos, const TVector3& mom, const TMatrixDSym& cov6x6) const;
-  virtual void setPosMomCov(MeasuredStateOnPlane& state, const TVectorD& state6, const TMatrixDSym& cov6x6) const;
+  virtual void setPosMom(StateOnPlane& state, const TVector3& pos, const TVector3& mom) const override;
+  virtual void setPosMom(StateOnPlane& state, const TVectorD& state6) const override;
+  virtual void setPosMomErr(MeasuredStateOnPlane& state, const TVector3& pos, const TVector3& mom, const TVector3& posErr, const TVector3& momErr) const override;
+  virtual void setPosMomCov(MeasuredStateOnPlane& state, const TVector3& pos, const TVector3& mom, const TMatrixDSym& cov6x6) const override;
+  virtual void setPosMomCov(MeasuredStateOnPlane& state, const TVectorD& state6, const TMatrixDSym& cov6x6) const override;
 
-  virtual void setChargeSign(StateOnPlane& state, double charge) const;
-  virtual void setQop(StateOnPlane& state, double qop) const {state.getState()(0) = qop;}
+  virtual void setChargeSign(StateOnPlane& state, double charge) const override;
+  virtual void setQop(StateOnPlane& state, double qop) const override {state.getState()(0) = qop;}
 
   void setSpu(StateOnPlane& state, double spu) const;
-  void setTime(StateOnPlane& state, double time) const;
+  void setTime(StateOnPlane& state, double time) const override;
 
   //! The actual Runge Kutta propagation
   /** propagate state7 with step S. Fills SA (Start directions derivatives dA/S).
@@ -192,8 +192,8 @@ class RKTrackRep : public AbsTrackRep {
                      bool varField = true,
                      bool calcOnlyLastRowOfJ = false) const;
 
-  virtual bool isSameType(const AbsTrackRep* other);
-  virtual bool isSame(const AbsTrackRep* other);
+  virtual bool isSameType(const AbsTrackRep* other) override;
+  virtual bool isSame(const AbsTrackRep* other) override;
 
  private:
 
@@ -307,7 +307,7 @@ class RKTrackRep : public AbsTrackRep {
 
  public:
 
-  ClassDef(RKTrackRep, 1)
+  ClassDefOverride(RKTrackRep, 1)
 
 };
 

--- a/trackReps/include/TGeoMaterialInterface.h
+++ b/trackReps/include/TGeoMaterialInterface.h
@@ -43,7 +43,7 @@ class TGeoMaterialInterface : public AbsMaterialInterface {
       direction.  Returns true if the volume changed.
    */
   bool initTrack(double posX, double posY, double posZ,
-                 double dirX, double dirY, double dirZ);
+                 double dirX, double dirY, double dirZ) override;
 
   Material getMaterialParameters() override;
 
@@ -56,9 +56,9 @@ class TGeoMaterialInterface : public AbsMaterialInterface {
   double findNextBoundary(const RKTrackRep* rep,
                           const M1x7& state7,
                           double sMax,
-                          bool varField = true);
+                          bool varField = true) override;
 
-  // ClassDef(TGeoMaterialInterface, 1);
+  // ClassDefOverride(TGeoMaterialInterface, 1);
 
  private:
 };


### PR DESCRIPTION
After running cppcheck 1.85 and clang we got a lot of warnings for
missing `override` keywords. This patch adds override in all places
either cppcheck of clang complained about.

Also, if appropriate `ClassDef` has been replaced with `ClassDefOverride`: if a parent class has already a `ClassDef` then this will add all members with an override keyword.