### PR TITLE
Prevent deprecation warnings when compiling with newer versions

### DIFF
--- a/core/include/StateOnPlane.h
+++ b/core/include/StateOnPlane.h
@@ -48,6 +48,7 @@ class StateOnPlane {
 
  public:
 
+  StateOnPlane(const genfit::StateOnPlane&) = default;
 
   StateOnPlane(const AbsTrackRep* rep = nullptr);
   //! state is defined by the TrackReps parameterization

--- a/trackReps/include/RKTools.h
+++ b/trackReps/include/RKTools.h
@@ -33,6 +33,9 @@ template <size_t nRows, size_t nCols>
 struct RKMatrix {
   double vals[nRows * nCols];
 
+  RKMatrix() = default;
+  RKMatrix(const RKMatrix&) = default;
+
   double& operator()(size_t iRow, size_t iCol) {
     return vals[nCols*iRow + iCol];
   }

--- a/trackReps/include/StepLimits.h
+++ b/trackReps/include/StepLimits.h
@@ -57,6 +57,8 @@ class StepLimits {
   StepLimits()
   : limits_(ENUM_NR_ITEMS, maxLimit_), stepSign_(1) {;}
 
+  StepLimits(const StepLimits&) = default;
+
   StepLimits& operator=(const StepLimits& other);
 
   //! Get limit of type. If that limit has not yet been set, return max double value.


### PR DESCRIPTION
Added some default constructors to prevent deprecation warnings when compiling with newer compiler versions (e.g. when compiling with basf2)