### PR TITLE
Fix installation prefix convetion.

### DIFF
--- a/cmake/settings.cmake
+++ b/cmake/settings.cmake
@@ -17,9 +17,9 @@ MARK_AS_ADVANCED( LIBRARY_OUTPUT_PATH )
 # what happens when `make install` is invoked:
 # set default install prefix to project root directory
 # instead of the cmake default /usr/local
-IF( CMAKE_INSTALL_PREFIX STREQUAL "/usr/local" )
-    SET( CMAKE_INSTALL_PREFIX "${PROJECT_SOURCE_DIR}" )
-ENDIF()
+#IF( CMAKE_INSTALL_PREFIX STREQUAL "/usr/local" )
+#    SET( CMAKE_INSTALL_PREFIX "${PROJECT_SOURCE_DIR}" )
+#ENDIF()
 
 # write this variable to cache
 SET( CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" CACHE PATH "Where to install ${PROJECT_NAME}" FORCE )


### PR DESCRIPTION
This removes the restriction on the installation prefix. I don't see why this should ever be here. 

Also, in-source-installs should be considered evil. 