### PR TITLE
Fix a clang warning

### DIFF
--- a/eventDisplay/src/EventDisplay.cc
+++ b/eventDisplay/src/EventDisplay.cc
@@ -435,7 +435,8 @@ void EventDisplay::drawEvent(unsigned int id, bool resetCam) {
       if (tp->getNumRawMeasurements() > 1) {
         bool sameTypes(true);
         for (unsigned int iM=1; iM<tp->getNumRawMeasurements(); ++iM) {
-          if (typeid(*(tp->getRawMeasurement(iM))) != typeid(*m))
+	  auto& rawMeasurement = *(tp->getRawMeasurement(iM));
+          if (typeid(rawMeasurement) != typeid(*m))
             sameTypes = false;
         }
         if (!sameTypes) {


### PR DESCRIPTION
While compiling basf2 with clang, I noticed the followig warning:
`warning: expression with side effects will be evaluated despite being used as an operand to 'typeid' [-Wpotentially-evaluated-expression]`
(for checking the warning, you can inspect the following log of a bamboo build for basf2: https://bamboo.desy.de/download/B2-BASF29007-JOB1/build_logs/B2-BASF29007-JOB1-6.log or, even better: https://travis-ci.org/github/GenFit/GenFit/jobs/770674354#L544)

A simple evaluation of the argument of 'typeid' outside it not only fixes the warning, but it also makes the code a bit more readable and clear.