### PR TITLE
Let GenFit compile when C++20 is enabled

### DIFF
--- a/gtest/TestRKTrackRep.cpp
+++ b/gtest/TestRKTrackRep.cpp
@@ -316,7 +316,7 @@ namespace genfit {
         genfit::M1x7 myStartState;
         genfit::M1x7 myDestState;
 
-        EXPECT_EQ(0, myRKTrackRep.ExtrapSteps_.size());
+        EXPECT_EQ(0u, myRKTrackRep.ExtrapSteps_.size());
         EXPECT_THROW(myRKTrackRep.calcForwardJacobianAndNoise(myStartState, myStartPlane, myDestState, myDestPlane),
                      genfit::Exception);
     }

--- a/test/streamerTest/main.cc
+++ b/test/streamerTest/main.cc
@@ -43,7 +43,7 @@ bool emptyTrackTest()
   genfit::Track *t = new genfit::Track();
   try {
     t->checkConsistency();
-  } catch (genfit::Exception) {
+  } catch (genfit::Exception&) {
     return false;
   }
 
@@ -59,7 +59,7 @@ bool emptyTrackTest()
   try {
     t->checkConsistency();
     result = true;
-  } catch (genfit::Exception) {
+  } catch (genfit::Exception&) {
     result = false;
   }
   delete t;

--- a/trackReps/include/RKTools.h
+++ b/trackReps/include/RKTools.h
@@ -35,6 +35,9 @@ struct RKMatrix {
 
   RKMatrix() = default;
   RKMatrix(const RKMatrix&) = default;
+  RKMatrix(std::initializer_list<double> initList) {
+    std::copy(initList.begin(), initList.end(), vals);
+  };
 
   double& operator()(size_t iRow, size_t iCol) {
     return vals[nCols*iRow + iCol];

--- a/trackReps/include/RKTools.h
+++ b/trackReps/include/RKTools.h
@@ -26,6 +26,7 @@
 
 #include <stddef.h>
 #include <algorithm>
+#include <initializer_list>
 
 namespace genfit {
 
@@ -48,10 +49,12 @@ struct RKMatrix {
   const double& operator[](size_t n) const {
     return vals[n];
   }
+
   double* begin() { return vals; }
   double* end() { return vals + nRows * nCols; }
   const double* begin() const { return vals; }
   const double* end() const { return vals + nRows * nCols; }
+
   RKMatrix<nRows, nCols>& operator=(const RKMatrix<nRows, nCols>& o) {
     std::copy(o.begin(), o.end(), this->begin());
     return *this;


### PR DESCRIPTION
I am thinking to move basf2 from C++17 to C++20. As expected, I found few compiler errors, and one is from GenFit, so let me fix it.

I tested that GenFit compiles with both C++17 and C++20 using gcc/g++ and clang/clang++.

(In the meanwhile, I also fixed a couple of compiler warnings.)