### PR TITLE
change track::checkConsistency from void to bool

### DIFF
--- a/core/include/Track.h
+++ b/core/include/Track.h
@@ -298,8 +298,8 @@ class Track : public TObject {
   void prune(const Option_t* = "CFLWRMIU");
 
   void Print(const Option_t* = "") const;
-
-  void checkConsistency() const;
+  
+  bool checkConsistency() const;
 
  private:
 

--- a/core/src/Track.cc
+++ b/core/src/Track.cc
@@ -1283,7 +1283,7 @@ void Track::Print(const Option_t* option) const {
 }
 
 
-void Track::checkConsistency() const {
+bool Track::checkConsistency() const {
 
   bool consistent = true;
   std::stringstream failures;
@@ -1444,6 +1444,8 @@ void Track::checkConsistency() const {
   if (not consistent) {
     throw genfit::Exception(failures.str(), __LINE__, __FILE__);
   }
+  
+  return consistent;
 }
 
 


### PR DESCRIPTION
allows the use of `assert(track->checkConsistency())`
solves #82

Of course, one could also do it the other way round and change `vertexingTest/main.cc` from using `assert` to just calling `trackPtr->checkConsistency()` standalone. But if the test was written under the assumption one can call assert to a track, this might also be used in other cases?