### PR TITLE
Make building tests explicitly optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,12 +36,5 @@ install:
   - cd .. && mkdir build && cd build
   - cmake ../GenFit
   - make
-  - make tests
 script:
-  # generate test geometry
-  - root -l -b -q ../GenFit/test/makeGeom.C
-  # run unit tests, must be executed in the build folder
-  # so ROOT can find its .pcm files
-  - ./bin/gtests
-  - ./bin/streamerTest
-  - ./bin/unitTests
+  - ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,6 +306,7 @@ else()
 	TARGET_LINK_LIBRARIES(${PROJECT_NAME} ${ROOT_LIBS})
 endif()
 
+INCLUDE(CTest)
 
 ADD_CUSTOM_TARGET( tests )
 
@@ -320,8 +321,18 @@ IF(DEFINED RAVE)
   ADD_GENFIT_TEST( vertexingTestRead       test/vertexingTest/read.cc)
 ENDIF()
 
-INCLUDE(CTest)
 IF(BUILD_TESTING)
+
+	# Run these automatically via ctest since they do not need a GUI. Create the
+	# necessary geometry first via a dummy test
+	ADD_TEST(NAME createGeometry COMMAND root -l -b -q ${CMAKE_CURRENT_LIST_DIR}/test/makeGeom.C)
+
+	ADD_TEST(NAME streamerTest COMMAND streamerTest)
+	SET_PROPERTY(TEST streamerTest PROPERTY DEPENDS createGeometry)
+
+	ADD_TEST(NAME unitTests COMMAND unitTests)
+	SET_PROPERTY(TEST unitTests PROPERTY DEPENDS createGeometry)
+
     ENABLE_TESTING()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,9 +320,12 @@ IF(DEFINED RAVE)
   ADD_GENFIT_TEST( vertexingTestRead       test/vertexingTest/read.cc)
 ENDIF()
 
+INCLUDE(CTest)
+IF(BUILD_TESTING)
+    ENABLE_TESTING()
 
-FIND_PACKAGE(GTest)
-IF(GTEST_FOUND)
+
+	FIND_PACKAGE(GTest REQUIRED)
 	ADD_EXECUTABLE(gtests
 			gtest/TestConstField.cpp
 			gtest/TestMaterialEffects.cpp
@@ -332,9 +335,8 @@ IF(GTEST_FOUND)
 	TARGET_LINK_LIBRARIES(gtests ${GTEST_BOTH_LIBRARIES} ${ROOT_LIBS} ${PROJECT_NAME})  # gtest gtest_main
 	MESSAGE(STATUS  ${GTEST_INCLUDE_DIRS})
 	TARGET_INCLUDE_DIRECTORIES(gtests PUBLIC ${GTEST_INCLUDE_DIRS})
+	GTEST_DISCOVER_TESTS(gtests)
 	INSTALL(TARGETS gtests DESTINATION bin)
-ELSE()
-	MESSAGE(STATUS "GTest not installed or found -- skip building unittests.")
 ENDIF()
 
 # generate and install following configuration files

--- a/cmake/genfit.cmake
+++ b/cmake/genfit.cmake
@@ -1,5 +1,11 @@
 MACRO( ADD_GENFIT_TEST _testname )
-    ADD_EXECUTABLE( ${_testname} EXCLUDE_FROM_ALL ${ARGN} )
+    # If we have tests enabled build all tests directly, otherwise build them
+    # only via the tests target
+    IF(BUILD_TESTING)
+      ADD_EXECUTABLE( ${_testname} ${ARGN} )
+    ELSE()
+      ADD_EXECUTABLE( ${_testname} EXCLUDE_FROM_ALL ${ARGN} )
+    ENDIF()
     ADD_DEPENDENCIES( tests  ${_testname} )
     TARGET_LINK_LIBRARIES( ${_testname} ${PROJECT_NAME}  ${ROOT_LIBS} -lGeom )
     #INSTALL( TARGETS ${_testname} DESTINATION ${EXECUTABLE_INSTALL_DIR})


### PR DESCRIPTION
Make building the tests explicitly optional by using `CTest` facilities, instead of having it implicitly depend on the presence of `GTest`.

This will add a new option `BUILD_TESTING` to the cmake configuration, which defaults to `ON`. If this option is set, then finding `GTest` is mandatory. It also enables integration with `ctest`, so that calling `ctest` after building will automatically run all tests (the original `bin/gtests` is still available and unchanged).