### PR TITLE
Fix of the assignment operator

### DIFF
--- a/core/src/Track.cc
+++ b/core/src/Track.cc
@@ -151,7 +151,7 @@ Track& Track::operator=(Track other) {
   swap(other);
 
   for (std::vector<TrackPoint*>::const_iterator it=trackPoints_.begin(); it!=trackPoints_.end(); ++it) {
-    trackPoints_.back()->setTrack(this);
+    (*it)->setTrack(this);
   }
 
   fillPointsWithMeasurement();


### PR DESCRIPTION
This fix the "=" operator, before it was setting the track only on the last TrackPoint, and not on all of them.