### PR TITLE
Fix gbl bug extend controller

### DIFF
--- a/GBL/include/GblTrackSegmentController.h
+++ b/GBL/include/GblTrackSegmentController.h
@@ -45,9 +45,15 @@ namespace genfit {
     
     virtual ~GblTrackSegmentController() {};
     
-    virtual GblTrackSegmentController* clone() const {return new GblTrackSegmentController(*this);}
-    
-    virtual void controlTrackSegment(TVector3, TVector3, double, GblFitter *) {;}
+    /**
+    * @brief Function called for each segment of trajectory. User can decide on MS options.
+    *        This function must be implemented by the actual class deriving from this abstract class
+    * @param entry Position of segment starting point
+    * @param exit Position of segment ending point
+    * @param scatTheta Total MS variance accumulated in this segment
+    * @param fitter Pointer to the fitter - so you can set the MS options
+    */
+    virtual void controlTrackSegment(TVector3 entry, TVector3 exit, double scatTheta, GblFitter * fitter) = 0;
     
     virtual void Print(const Option_t* = "") const {;}
     

--- a/GBL/include/GblTrackSegmentController.h
+++ b/GBL/include/GblTrackSegmentController.h
@@ -47,7 +47,7 @@ namespace genfit {
     
     virtual GblTrackSegmentController* clone() const {return new GblTrackSegmentController(*this);}
     
-    virtual void controlTrackSegment(TVector3, TVector3, GblFitter *) {;}
+    virtual void controlTrackSegment(TVector3, TVector3, double, GblFitter *) {;}
     
     virtual void Print(const Option_t* = "") const {;}
     

--- a/GBL/src/GblFitter.cc
+++ b/GBL/src/GblFitter.cc
@@ -460,7 +460,7 @@ double GblFitter::constructGblInfo(Track* trk, const AbsTrackRep* rep)
     
     // Call segment controller to set MS options:    
     if (m_segmentController)
-      m_segmentController->controlTrackSegment(segmentEntry, segmentExit, this);    
+      m_segmentController->controlTrackSegment(segmentEntry, segmentExit, scatTheta, this);    
     
     // Scattering options: OFF / THIN / THICK
     if (m_enableScatterers && !m_enableIntermediateScatterer) {

--- a/GBL/src/GblTrajectory.cc
+++ b/GBL/src/GblTrajectory.cc
@@ -994,7 +994,7 @@ void GblTrajectory::prepare() {
 		std::vector<double> derivatives(numCurvature);
 		for (unsigned int iExt = 0; iExt < nExt; ++iExt) {
 			for (unsigned int iCol = 0; iCol < numCurvature; ++iCol) {
-				index[iCol] = iCol + 1;
+				index[iCol] = numLocals + iCol + 1;
 				derivatives[iCol] = externalDerivatives(iExt, iCol);
 			}
 			GblData aData(1U, externalMeasurements(iExt),


### PR DESCRIPTION
Two important changes needed for Belle II software (basf2):
- bugfix in GBL composed trajectories used for alignment with two-body-decays (ad-hoc bugfix, without full GBL update (to EIGEN version) - needs more work)
- pass additional parameter to be able to turn off multiple scattering in Central Drift Chamber (CDC) of Belle II if only small amount of material (gas) is found between measurement - too many scatterers were causing problems with positive-definitiveness of matrices due to rounding errors
