### PR TITLE
Fix the bug of the poca calulation in AbsTrackRep

### DIFF
--- a/core/include/AbsTrackRep.h
+++ b/core/include/AbsTrackRep.h
@@ -126,11 +126,11 @@ class AbsTrackRep : public TObject {
       bool stopAtBoundary = false,
       bool calcJacobianNoise = false) const {
     TVector3 wireDir(point2 - point1);
-    wireDir.Unit();
+    wireDir = wireDir.Unit();
     double retval = this->extrapolateToLine(state, point1, wireDir, stopAtBoundary, calcJacobianNoise);
     poca = this->getPos(state);
     dirInPoca = this->getMom(state);
-    dirInPoca.Unit();
+    dirInPoca = dirInPoca.Unit();
 
     poca_onwire = point1 + wireDir*((poca - point1)*wireDir);
     


### PR DESCRIPTION
Set the wire direction to be the unit vector in the `extrapolateToLine` function of AbsTrackRep class.