### PR TITLE
Changed format/style of all the GenFit files with astyle 3.1

### DIFF
--- a/GBL/include/BorderedBandMatrix.h
+++ b/GBL/include/BorderedBandMatrix.h
@@ -44,67 +44,67 @@
 namespace gbl {
 
 /// (Symmetric) Bordered Band Matrix.
-/**
- *  Separate storage of border, mixed and band parts (as vector<double>).
- *
- *\verbatim
- *  Example for matrix size=8 with border size and band width of two
- *
- *     +-                                 -+
- *     |  B11 B12 M13 M14 M15 M16 M17 M18  |
- *     |  B12 B22 M23 M24 M25 M26 M27 M28  |
- *     |  M13 M23 C33 C34 C35  0.  0.  0.  |
- *     |  M14 M24 C34 C44 C45 C46  0.  0.  |
- *     |  M15 M25 C35 C45 C55 C56 C57  0.  |
- *     |  M16 M26  0. C46 C56 C66 C67 C68  |
- *     |  M17 M27  0.  0. C57 C67 C77 C78  |
- *     |  M18 M28  0.  0.  0. C68 C78 C88  |
- *     +-                                 -+
- *
- *  Is stored as::
- *
- *     +-         -+     +-                         -+
- *     |  B11 B12  |     |  M13 M14 M15 M16 M17 M18  |
- *     |  B12 B22  |     |  M23 M24 M25 M26 M27 M28  |
- *     +-         -+     +-                         -+
- *
- *                       +-                         -+
- *                       |  C33 C44 C55 C66 C77 C88  |
- *                       |  C34 C45 C56 C67 C78  0.  |
- *                       |  C35 C46 C57 C68  0.  0.  |
- *                       +-                         -+
- *\endverbatim
- */
+  /**
+   *  Separate storage of border, mixed and band parts (as vector<double>).
+   *
+   *\verbatim
+   *  Example for matrix size=8 with border size and band width of two
+   *
+   *     +-                                 -+
+   *     |  B11 B12 M13 M14 M15 M16 M17 M18  |
+   *     |  B12 B22 M23 M24 M25 M26 M27 M28  |
+   *     |  M13 M23 C33 C34 C35  0.  0.  0.  |
+   *     |  M14 M24 C34 C44 C45 C46  0.  0.  |
+   *     |  M15 M25 C35 C45 C55 C56 C57  0.  |
+   *     |  M16 M26  0. C46 C56 C66 C67 C68  |
+   *     |  M17 M27  0.  0. C57 C67 C77 C78  |
+   *     |  M18 M28  0.  0.  0. C68 C78 C88  |
+   *     +-                                 -+
+   *
+   *  Is stored as::
+   *
+   *     +-         -+     +-                         -+
+   *     |  B11 B12  |     |  M13 M14 M15 M16 M17 M18  |
+   *     |  B12 B22  |     |  M23 M24 M25 M26 M27 M28  |
+   *     +-         -+     +-                         -+
+   *
+   *                       +-                         -+
+   *                       |  C33 C44 C55 C66 C77 C88  |
+   *                       |  C34 C45 C56 C67 C78  0.  |
+   *                       |  C35 C46 C57 C68  0.  0.  |
+   *                       +-                         -+
+   *\endverbatim
+   */
 
-class BorderedBandMatrix {
-public:
-	BorderedBandMatrix();
-	virtual ~BorderedBandMatrix();
-	void resize(unsigned int nSize, unsigned int nBorder = 1,
-			unsigned int nBand = 5);
-	void solveAndInvertBorderedBand(const VVector &aRightHandSide,
-			VVector &aSolution);
-	void addBlockMatrix(double aWeight,
-			const std::vector<unsigned int>* anIndex,
-			const std::vector<double>* aVector);
-	TMatrixDSym getBlockMatrix(const std::vector<unsigned int> &anIndex) const;
-	void printMatrix() const;
+  class BorderedBandMatrix {
+  public:
+    BorderedBandMatrix();
+    virtual ~BorderedBandMatrix();
+    void resize(unsigned int nSize, unsigned int nBorder = 1,
+                unsigned int nBand = 5);
+    void solveAndInvertBorderedBand(const VVector& aRightHandSide,
+                                    VVector& aSolution);
+    void addBlockMatrix(double aWeight,
+                        const std::vector<unsigned int>* anIndex,
+                        const std::vector<double>* aVector);
+    TMatrixDSym getBlockMatrix(const std::vector<unsigned int>& anIndex) const;
+    void printMatrix() const;
 
-private:
-	unsigned int numSize; ///< Matrix size
-	unsigned int numBorder; ///< Border size
-	unsigned int numBand; ///< Band width
-	unsigned int numCol; ///< Band matrix size
-	VSymMatrix theBorder; ///< Border part
-	VMatrix theMixed; ///< Mixed part
-	VMatrix theBand; ///< Band part
+  private:
+    unsigned int numSize; ///< Matrix size
+    unsigned int numBorder; ///< Border size
+    unsigned int numBand; ///< Band width
+    unsigned int numCol; ///< Band matrix size
+    VSymMatrix theBorder; ///< Border part
+    VMatrix theMixed; ///< Mixed part
+    VMatrix theBand; ///< Band part
 
-	void decomposeBand();
-	VVector solveBand(const VVector &aRightHandSide) const;
-	VMatrix solveBand(const VMatrix &aRightHandSide) const;
-	VMatrix invertBand();
-	VMatrix bandOfAVAT(const VMatrix &anArray,
-			const VSymMatrix &aSymArray) const;
-};
+    void decomposeBand();
+    VVector solveBand(const VVector& aRightHandSide) const;
+    VMatrix solveBand(const VMatrix& aRightHandSide) const;
+    VMatrix invertBand();
+    VMatrix bandOfAVAT(const VMatrix& anArray,
+                       const VSymMatrix& aSymArray) const;
+  };
 }
 #endif /* BORDEREDBANDMATRIX_H_ */

--- a/GBL/include/GFGbl.h
+++ b/GBL/include/GFGbl.h
@@ -38,19 +38,19 @@
 
 
 namespace genfit {
-  
-  
+
+
   /** @brief Generic GBL implementation
-   * 
+   *
    * The interface class to GBL track fit
    *
    */
   class GFGbl : public AbsFitter {
-    
+
   private:
     GFGbl(const GFGbl&);
     GFGbl& operator=(GFGbl const&);
-    
+
     std::string m_milleFileName;
     std::string m_gblInternalIterations;
     double m_pValueCut;
@@ -58,47 +58,48 @@ namespace genfit {
     double m_chi2Cut;
     bool m_enableScatterers;
     bool m_enableIntermediateScatterer;
-    
-    
+
+
   public:
-    
+
     /**
      * Constructor
      */
     GFGbl();
-    
+
     /**
      * Destructor
      */
     virtual ~GFGbl() {;}
-    
+
     /**
      * Creates the mille binary file for output of
      * data for Millepede II alignment, can be set by setMP2Options
      */
     void beginRun();
-    
+
     /**
      * Required to write and close ROOT file
      * with debug output. Destructor cannot be used.
      * To be called from endRun function of a module
      */
     void endRun();
-    
-    
+
+
     /**
      * @brief Sets internal GBL down-weighting
      * @param internalIterations GBL internal down-weighting settings, see GBL doc
      * @return void
      */
-    void setGBLOptions(std::string internalIterations = "THC", bool enableScatterers = true, bool enableIntermediateScatterer = true) {
+    void setGBLOptions(std::string internalIterations = "THC", bool enableScatterers = true, bool enableIntermediateScatterer = true)
+    {
       m_gblInternalIterations = internalIterations;
       if (!enableScatterers)
         enableIntermediateScatterer = false;
       m_enableScatterers = enableScatterers;
       m_enableIntermediateScatterer = enableIntermediateScatterer;
     }
-    
+
     /**
      * @brief Sets GBL & Millepede settings
      * @param pValueCut minimum track p-value for MP2 output
@@ -106,26 +107,28 @@ namespace genfit {
      * @param mille_file_name name of MP2 binary file for output
      * @return void
      */
-    void setMP2Options(double pValueCut = 0., unsigned int minNdf = 1, std::string mille_file_name = "millefile.dat", double chi2Cut = 0.) {
+    void setMP2Options(double pValueCut = 0., unsigned int minNdf = 1, std::string mille_file_name = "millefile.dat",
+                       double chi2Cut = 0.)
+    {
       m_pValueCut = pValueCut;
       m_minNdf = minNdf;
       m_milleFileName = mille_file_name;
       m_chi2Cut = chi2Cut;
     }
-    
+
     /**
      * Performs fit on a Track.
      * Hit resorting currently NOT supported.
      */
     void processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool resortHits = false) override;
-    
-    
+
+
   public:
-    
+
     ClassDef(GFGbl, 1)
-    
+
   };
-  
+
 }  /* End of namespace genfit */
 /** @} */
 

--- a/GBL/include/GblData.h
+++ b/GBL/include/GblData.h
@@ -48,53 +48,53 @@ typedef ROOT::Math::SMatrix<double, 5, 5> SMatrix55;
 namespace gbl {
 
 /// Data (block) for independent scalar measurement
-/**
- * Data (block) containing value, precision and derivatives for measurements and kinks.
- * Created from attributes of GblPoints, used to construct linear equation system for track fit.
- */
-class GblData {
-public:
-        GblData() : theLabel(0), theValue(0.), thePrecision(-1.), theDownWeight(0.), thePrediction(0.) {};
-	GblData(unsigned int aLabel, double aMeas, double aPrec);
-	virtual ~GblData();
-	void addDerivatives(unsigned int iRow,
-			const std::vector<unsigned int> &labDer, const SMatrix55 &matDer,
-			unsigned int iOff, const TMatrixD &derLocal,
-			const std::vector<int> &labGlobal, const TMatrixD &derGlobal,
-			unsigned int nLocal, const TMatrixD &derTrans);
-	void addDerivatives(unsigned int iRow,
-			const std::vector<unsigned int> &labDer, const SMatrix27 &matDer,
-			unsigned int nLocal, const TMatrixD &derTrans);
-	void addDerivatives(const std::vector<unsigned int> &index,
-			const std::vector<double> &derivatives);
+  /**
+   * Data (block) containing value, precision and derivatives for measurements and kinks.
+   * Created from attributes of GblPoints, used to construct linear equation system for track fit.
+   */
+  class GblData {
+  public:
+    GblData() : theLabel(0), theValue(0.), thePrecision(-1.), theDownWeight(0.), thePrediction(0.) {};
+    GblData(unsigned int aLabel, double aMeas, double aPrec);
+    virtual ~GblData();
+    void addDerivatives(unsigned int iRow,
+                        const std::vector<unsigned int>& labDer, const SMatrix55& matDer,
+                        unsigned int iOff, const TMatrixD& derLocal,
+                        const std::vector<int>& labGlobal, const TMatrixD& derGlobal,
+                        unsigned int nLocal, const TMatrixD& derTrans);
+    void addDerivatives(unsigned int iRow,
+                        const std::vector<unsigned int>& labDer, const SMatrix27& matDer,
+                        unsigned int nLocal, const TMatrixD& derTrans);
+    void addDerivatives(const std::vector<unsigned int>& index,
+                        const std::vector<double>& derivatives);
 
-	void setPrediction(const VVector &aVector);
-	double setDownWeighting(unsigned int aMethod);
-	double getChi2() const;
-	void printData() const;
-	void getLocalData(double &aValue, double &aWeight,
-			std::vector<unsigned int>* &indLocal,
-			std::vector<double>* &derLocal);
-	void getAllData(double &aValue, double &aErr,
-			std::vector<unsigned int>* &indLocal,
-			std::vector<double>* &derLocal, std::vector<int>* &labGlobal,
-			std::vector<double>* &derGlobal);
-	void getResidual(double &aResidual, double &aVariance, double &aDownWeight,
-			std::vector<unsigned int>* &indLocal,
-			std::vector<double>* &derLocal);
+    void setPrediction(const VVector& aVector);
+    double setDownWeighting(unsigned int aMethod);
+    double getChi2() const;
+    void printData() const;
+    void getLocalData(double& aValue, double& aWeight,
+                      std::vector<unsigned int>*& indLocal,
+                      std::vector<double>*& derLocal);
+    void getAllData(double& aValue, double& aErr,
+                    std::vector<unsigned int>*& indLocal,
+                    std::vector<double>*& derLocal, std::vector<int>*& labGlobal,
+                    std::vector<double>*& derGlobal);
+    void getResidual(double& aResidual, double& aVariance, double& aDownWeight,
+                     std::vector<unsigned int>*& indLocal,
+                     std::vector<double>*& derLocal);
 
-private:
-	unsigned int theLabel; ///< Label (of measurements point)
-	double theValue; ///< Value (residual)
-	double thePrecision; ///< Precision (1/sigma**2)
-	double theDownWeight; ///< Down-weighting factor (0-1)
-	double thePrediction; ///< Prediction from fit
-	std::vector<unsigned int> theParameters; ///< List of fit parameters (with non zero derivatives)
-	std::vector<double> theDerivatives; ///< List of derivatives for fit
-	std::vector<int> globalLabels; ///< Labels for global derivatives
-	std::vector<double> globalDerivatives; ///< Global derivatives
+  private:
+    unsigned int theLabel; ///< Label (of measurements point)
+    double theValue; ///< Value (residual)
+    double thePrecision; ///< Precision (1/sigma**2)
+    double theDownWeight; ///< Down-weighting factor (0-1)
+    double thePrediction; ///< Prediction from fit
+    std::vector<unsigned int> theParameters; ///< List of fit parameters (with non zero derivatives)
+    std::vector<double> theDerivatives; ///< List of derivatives for fit
+    std::vector<int> globalLabels; ///< Labels for global derivatives
+    std::vector<double> globalDerivatives; ///< Global derivatives
 
-        ClassDef(GblData, 1)
-};
+    ClassDef(GblData, 1)
+  };
 }
 #endif /* GBLDATA_H_ */

--- a/GBL/include/GblFitStatus.h
+++ b/GBL/include/GblFitStatus.h
@@ -1,18 +1,18 @@
 /* Copyright 2008-2010, Technische Universitaet Muenchen,
  *   Authors: Christian Hoeppner & Sebastian Neubert & Johannes Rauch
- * 
+ *
  *   This file is part of GENFIT.
- * 
+ *
  *   GENFIT is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU Lesser General Public License as published
  *   by the Free Software Foundation, either version 3 of the License, or
  *   (at your option) any later version.
- * 
+ *
  *   GENFIT is distributed in the hope that it will be useful,
  *   but WITHOUT ANY WARRANTY; without even the implied warranty of
  *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *   GNU Lesser General Public License for more details.
- * 
+ *
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with GENFIT.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -32,54 +32,54 @@
 
 
 namespace genfit {
-  
+
   /**
    * @brief FitStatus for use with GblFitter
    */
   class GblFitStatus : public FitStatus {
-    
+
   public:
-    
+
     GblFitStatus() :
-    FitStatus(), numIterations_(0), fittedWithReferenceTrack_(false),
-    trackLen_(0), curvatureFlag_(true), maxLocalFitParams_(0) {;}
-    
+      FitStatus(), numIterations_(0), fittedWithReferenceTrack_(false),
+      trackLen_(0), curvatureFlag_(true), maxLocalFitParams_(0) {;}
+
     virtual ~GblFitStatus() {};
-    
+
     virtual FitStatus* clone() const override {return new GblFitStatus(*this);}
-    
+
     void setCurvature(bool useCurvature) {curvatureFlag_ = useCurvature;}
     bool hasCurvature() { return curvatureFlag_; }
     void setMaxLocalFitParams(unsigned maxLocalFitParams) {maxLocalFitParams_ = maxLocalFitParams;}
     bool getMaxLocalFitParams() { return maxLocalFitParams_; }
-    
+
     unsigned int getNumIterations() const {return numIterations_;}
     bool isFittedWithReferenceTrack() const {return fittedWithReferenceTrack_;}
     double getTrackLen() const {return trackLen_;}
     // virtual double getPVal() : not overridden, as it does the right thing.
-    
+
     void setNumIterations(unsigned int numIterations) {numIterations_ = numIterations;}
     void setIsFittedWithReferenceTrack(bool fittedWithReferenceTrack = true) {fittedWithReferenceTrack_ = fittedWithReferenceTrack;}
     void setTrackLen(double trackLen) {trackLen_ = trackLen;}
-    
+
     virtual void Print(const Option_t* = "") const override {;}
-    
+
   protected:
-    
+
     unsigned int numIterations_; // number of iterations that have been performed
     bool fittedWithReferenceTrack_;
-    
+
     double trackLen_;
     bool curvatureFlag_;
     int maxLocalFitParams_;
-    
-    
+
+
   public:
-    
+
     ClassDefOverride(GblFitStatus, 1)
-    
+
   };
-  
+
 } /* End of namespace genfit */
 /** @} */
 

--- a/GBL/include/GblFitter.h
+++ b/GBL/include/GblFitter.h
@@ -42,45 +42,46 @@
 
 
 namespace genfit {
-  
+
   class GblTrackSegmentController;
-  
+
   /** @brief Generic GBL implementation
-   * 
+   *
    * The interface class to GBL track fit
    *
    */
   class GblFitter : public AbsFitter {
-    
+
   private:
     GblFitter(const GblFitter&);
     GblFitter& operator=(GblFitter const&);
-    
+
     std::string m_gblInternalIterations;
     bool m_enableScatterers;
     bool m_enableIntermediateScatterer;
     unsigned int m_externalIterations;
     unsigned int m_recalcJacobians;
-    
+
     // Minimum scattering sigma (will be squared and inverted...)
     double scatEpsilon;
     GblTrackSegmentController* m_segmentController;
-    
+
   public:
-    
+
     /**
      * Default (and only) constructor
      */
-    GblFitter() : AbsFitter(), m_gblInternalIterations(""), m_enableScatterers(true), m_enableIntermediateScatterer(true), m_externalIterations(1), m_recalcJacobians(0), scatEpsilon(1.e-8), m_segmentController(nullptr) {;}
-    
+    GblFitter() : AbsFitter(), m_gblInternalIterations(""), m_enableScatterers(true), m_enableIntermediateScatterer(true),
+      m_externalIterations(1), m_recalcJacobians(0), scatEpsilon(1.e-8), m_segmentController(nullptr) {;}
+
     /**
      * Destructor
      */
-    virtual ~GblFitter();    
+    virtual ~GblFitter();
 
     /**
      * @brief Set options of the fitter/GBL
-     * 
+     *
      * @return void
      * @param internalIterations GBL down-weighting in iterations. One letter (T,H,C) per iteration.
      *                           Seems "HH" is resonable for outliers. Default "" is OK.
@@ -97,7 +98,9 @@ namespace genfit {
      * @param recalcJacobians Number of iteration up to which Jacobians should be recalculated / planes/meas updated after the fit.
      *                        0 = do not recalculate Jacobians. 1 = recalculate after first GBL fit. 2 = after 1st and 2nd GBL fit etc.
      */
-    void setOptions(const std::string &internalIterations = "", bool enableScatterers = true, bool enableIntermediateScatterer = true, unsigned int externalIterations = 1, unsigned int recalcJacobians = 1) {
+    void setOptions(const std::string& internalIterations = "", bool enableScatterers = true, bool enableIntermediateScatterer = true,
+                    unsigned int externalIterations = 1, unsigned int recalcJacobians = 1)
+    {
       m_externalIterations = externalIterations;
       m_gblInternalIterations = internalIterations;
       m_recalcJacobians = recalcJacobians;
@@ -107,22 +110,23 @@ namespace genfit {
       m_enableIntermediateScatterer = enableIntermediateScatterer;
     }
 
-    
+
     /**
      * @brief Set multiple scattering options of the fitter/GBL
-     * 
+     *
      * @return void
      * @param enableScatterers If false, no scatterers will be added to GBL trajectory
      * @param enableIntermediateScatterer True to simulate thick sctatterers by two thin scatterers
      *                                    1st at detector plane and intermediate between each two planes
      */
-    void setMSOptions(bool enableScatterers = true, bool enableIntermediateScatterer = true) {
+    void setMSOptions(bool enableScatterers = true, bool enableIntermediateScatterer = true)
+    {
       if (!enableScatterers)
         enableIntermediateScatterer = false;
       m_enableScatterers = enableScatterers;
       m_enableIntermediateScatterer = enableIntermediateScatterer;
     }
-    
+
     /**
      * @brief Evaluates moments of radiation length distribution from list of
      * material steps and computes parameters describing a corresponding thick scatterer.
@@ -146,83 +150,83 @@ namespace genfit {
                                  double& theta, double& s, double& ds,
                                  const double p, const double mass, const double charge,
                                  const std::vector<genfit::MatStep>& steps) const;
-    
+
     /**
      * Performs fit on a Track.
-     * Hit resorting currently supported (use only if necessary /wire chamber/ ... will 
+     * Hit resorting currently supported (use only if necessary /wire chamber/ ... will
      * extrapolate along whole track to sort the hits).
      */
     void processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool resortHits = false) override;
-    
+
     /**
      * @brief Propagate seed, populate track with scatterers
      * and GblFitterInfos with reference state set
-     * 
+     *
      * @param trk Track to attach with infos at given rep
      * @param rep TrackRep to which fitter info shall be attached
      * @return Length of track from extrapolations
      */
     double constructGblInfo(Track* trk, const AbsTrackRep* rep);
-    
+
     /**
      * @brief Populate all fitter infos in track for rep with
-     * results of trajectory fit. 
+     * results of trajectory fit.
      *
      * Updates also seed state in track (from forward prediction
      * at first point)
-     * 
+     *
      * (The trajectory can only be cut before track end,
      * cannot have missing points in between (if valid))
-     * 
-     * 
-     * 
+     *
+     *
+     *
      * TODO ??
      * Re-construct all points in GblFitterInfos (updated) and collect them
      * in fit status
-     * 
-     * 
+     *
+     *
      * @param traj The fitted GblTrajectory
-     * @param trk The track with fitter infos from whose points traj was created 
+     * @param trk The track with fitter infos from whose points traj was created
      * @param rep The representation to which this fit status belong
      */
     void updateGblInfo(gbl::GblTrajectory& traj, genfit::Track* trk, const genfit::AbsTrackRep* rep);
-    
+
     /**
      * @brief Constructs all GBL points and returns them in vector
      * for trajectory construction
-     * 
+     *
      * @return const std::vector< gbl::GblPoint, std::allocator >&
      */
     std::vector<gbl::GblPoint> collectGblPoints(genfit::Track* trk, const genfit::AbsTrackRep* rep);
-    
+
     /**
      * @brief Remove all previous gbl fitter data from track
      * Also removes trackpoints without measurement
-     * 
+     *
      * @param trk The track
      * @param rep Representation for which to clean data
      * @return void
      */
     void cleanGblInfo(Track* trk, const AbsTrackRep* rep) const;
-    
+
     /**
      * @brief Sort hits in track by arc-len using extrapolation
-     * 
+     *
      * @param trk The track
      * @param rep The track representation
      * @return void
      */
     void sortHits(Track* trk, const AbsTrackRep* rep) const;
-    
+
     void setTrackSegmentController(GblTrackSegmentController* controler);
-    
-    
+
+
   public:
-    
+
     ClassDef(GblFitter, 2)
-    
+
   };
-  
+
 }  /* End of namespace genfit */
 /** @} */
 

--- a/GBL/include/GblFitterInfo.h
+++ b/GBL/include/GblFitterInfo.h
@@ -1,18 +1,18 @@
 /* Copyright 2008-2010, Technische Universitaet Muenchen,
  *   Authors: Christian Hoeppner & Sebastian Neubert & Johannes Rauch
- * 
+ *
  *   This file is part of GENFIT.
- * 
+ *
  *   GENFIT is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU Lesser General Public License as published
  *   by the Free Software Foundation, either version 3 of the License, or
  *   (at your option) any later version.
- * 
+ *
  *   GENFIT is distributed in the hope that it will be useful,
  *   but WITHOUT ANY WARRANTY; without even the implied warranty of
  *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *   GNU Lesser General Public License for more details.
- * 
+ *
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with GENFIT.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -44,78 +44,78 @@
 
 
 namespace genfit {
-  
-  
+
+
   /**
    *  @brief Collects information needed and produced by a GblFitter/GBL and is specific to one AbsTrackRep of the Track.
    */
   class GblFitterInfo : public AbsFitterInfo {
-    
+
   public:
-    
+
     /**
-     * @brief Constructor for ROOT I/O 
+     * @brief Constructor for ROOT I/O
      */
     GblFitterInfo();
-    
+
     /**
      * @brief Default (inherited) constructor
      * Should not be used or the reference should set immediately upon
      * construction (to set the plane).
      */
     GblFitterInfo(const TrackPoint* trackPoint, const AbsTrackRep* rep);
-    
+
     /**
      * @brief Default user constructor
-     * 
+     *
      * @param trackPoint The point at track to attach fitter info.
      * @param rep The representation this fitter info belongs to
      * @param referenceState State from extrapolation to init predictions and plane
      */
     GblFitterInfo(const TrackPoint* trackPoint, const AbsTrackRep* rep, StateOnPlane& referenceState);
-    
+
     /**
      * @brief (Initial) reset of fitter info
-     * 
+     *
      * @param measurementDim Measurement dimesion (2)
      * @param repDim Representation dimesion (5)
      * @return void
      */
     void reset(unsigned int measurementDim = 2, unsigned int repDim = 5);
-        
+
     /**
      * @brief Set the prediction and plane (from measurement if any)
      * You should use the user constructor instead.
-     * 
+     *
      * Reference gets not updated internally in fitter info.
      * After updateFitResults(...), updates affect the +/- predictions directly.
-     * 
+     *
      * Should be called only once (so rather use constructor).
      * Otherwise will rewrite fitted state by reference (and you have to update from fit again)
-     * 
+     *
      * @param referenceState StateOnPlane from extrapolation to this point
      * @return void
      */
     void setReferenceState(StateOnPlane& referenceState);
     /**
      * @brief Set the Jacobian for further GblPoint construction
-     * 
+     *
      * @param jacobian 5x5 TMatrixD with Jacobian for propagation of the state from previous point
      *                 to this point.
      * @return void
      */
     void setJacobian(TMatrixD jacobian);
-    
+
     /**
      * @brief Get scattering covariance projected into (measurement) plane
-     * 
+     *
      * @param variance Variance of slopes in track frame
      * @param trackDirection Direction of the track at the plane
      * @param measurementPlane The plane with measurement to which MS shall be projected
      * @return TMatrixDSym
      */
     TMatrixDSym getCovariance(double variance, TVector3 trackDirection, SharedPlanePtr measurementPlane) const;
-    
+
     /**
      * @brief Collect all data and create a GblPoint
      * - Jacobian is taken from fitter info ... use setJaobian() to change it
@@ -123,22 +123,22 @@ namespace genfit {
      * - A measurement (first MeasurementOnPlane in 1st RawMeasurement) is added.
      * - Global and local derivatives are added for RawMesurement implementing
      *   ICalibrationParametersDerivatives interface. Using most up to date prediction.
-     * 
+     *
      * @return gbl::GblPoint
      */
     gbl::GblPoint constructGblPoint();
-  
+
     /**
      * @brief Update fitter info from GBL fit results
-     * 
+     *
      * Locates itself in track/trajectory and updates
      * predictions, errors, etc.
-     * 
+     *
      * @param traj Fitted GblTrajectory constructed with this point
      * @return void
      */
     void updateFitResults(gbl::GblTrajectory& traj);
-    
+
     /**
      * @brief Get the prediction at this point
      * Always biased in GBL (global fit)
@@ -146,9 +146,9 @@ namespace genfit {
      * a scatterer at this point).
      * Per default the state after kink for forward propagation
      * is returned.
-     * 
+     *
      * If not yet fitted, returns the reference state
-     * 
+     *
      * @param afterKink If true, returns prediction for forward propagation.
      *                  If false, for backward
      * @return const genfit::MeasuredStateOnPlane&
@@ -157,12 +157,12 @@ namespace genfit {
 
     /**
      * @brief Get the residual
-     * 
+     *
      * Temporarily constructs measurements
      * and calculates residual as meas - prediction.
-     * 
+     *
      * Always biased. Always only one (1st) measurement!
-     * 
+     *
      * @param  ...
      * @param  ...
      * @param onlyMeasurementErrors If true, covariance of measurement returned.
@@ -170,58 +170,58 @@ namespace genfit {
      * @return genfit::MeasurementOnPlane
      */
     MeasurementOnPlane getResidual(unsigned int = 0, bool = false, bool onlyMeasurementErrors = true) const override;
-    
+
     /**
      * @brief Get kink (residual) with diagonalized covariance (2D)
      * Covariance may be zero if not yet fitted or no scatterer!
-     * 
+     *
      * @return genfit::MeasurementOnPlane
      */
     MeasurementOnPlane getKink() const;
-    
+
     /**
      * @brief Get kink (residual) (2D)
      * = 0 - ( (+)pred - (-)pred )
-     * 
+     *
      * @return TVectorD
      */
     TVectorD getKinks() const;
-    
+
     /**
      * @brief Get the measurement on plane from stored
      * measurement data (from last construction/update)
-     * 
+     *
      * @return genfit::MeasuredStateOnPlane
      */
     MeasurementOnPlane getMeasurement() const;
-    
+
     /**
      * @brief SHOULD BE USED ONLY INTERNALY!
      * Update the plane from measurement constructed with state
      * or take plane from state if there is no measurement.
      * 1st raw Measurement with highest weight is constructed and stored as matrices.
-     * 
+     *
      * @return void
      */
-    void updateMeasurementAndPlane(const StateOnPlane & sop);
+    void updateMeasurementAndPlane(const StateOnPlane& sop);
 
     /**
      * @brief Returns (copy of) the stored reference 5D state at current plane with internal rep
-     * 
+     *
      * @return genfit::StateOnPlane
      */
     StateOnPlane getReferenceState() const {return StateOnPlane(refPrediction_, sharedPlane_, rep_);}
-    
+
     /**
      * @brief Re-extrapolates between prevFitterInfo and this point using
      * forward state to update the Jacobian (if planes and/or states changed,
      * internal predictions are extrapolated to new planes)
-     * 
+     *
      * @param prevFitterInfo Pointer to GblFitterInfo of previous point
      * @return void
      */
     void recalculateJacobian(GblFitterInfo* prevFitterInfo);
-    
+
     virtual ~GblFitterInfo() {;}
     virtual GblFitterInfo* clone() const override;
     bool hasMeasurements() const override {return trackPoint_->hasRawMeasurements();}
@@ -235,7 +235,8 @@ namespace genfit {
 
     void deleteForwardInfo() override {;}
     void deleteBackwardInfo() override {;}
-    void deletePredictions() {
+    void deletePredictions()
+    {
       deleteBackwardInfo();
       deleteForwardInfo();
     }
@@ -243,7 +244,7 @@ namespace genfit {
     void deleteMeasurementInfo() override {;} // We do not keep the measurements
     virtual void Print(const Option_t* = "") const override;
     virtual bool checkConsistency(const genfit::PruneFlags* = nullptr) const override;
-       
+
   private:
     TMatrixD jacobian_;
     TVectorD measResiduals_;
@@ -259,20 +260,20 @@ namespace genfit {
     TVectorD fwdPrediction_;
     TVectorD bwdPrediction_;
     TVectorD refPrediction_;
-    
+
     TVectorD measurement_;
     TMatrixDSym measCov_;
     TMatrixD hMatrix_;
 
     mutable std::unique_ptr<MeasuredStateOnPlane> fittedStateBwd_; //!  cache
     mutable std::unique_ptr<MeasuredStateOnPlane> fittedStateFwd_; //!  cache
-    
+
   public:
-    
+
     ClassDefOverride(GblFitterInfo, 1)
-    
+
   };
-  
+
 } /* End of namespace genfit */
 /** @} */
 

--- a/GBL/include/GblPoint.h
+++ b/GBL/include/GblPoint.h
@@ -54,79 +54,79 @@ typedef ROOT::Math::SVector<double, 5> SVector5;
 namespace gbl {
 
 /// Point on trajectory
-/**
- * User supplied point on (initial) trajectory.
- *
- * Must have jacobian for propagation from previous point. May have:
- *
- *   -# Measurement (1D - 5D)
- *   -# Scatterer (thin, 2D kinks)
- *   -# Additional local parameters (with derivatives). Fitted together with track parameters.
- *   -# Additional global parameters (with labels and derivatives). Not fitted, only passed
- *      on to (binary) file for fitting with Millepede-II.
- */
-class GblPoint {
-public:
-	explicit GblPoint(const TMatrixD &aJacobian);
-	explicit GblPoint(const SMatrix55 &aJacobian);
-	virtual ~GblPoint();
-	void addMeasurement(const TMatrixD &aProjection, const TVectorD &aResiduals,
-			const TVectorD &aPrecision, double minPrecision = 0.);
-	void addMeasurement(const TMatrixD &aProjection, const TVectorD &aResiduals,
-			const TMatrixDSym &aPrecision, double minPrecision = 0.);
-	void addMeasurement(const TVectorD &aResiduals, const TVectorD &aPrecision,
-			double minPrecision = 0.);
-	void addMeasurement(const TVectorD &aResiduals,
-			const TMatrixDSym &aPrecision, double minPrecision = 0.);
-	unsigned int hasMeasurement() const;
-	void getMeasurement(SMatrix55 &aProjection, SVector5 &aResiduals,
-			SVector5 &aPrecision) const;
-	void getMeasTransformation(TMatrixD &aTransformation) const;
-	void addScatterer(const TVectorD &aResiduals, const TVectorD &aPrecision);
-	void addScatterer(const TVectorD &aResiduals,
-			const TMatrixDSym &aPrecision);
-	bool hasScatterer() const;
-	void getScatterer(SMatrix22 &aTransformation, SVector2 &aResiduals,
-			SVector2 &aPrecision) const;
-	void getScatTransformation(TMatrixD &aTransformation) const;
-	void addLocals(const TMatrixD &aDerivatives);
-	unsigned int getNumLocals() const;
-	const TMatrixD& getLocalDerivatives() const;
-	void addGlobals(const std::vector<int> &aLabels,
-			const TMatrixD &aDerivatives);
-	unsigned int getNumGlobals() const;
-	std::vector<int> getGlobalLabels() const;
-	const TMatrixD& getGlobalDerivatives() const;
-	void setLabel(unsigned int aLabel);
-	unsigned int getLabel() const;
-	void setOffset(int anOffset);
-	int getOffset() const;
-	const SMatrix55& getP2pJacobian() const;
-	void addPrevJacobian(const SMatrix55 &aJac);
-	void addNextJacobian(const SMatrix55 &aJac);
-	void getDerivatives(int aDirection, SMatrix22 &matW, SMatrix22 &matWJ,
-			SVector2 &vecWd) const;
-	void printPoint(unsigned int level = 0) const;
+  /**
+   * User supplied point on (initial) trajectory.
+   *
+   * Must have jacobian for propagation from previous point. May have:
+   *
+   *   -# Measurement (1D - 5D)
+   *   -# Scatterer (thin, 2D kinks)
+   *   -# Additional local parameters (with derivatives). Fitted together with track parameters.
+   *   -# Additional global parameters (with labels and derivatives). Not fitted, only passed
+   *      on to (binary) file for fitting with Millepede-II.
+   */
+  class GblPoint {
+  public:
+    explicit GblPoint(const TMatrixD& aJacobian);
+    explicit GblPoint(const SMatrix55& aJacobian);
+    virtual ~GblPoint();
+    void addMeasurement(const TMatrixD& aProjection, const TVectorD& aResiduals,
+                        const TVectorD& aPrecision, double minPrecision = 0.);
+    void addMeasurement(const TMatrixD& aProjection, const TVectorD& aResiduals,
+                        const TMatrixDSym& aPrecision, double minPrecision = 0.);
+    void addMeasurement(const TVectorD& aResiduals, const TVectorD& aPrecision,
+                        double minPrecision = 0.);
+    void addMeasurement(const TVectorD& aResiduals,
+                        const TMatrixDSym& aPrecision, double minPrecision = 0.);
+    unsigned int hasMeasurement() const;
+    void getMeasurement(SMatrix55& aProjection, SVector5& aResiduals,
+                        SVector5& aPrecision) const;
+    void getMeasTransformation(TMatrixD& aTransformation) const;
+    void addScatterer(const TVectorD& aResiduals, const TVectorD& aPrecision);
+    void addScatterer(const TVectorD& aResiduals,
+                      const TMatrixDSym& aPrecision);
+    bool hasScatterer() const;
+    void getScatterer(SMatrix22& aTransformation, SVector2& aResiduals,
+                      SVector2& aPrecision) const;
+    void getScatTransformation(TMatrixD& aTransformation) const;
+    void addLocals(const TMatrixD& aDerivatives);
+    unsigned int getNumLocals() const;
+    const TMatrixD& getLocalDerivatives() const;
+    void addGlobals(const std::vector<int>& aLabels,
+                    const TMatrixD& aDerivatives);
+    unsigned int getNumGlobals() const;
+    std::vector<int> getGlobalLabels() const;
+    const TMatrixD& getGlobalDerivatives() const;
+    void setLabel(unsigned int aLabel);
+    unsigned int getLabel() const;
+    void setOffset(int anOffset);
+    int getOffset() const;
+    const SMatrix55& getP2pJacobian() const;
+    void addPrevJacobian(const SMatrix55& aJac);
+    void addNextJacobian(const SMatrix55& aJac);
+    void getDerivatives(int aDirection, SMatrix22& matW, SMatrix22& matWJ,
+                        SVector2& vecWd) const;
+    void printPoint(unsigned int level = 0) const;
 
-private:
-	unsigned int theLabel; ///< Label identifying point
-	int theOffset; ///< Offset number at point if not negative (else interpolation needed)
-	SMatrix55 p2pJacobian; ///< Point-to-point jacobian from previous point
-	SMatrix55 prevJacobian; ///< Jacobian to previous scatterer (or first measurement)
-	SMatrix55 nextJacobian; ///< Jacobian to next scatterer (or last measurement)
-	unsigned int measDim; ///< Dimension of measurement (1-5), 0 indicates absence of measurement
-	SMatrix55 measProjection; ///< Projection from measurement to local system
-	SVector5 measResiduals; ///< Measurement residuals
-	SVector5 measPrecision; ///< Measurement precision (diagonal of inverse covariance matrix)
-	bool transFlag; ///< Transformation exists?
-	TMatrixD measTransformation; ///< Transformation of diagonalization (of meas. precision matrix)
-	bool scatFlag; ///< Scatterer present?
-	SMatrix22 scatTransformation; ///< Transformation of diagonalization (of scat. precision matrix)
-	SVector2 scatResiduals; ///< Scattering residuals (initial kinks if iterating)
-	SVector2 scatPrecision; ///< Scattering precision (diagonal of inverse covariance matrix)
-	TMatrixD localDerivatives; ///< Derivatives of measurement vs additional local (fit) parameters
-	std::vector<int> globalLabels; ///< Labels of global (MP-II) derivatives
-	TMatrixD globalDerivatives; ///< Derivatives of measurement vs additional global (MP-II) parameters
-};
+  private:
+    unsigned int theLabel; ///< Label identifying point
+    int theOffset; ///< Offset number at point if not negative (else interpolation needed)
+    SMatrix55 p2pJacobian; ///< Point-to-point jacobian from previous point
+    SMatrix55 prevJacobian; ///< Jacobian to previous scatterer (or first measurement)
+    SMatrix55 nextJacobian; ///< Jacobian to next scatterer (or last measurement)
+    unsigned int measDim; ///< Dimension of measurement (1-5), 0 indicates absence of measurement
+    SMatrix55 measProjection; ///< Projection from measurement to local system
+    SVector5 measResiduals; ///< Measurement residuals
+    SVector5 measPrecision; ///< Measurement precision (diagonal of inverse covariance matrix)
+    bool transFlag; ///< Transformation exists?
+    TMatrixD measTransformation; ///< Transformation of diagonalization (of meas. precision matrix)
+    bool scatFlag; ///< Scatterer present?
+    SMatrix22 scatTransformation; ///< Transformation of diagonalization (of scat. precision matrix)
+    SVector2 scatResiduals; ///< Scattering residuals (initial kinks if iterating)
+    SVector2 scatPrecision; ///< Scattering precision (diagonal of inverse covariance matrix)
+    TMatrixD localDerivatives; ///< Derivatives of measurement vs additional local (fit) parameters
+    std::vector<int> globalLabels; ///< Labels of global (MP-II) derivatives
+    TMatrixD globalDerivatives; ///< Derivatives of measurement vs additional global (MP-II) parameters
+  };
 }
 #endif /* GBLPOINT_H_ */

--- a/GBL/include/GblTrackSegmentController.h
+++ b/GBL/include/GblTrackSegmentController.h
@@ -1,18 +1,18 @@
 /* Copyright 2008-2010, Technische Universitaet Muenchen,
  *   Authors: Christian Hoeppner & Sebastian Neubert & Johannes Rauch
- * 
+ *
  *   This file is part of GENFIT.
- * 
+ *
  *   GENFIT is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU Lesser General Public License as published
  *   by the Free Software Foundation, either version 3 of the License, or
  *   (at your option) any later version.
- * 
+ *
  *   GENFIT is distributed in the hope that it will be useful,
  *   but WITHOUT ANY WARRANTY; without even the implied warranty of
  *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *   GNU Lesser General Public License for more details.
- * 
+ *
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with GENFIT.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -32,19 +32,19 @@
 #include <TVector3.h>
 
 namespace genfit {
-  
+
   class GblFitter;
   /**
    * @brief TrackSegmentController for use with GblFitter
    */
   class GblTrackSegmentController {
-    
+
   public:
-    
+
     GblTrackSegmentController() {;}
-    
+
     virtual ~GblTrackSegmentController() {};
-    
+
     /**
     * @brief Function called for each segment of trajectory. User can decide on MS options.
     *        This function must be implemented by the actual class deriving from this abstract class
@@ -53,18 +53,18 @@ namespace genfit {
     * @param scatTheta Total MS variance accumulated in this segment
     * @param fitter Pointer to the fitter - so you can set the MS options
     */
-    virtual void controlTrackSegment(TVector3 entry, TVector3 exit, double scatTheta, GblFitter * fitter) = 0;
-    
+    virtual void controlTrackSegment(TVector3 entry, TVector3 exit, double scatTheta, GblFitter* fitter) = 0;
+
     virtual void Print(const Option_t* = "") const {;}
-    
+
   protected:
-    
+
   public:
-    
+
     ClassDef(GblTrackSegmentController, 1)
-    
+
   };
-  
+
 } /* End of namespace genfit */
 /** @} */
 

--- a/GBL/include/GblTrajectory.h
+++ b/GBL/include/GblTrajectory.h
@@ -41,91 +41,91 @@
 namespace gbl {
 
 /// GBL trajectory.
-/**
- * List of GblPoints ordered by arc length.
- * Can be fitted and optionally written to MP-II binary file.
- */
-class GblTrajectory {
-public:
-	explicit GblTrajectory(const std::vector<GblPoint> &aPointList, bool flagCurv = true,
-			bool flagU1dir = true, bool flagU2dir = true);
-	GblTrajectory(const std::vector<GblPoint> &aPointList, unsigned int aLabel,
-			const TMatrixDSym &aSeed, bool flagCurv = true, bool flagU1dir =
-					true, bool flagU2dir = true);
-	explicit GblTrajectory(
-			const std::vector<std::pair<std::vector<GblPoint>, TMatrixD> > &aPointaAndTransList);
-	GblTrajectory(
-			const std::vector<std::pair<std::vector<GblPoint>, TMatrixD> > &aPointaAndTransList,
-			const TMatrixD &extDerivatives, const TVectorD &extMeasurements,
-			const TVectorD &extPrecisions);
-	GblTrajectory(
-			const std::vector<std::pair<std::vector<GblPoint>, TMatrixD> > &aPointaAndTransList,
-			const TMatrixD &extDerivatives, const TVectorD &extMeasurements,
-			const TMatrixDSym &extPrecisions);
-	virtual ~GblTrajectory();
-	bool isValid() const;
-	unsigned int getNumPoints() const;
-	unsigned int getResults(int aSignedLabel, TVectorD &localPar,
-			TMatrixDSym &localCov) const;
-	unsigned int getMeasResults(unsigned int aLabel, unsigned int &numRes,
-			TVectorD &aResiduals, TVectorD &aMeasErrors, TVectorD &aResErrors,
-			TVectorD &aDownWeights);
-	unsigned int getScatResults(unsigned int aLabel, unsigned int &numRes,
-			TVectorD &aResiduals, TVectorD &aMeasErrors, TVectorD &aResErrors,
-			TVectorD &aDownWeights);
-	unsigned int getLabels(std::vector<unsigned int> &aLabelList);
-	unsigned int getLabels(std::vector<std::vector<unsigned int> > &aLabelList);
-	unsigned int fit(double &Chi2, int &Ndf, double &lostWeight,
-			std::string optionList = "");
-	void milleOut(MilleBinary &aMille);
-	void printTrajectory(unsigned int level = 0);
-	void printPoints(unsigned int level = 0);
-	void printData();
-        std::vector<GblData> getData() {return theData;}
+  /**
+   * List of GblPoints ordered by arc length.
+   * Can be fitted and optionally written to MP-II binary file.
+   */
+  class GblTrajectory {
+  public:
+    explicit GblTrajectory(const std::vector<GblPoint>& aPointList, bool flagCurv = true,
+                           bool flagU1dir = true, bool flagU2dir = true);
+    GblTrajectory(const std::vector<GblPoint>& aPointList, unsigned int aLabel,
+                  const TMatrixDSym& aSeed, bool flagCurv = true, bool flagU1dir =
+                    true, bool flagU2dir = true);
+    explicit GblTrajectory(
+      const std::vector<std::pair<std::vector<GblPoint>, TMatrixD> >& aPointaAndTransList);
+    GblTrajectory(
+      const std::vector<std::pair<std::vector<GblPoint>, TMatrixD> >& aPointaAndTransList,
+      const TMatrixD& extDerivatives, const TVectorD& extMeasurements,
+      const TVectorD& extPrecisions);
+    GblTrajectory(
+      const std::vector<std::pair<std::vector<GblPoint>, TMatrixD> >& aPointaAndTransList,
+      const TMatrixD& extDerivatives, const TVectorD& extMeasurements,
+      const TMatrixDSym& extPrecisions);
+    virtual ~GblTrajectory();
+    bool isValid() const;
+    unsigned int getNumPoints() const;
+    unsigned int getResults(int aSignedLabel, TVectorD& localPar,
+                            TMatrixDSym& localCov) const;
+    unsigned int getMeasResults(unsigned int aLabel, unsigned int& numRes,
+                                TVectorD& aResiduals, TVectorD& aMeasErrors, TVectorD& aResErrors,
+                                TVectorD& aDownWeights);
+    unsigned int getScatResults(unsigned int aLabel, unsigned int& numRes,
+                                TVectorD& aResiduals, TVectorD& aMeasErrors, TVectorD& aResErrors,
+                                TVectorD& aDownWeights);
+    unsigned int getLabels(std::vector<unsigned int>& aLabelList);
+    unsigned int getLabels(std::vector<std::vector<unsigned int> >& aLabelList);
+    unsigned int fit(double& Chi2, int& Ndf, double& lostWeight,
+                     std::string optionList = "");
+    void milleOut(MilleBinary& aMille);
+    void printTrajectory(unsigned int level = 0);
+    void printPoints(unsigned int level = 0);
+    void printData();
+    std::vector<GblData> getData() {return theData;}
 
-private:
-	unsigned int numAllPoints; ///< Number of all points on trajectory
-	std::vector<unsigned int> numPoints; ///< Number of points on (sub)trajectory
-	unsigned int numTrajectories; ///< Number of trajectories (in composed trajectory)
-	unsigned int numOffsets; ///< Number of (points with) offsets on trajectory
-	unsigned int numInnerTrans; ///< Number of inner transformations to external parameters
-	unsigned int numCurvature; ///< Number of curvature parameters (0 or 1) or external parameters
-	unsigned int numParameters; ///< Number of fit parameters
-	unsigned int numLocals; ///< Total number of (additional) local parameters
-	unsigned int numMeasurements; ///< Total number of measurements
-	unsigned int externalPoint; ///< Label of external point (or 0)
-	bool constructOK; ///< Trajectory has been successfully constructed (ready for fit/output)
-	bool fitOK; ///< Trajectory has been successfully fitted (results are valid)
-	std::vector<unsigned int> theDimension; ///< List of active dimensions (0=u1, 1=u2) in fit
-	std::vector<std::vector<GblPoint> > thePoints; ///< (list of) List of points on trajectory
-	std::vector<GblData> theData; ///< List of data blocks
-	std::vector<unsigned int> measDataIndex; ///< mapping points to data blocks from measurements
-	std::vector<unsigned int> scatDataIndex; ///< mapping points to data blocks from scatterers
-	TMatrixDSym externalSeed; ///< Precision (inverse covariance matrix) of external seed
-	std::vector<TMatrixD> innerTransformations; ///< Transformations at innermost points of
-	// composed trajectory (from common external parameters)
-	TMatrixD externalDerivatives; // Derivatives for external measurements of composed trajectory
-	TVectorD externalMeasurements; // Residuals for external measurements of composed trajectory
-	TVectorD externalPrecisions; // Precisions for external measurements of composed trajectory
-	VVector theVector; ///< Vector of linear equation system
-	BorderedBandMatrix theMatrix; ///< (Bordered band) matrix of linear equation system
+  private:
+    unsigned int numAllPoints; ///< Number of all points on trajectory
+    std::vector<unsigned int> numPoints; ///< Number of points on (sub)trajectory
+    unsigned int numTrajectories; ///< Number of trajectories (in composed trajectory)
+    unsigned int numOffsets; ///< Number of (points with) offsets on trajectory
+    unsigned int numInnerTrans; ///< Number of inner transformations to external parameters
+    unsigned int numCurvature; ///< Number of curvature parameters (0 or 1) or external parameters
+    unsigned int numParameters; ///< Number of fit parameters
+    unsigned int numLocals; ///< Total number of (additional) local parameters
+    unsigned int numMeasurements; ///< Total number of measurements
+    unsigned int externalPoint; ///< Label of external point (or 0)
+    bool constructOK; ///< Trajectory has been successfully constructed (ready for fit/output)
+    bool fitOK; ///< Trajectory has been successfully fitted (results are valid)
+    std::vector<unsigned int> theDimension; ///< List of active dimensions (0=u1, 1=u2) in fit
+    std::vector<std::vector<GblPoint> > thePoints; ///< (list of) List of points on trajectory
+    std::vector<GblData> theData; ///< List of data blocks
+    std::vector<unsigned int> measDataIndex; ///< mapping points to data blocks from measurements
+    std::vector<unsigned int> scatDataIndex; ///< mapping points to data blocks from scatterers
+    TMatrixDSym externalSeed; ///< Precision (inverse covariance matrix) of external seed
+    std::vector<TMatrixD> innerTransformations; ///< Transformations at innermost points of
+    // composed trajectory (from common external parameters)
+    TMatrixD externalDerivatives; // Derivatives for external measurements of composed trajectory
+    TVectorD externalMeasurements; // Residuals for external measurements of composed trajectory
+    TVectorD externalPrecisions; // Precisions for external measurements of composed trajectory
+    VVector theVector; ///< Vector of linear equation system
+    BorderedBandMatrix theMatrix; ///< (Bordered band) matrix of linear equation system
 
-	std::pair<std::vector<unsigned int>, TMatrixD> getJacobian(
-			int aSignedLabel) const;
-	void getFitToLocalJacobian(std::vector<unsigned int> &anIndex,
-			SMatrix55 &aJacobian, const GblPoint &aPoint, unsigned int measDim,
-			unsigned int nJacobian = 1) const;
-	void getFitToKinkJacobian(std::vector<unsigned int> &anIndex,
-			SMatrix27 &aJacobian, const GblPoint &aPoint) const;
-	void construct();
-	void defineOffsets();
-	void calcJacobians();
-	void prepare();
-	void buildLinearEquationSystem();
-	void predict();
-	double downWeight(unsigned int aMethod);
-	void getResAndErr(unsigned int aData, double &aResidual,
-			double &aMeadsError, double &aResError, double &aDownWeight);
-};
+    std::pair<std::vector<unsigned int>, TMatrixD> getJacobian(
+      int aSignedLabel) const;
+    void getFitToLocalJacobian(std::vector<unsigned int>& anIndex,
+                               SMatrix55& aJacobian, const GblPoint& aPoint, unsigned int measDim,
+                               unsigned int nJacobian = 1) const;
+    void getFitToKinkJacobian(std::vector<unsigned int>& anIndex,
+                              SMatrix27& aJacobian, const GblPoint& aPoint) const;
+    void construct();
+    void defineOffsets();
+    void calcJacobians();
+    void prepare();
+    void buildLinearEquationSystem();
+    void predict();
+    double downWeight(unsigned int aMethod);
+    void getResAndErr(unsigned int aData, double& aResidual,
+                      double& aMeadsError, double& aResError, double& aDownWeight);
+  };
 }
 #endif /* GBLTRAJECTORY_H_ */

--- a/GBL/include/ICalibrationParametersDerivatives.h
+++ b/GBL/include/ICalibrationParametersDerivatives.h
@@ -31,126 +31,126 @@
 
 namespace genfit {
 
-/** @brief Abstract base class to establish an interface between physical representation
- * of the detector for alignment/calibration and (fitted) state on genfit::Track
- * 
- * An implementing class (RecoHit) should be able to calculate derivatives of 
- * track fit residuals (2D for planar, 1D for strip hit) residuals w.r.t.
- * global (and optionally additional local) parameters. Global parameters
- * need unique integer labels to identify them across all sub-detectors
- *
- *  @author TadeasBilka
- */
-class ICalibrationParametersDerivatives {
+  /** @brief Abstract base class to establish an interface between physical representation
+   * of the detector for alignment/calibration and (fitted) state on genfit::Track
+   *
+   * An implementing class (RecoHit) should be able to calculate derivatives of
+   * track fit residuals (2D for planar, 1D for strip hit) residuals w.r.t.
+   * global (and optionally additional local) parameters. Global parameters
+   * need unique integer labels to identify them across all sub-detectors
+   *
+   *  @author TadeasBilka
+   */
+  class ICalibrationParametersDerivatives {
 
- public:
-   virtual ~ICalibrationParametersDerivatives(){}
+  public:
+    virtual ~ICalibrationParametersDerivatives() {}
 
-   /**
-    * @brief Labels and derivatives of residuals (local measurement coordinates) w.r.t. alignment/calibration parameters
-    * Matrix "G" of derivatives valid for given prediction of track state:
-    * 
-    * G(i, j) = d_residual_i/d_parameter_j
-    * 
-    * For 2D measurement (u,v):
-    * 
-    * G = ( du/da du/db du/dc ... )
-    *     ( dv/da dv/db dv/dc ... )
-    * 
-    * for calibration parameters a, b, c.
-    * 
-    * For 1D measurement:
-    * 
-    * G = (   0     0     0   ... )
-    *     ( dv/da dv/db dv/dc ... )    for V-strip,
-    * 
-    * 
-    * G = ( du/da du/db du/dc ... )
-    *     (   0     0     0   ... )    for U-strip,
-    *
-    * Measurements with more dimesions (slopes, curvature) should provide
-    * full 4-5Dx(n params) matrix (state as (q/p, u', v', u, v) or (u', v', u, v))
-    * 
-    * 
-    * @param sop Predicted state of the track as linearization point around 
-    * which derivatives of alignment/calibration parameters shall be computed
-    * @return pair<vector<int>, TMatrixD> With matrix with #rows = dimension of residual, #columns = number of parameters.
-    * #columns must match vector<int>.size().
-    */
-   virtual std::pair<std::vector<int>, TMatrixD> globalDerivatives(const genfit::StateOnPlane* sop) {return std::make_pair(labels(), derivatives(sop));};
+    /**
+     * @brief Labels and derivatives of residuals (local measurement coordinates) w.r.t. alignment/calibration parameters
+     * Matrix "G" of derivatives valid for given prediction of track state:
+     *
+     * G(i, j) = d_residual_i/d_parameter_j
+     *
+     * For 2D measurement (u,v):
+     *
+     * G = ( du/da du/db du/dc ... )
+     *     ( dv/da dv/db dv/dc ... )
+     *
+     * for calibration parameters a, b, c.
+     *
+     * For 1D measurement:
+     *
+     * G = (   0     0     0   ... )
+     *     ( dv/da dv/db dv/dc ... )    for V-strip,
+     *
+     *
+     * G = ( du/da du/db du/dc ... )
+     *     (   0     0     0   ... )    for U-strip,
+     *
+     * Measurements with more dimesions (slopes, curvature) should provide
+     * full 4-5Dx(n params) matrix (state as (q/p, u', v', u, v) or (u', v', u, v))
+     *
+     *
+     * @param sop Predicted state of the track as linearization point around
+     * which derivatives of alignment/calibration parameters shall be computed
+     * @return pair<vector<int>, TMatrixD> With matrix with #rows = dimension of residual, #columns = number of parameters.
+     * #columns must match vector<int>.size().
+     */
+    virtual std::pair<std::vector<int>, TMatrixD> globalDerivatives(const genfit::StateOnPlane* sop) {return std::make_pair(labels(), derivatives(sop));};
 
-   /**
-    * @brief Vector of integer labels for calibration/alignment
-    * parameters available (must match #columns of derivatives(...))
-    * 
-    * unique across all sub-detectors in calibration
-    * 
-    * @return std::vector< int > Vector of integer labels
-    */
-   virtual std::vector<int> labels() {return std::vector<int>();}
-   
-   /**
-    * @brief Derivatives of residuals (local measurement coordinates) w.r.t. alignment/calibration parameters
-    * Matrix "G" of derivatives valid for given prediction of track state:
-    * 
-    * G(i, j) = d_residual_i/d_parameter_j
-    * 
-    * For 2D measurement (u,v):
-    * 
-    * G = ( du/da du/db du/dc ... )
-    *     ( dv/da dv/db dv/dc ... )
-    * 
-    * for calibration parameters a, b, c.
-    * 
-    * For 1D measurement both forms are allowed:
-    * 
-    * G = (   0     0     0   ... )
-    *     ( dv/da dv/db dv/dc ... )    for V-strip,
-    * 
-    * 
-    * G = ( du/da du/db du/dc ... )
-    *     (   0     0     0   ... )    for U-strip,
-    * 
-    * or :
-    * 
-    * G = ( d_sensitive/da d_sensitive/db d_sensitive/dc ... )   as matrix with one row.
-    * 
-    * A possible algorithm using these derivatives
-    * should be able to resolve this based on the measurement HMatrix.
-    * Measurements with more dimesions (slopes, curvature) should provide
-    * full 4-5Dx(n params) matrix (state as (q/p, u', v', u, v) or (u', v', u, v))
-    * 
-    * 
-    * @param sop Predicted state of the track as linearization point around 
-    * which derivatives of alignment/calibration parameters shall be computed
-    * @return TMatrixD Matrix with #rows = dimension of residual, #columns = number of parameters.
-    * #columns must match labels().size().
-    */
-   virtual TMatrixD derivatives(const genfit::StateOnPlane*) {return TMatrixD();}
-   
-   /**
-    * @brief Derivatives for additional local parameters to be fitted
-    * in global calibration algorithms together with with global parameters
-    * 
-    * Local parameters are not neccesarily identified by label because their number
-    * is proportional to number of measurements included in calibration
-    * (possibly very huge number!)
-    * 
-    * @return TMatrixD Matrix in form d_residual_i/d_parameter_j
-    */
-   virtual TMatrixD localDerivatives(const genfit::StateOnPlane*) {return TMatrixD();}
-   
-   /**
-    * @brief Vector of integer labels for local calibration
-    * parameters available (must match #columns of localDerivatives(...))
-    * 
-    * This will be usually ignored (e.g. does not have to match localDerivatives),
-    * but it is a good practice to return vector of zeros of correct size
-    * @return std::vector< int > Vector of integer labels
-    */
-   virtual std::vector<int> localLabels() {return std::vector<int>();}
-   
-};
+    /**
+     * @brief Vector of integer labels for calibration/alignment
+     * parameters available (must match #columns of derivatives(...))
+     *
+     * unique across all sub-detectors in calibration
+     *
+     * @return std::vector< int > Vector of integer labels
+     */
+    virtual std::vector<int> labels() {return std::vector<int>();}
+
+    /**
+     * @brief Derivatives of residuals (local measurement coordinates) w.r.t. alignment/calibration parameters
+     * Matrix "G" of derivatives valid for given prediction of track state:
+     *
+     * G(i, j) = d_residual_i/d_parameter_j
+     *
+     * For 2D measurement (u,v):
+     *
+     * G = ( du/da du/db du/dc ... )
+     *     ( dv/da dv/db dv/dc ... )
+     *
+     * for calibration parameters a, b, c.
+     *
+     * For 1D measurement both forms are allowed:
+     *
+     * G = (   0     0     0   ... )
+     *     ( dv/da dv/db dv/dc ... )    for V-strip,
+     *
+     *
+     * G = ( du/da du/db du/dc ... )
+     *     (   0     0     0   ... )    for U-strip,
+     *
+     * or :
+     *
+     * G = ( d_sensitive/da d_sensitive/db d_sensitive/dc ... )   as matrix with one row.
+     *
+     * A possible algorithm using these derivatives
+     * should be able to resolve this based on the measurement HMatrix.
+     * Measurements with more dimesions (slopes, curvature) should provide
+     * full 4-5Dx(n params) matrix (state as (q/p, u', v', u, v) or (u', v', u, v))
+     *
+     *
+     * @param sop Predicted state of the track as linearization point around
+     * which derivatives of alignment/calibration parameters shall be computed
+     * @return TMatrixD Matrix with #rows = dimension of residual, #columns = number of parameters.
+     * #columns must match labels().size().
+     */
+    virtual TMatrixD derivatives(const genfit::StateOnPlane*) {return TMatrixD();}
+
+    /**
+     * @brief Derivatives for additional local parameters to be fitted
+     * in global calibration algorithms together with with global parameters
+     *
+     * Local parameters are not neccesarily identified by label because their number
+     * is proportional to number of measurements included in calibration
+     * (possibly very huge number!)
+     *
+     * @return TMatrixD Matrix in form d_residual_i/d_parameter_j
+     */
+    virtual TMatrixD localDerivatives(const genfit::StateOnPlane*) {return TMatrixD();}
+
+    /**
+     * @brief Vector of integer labels for local calibration
+     * parameters available (must match #columns of localDerivatives(...))
+     *
+     * This will be usually ignored (e.g. does not have to match localDerivatives),
+     * but it is a good practice to return vector of zeros of correct size
+     * @return std::vector< int > Vector of integer labels
+     */
+    virtual std::vector<int> localLabels() {return std::vector<int>();}
+
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/GBL/include/MilleBinary.h
+++ b/GBL/include/MilleBinary.h
@@ -37,52 +37,52 @@
 namespace gbl {
 
 ///  Millepede-II (binary) record.
-/**
- *  Containing information for local (track) and global fit.
- *
- *  The data blocks are collected in two arrays, a real array
- *  (containing float or double values) and integer array, of same length.
- *  A positive record length indicate _float_ and a negative one _double_ values.
- *  The content of the record is:
- *\verbatim
- *         real array              integer array
- *     0   0.0                     error count (this record)
- *     1   RMEAS, measured value   0                            -+
- *     2   local derivative        index of local derivative     |
- *     3   local derivative        index of local derivative     |
- *     4    ...                                                  | block
- *         SIGMA, error (>0)       0                             |
- *         global derivative       label of global derivative    |
- *         global derivative       label of global derivative   -+
- *         RMEAS, measured value   0
- *         local derivative        index of local derivative
- *         local derivative        index of local derivative
- *         ...
- *         SIGMA, error            0
- *         global derivative       label of global derivative
- *         global derivative       label of global derivative
- *         ...
- *         global derivative       label of global derivative
- *\endverbatim
- */
-class MilleBinary {
-public:
-	MilleBinary(const std::string &fileName = "milleBinaryISN.dat",
-			bool doublePrec = false, unsigned int aSize = 2000);
-	virtual ~MilleBinary();
-	void addData(double aMeas, double aPrec,
-			const std::vector<unsigned int> &indLocal,
-			const std::vector<double> &derLocal,
-			const std::vector<int> &labGlobal,
-			const std::vector<double> &derGlobal);
-	void writeRecord();
+  /**
+   *  Containing information for local (track) and global fit.
+   *
+   *  The data blocks are collected in two arrays, a real array
+   *  (containing float or double values) and integer array, of same length.
+   *  A positive record length indicate _float_ and a negative one _double_ values.
+   *  The content of the record is:
+   *\verbatim
+   *         real array              integer array
+   *     0   0.0                     error count (this record)
+   *     1   RMEAS, measured value   0                            -+
+   *     2   local derivative        index of local derivative     |
+   *     3   local derivative        index of local derivative     |
+   *     4    ...                                                  | block
+   *         SIGMA, error (>0)       0                             |
+   *         global derivative       label of global derivative    |
+   *         global derivative       label of global derivative   -+
+   *         RMEAS, measured value   0
+   *         local derivative        index of local derivative
+   *         local derivative        index of local derivative
+   *         ...
+   *         SIGMA, error            0
+   *         global derivative       label of global derivative
+   *         global derivative       label of global derivative
+   *         ...
+   *         global derivative       label of global derivative
+   *\endverbatim
+   */
+  class MilleBinary {
+  public:
+    MilleBinary(const std::string& fileName = "milleBinaryISN.dat",
+                bool doublePrec = false, unsigned int aSize = 2000);
+    virtual ~MilleBinary();
+    void addData(double aMeas, double aPrec,
+                 const std::vector<unsigned int>& indLocal,
+                 const std::vector<double>& derLocal,
+                 const std::vector<int>& labGlobal,
+                 const std::vector<double>& derGlobal);
+    void writeRecord();
 
-private:
-	std::ofstream binaryFile; ///< Binary File
-	std::vector<int> intBuffer; ///< Integer buffer
-	std::vector<float> floatBuffer; ///< Float buffer
-	std::vector<double> doubleBuffer; ///< Double buffer
-	bool doublePrecision; ///< Flag for storage in as *double* values
-};
+  private:
+    std::ofstream binaryFile; ///< Binary File
+    std::vector<int> intBuffer; ///< Integer buffer
+    std::vector<float> floatBuffer; ///< Float buffer
+    std::vector<double> doubleBuffer; ///< Double buffer
+    bool doublePrecision; ///< Flag for storage in as *double* values
+  };
 }
 #endif /* MILLEBINARY_H_ */

--- a/GBL/include/MyDebugTools.h
+++ b/GBL/include/MyDebugTools.h
@@ -20,48 +20,48 @@ ofstream file("debug.txt");
 
 void outputMatrix(TMatrixDSym matrix, std::string caption = "")
 {
-	if (caption != "") file << caption << endl;
-	for (int i=0; i<matrix.GetNrows(); i++)
-	{
-		for (int j=0; j<matrix.GetNcols(); j++)
-		{
-			file << setw(12) << matrix[i][j] << "  ";
-		}
-		file << endl;
-	}
+  if (caption != "") file << caption << endl;
+  for (int i=0; i<matrix.GetNrows(); i++)
+  {
+    for (int j=0; j<matrix.GetNcols(); j++)
+    {
+      file << setw(12) << matrix[i][j] << "  ";
+    }
+    file << endl;
+  }
 }
 
 void outputMatrix(TMatrixD matrix, std::string caption = "")
 {
-	if (caption != "") file << caption << endl;
-	for (int i=0; i<matrix.GetNrows(); i++)
-	{
-		for (int j=0; j<matrix.GetNcols(); j++)
-		{
-			file << setw(12) << matrix[i][j] << "  ";
-		}
-		file << endl;
-	}
+  if (caption != "") file << caption << endl;
+  for (int i=0; i<matrix.GetNrows(); i++)
+  {
+    for (int j=0; j<matrix.GetNcols(); j++)
+    {
+      file << setw(12) << matrix[i][j] << "  ";
+    }
+    file << endl;
+  }
 }
 
 void outputVector(TVectorD vector, std::string caption)
 {
-	if (caption != "") file << caption << endl;
-	for (int i=0; i<vector.GetNoElements(); i++)
-	{
-		file << setw(12) << vector[i] << "  ";
-	}
-	file << endl;
+  if (caption != "") file << caption << endl;
+  for (int i=0; i<vector.GetNoElements(); i++)
+  {
+    file << setw(12) << vector[i] << "  ";
+  }
+  file << endl;
 }
 
 void outputVector(TVector3 vector, std::string caption)
 {
-	if (caption != "") file << caption << endl;
-	for (int i=0; i<3; i++)
-	{
-		file << setw(12) << vector[i] << "  ";
-	}
-	file << endl;
+  if (caption != "") file << caption << endl;
+  for (int i=0; i<3; i++)
+  {
+    file << setw(12) << vector[i] << "  ";
+  }
+  file << endl;
 }
 */
 #endif

--- a/GBL/include/VMatrix.h
+++ b/GBL/include/VMatrix.h
@@ -40,96 +40,102 @@
 namespace gbl {
 
 /// Simple Vector based on std::vector<double>
-class VVector {
-public:
-	VVector(const unsigned int nRows = 0);
-	VVector(const VVector &aVector);
-	virtual ~VVector();
-	void resize(const unsigned int nRows);
-	VVector getVec(unsigned int len, unsigned int start = 0) const;
-	void putVec(const VVector &aVector, unsigned int start = 0);
-	inline double &operator()(unsigned int i);
-	inline double operator()(unsigned int i) const;
-	unsigned int getNumRows() const;
-	void print() const;
-	VVector operator-(const VVector &aVector) const;
-	VVector &operator=(const VVector &aVector);
-private:
-	unsigned int numRows; ///< Number of rows
-	std::vector<double> theVec; ///< Data
-};
+  class VVector {
+  public:
+    VVector(const unsigned int nRows = 0);
+    VVector(const VVector& aVector);
+    virtual ~VVector();
+    void resize(const unsigned int nRows);
+    VVector getVec(unsigned int len, unsigned int start = 0) const;
+    void putVec(const VVector& aVector, unsigned int start = 0);
+    inline double& operator()(unsigned int i);
+    inline double operator()(unsigned int i) const;
+    unsigned int getNumRows() const;
+    void print() const;
+    VVector operator-(const VVector& aVector) const;
+    VVector& operator=(const VVector& aVector);
+  private:
+    unsigned int numRows; ///< Number of rows
+    std::vector<double> theVec; ///< Data
+  };
 
 /// Simple Matrix based on std::vector<double>
-class VMatrix {
-public:
-	VMatrix(const unsigned int nRows = 0, const unsigned int nCols = 0);
-	VMatrix(const VMatrix &aMatrix);
-	virtual ~VMatrix();
-	void resize(const unsigned int nRows, const unsigned int nCols);
-	VMatrix transpose() const;
-	inline double &operator()(unsigned int i, unsigned int j);
-	inline double operator()(unsigned int i, unsigned int j) const;
-	unsigned int getNumRows() const;
-	unsigned int getNumCols() const;
-	void print() const;
-	VVector operator*(const VVector &aVector) const;
-	VMatrix operator*(const VMatrix &aMatrix) const;
-	VMatrix operator+(const VMatrix &aMatrix) const;
-	VMatrix &operator=(const VMatrix &aMatrix);
-private:
-	unsigned int numRows; ///< Number of rows
-	unsigned int numCols; ///< Number of columns
-	std::vector<double> theVec; ///< Data
-};
+  class VMatrix {
+  public:
+    VMatrix(const unsigned int nRows = 0, const unsigned int nCols = 0);
+    VMatrix(const VMatrix& aMatrix);
+    virtual ~VMatrix();
+    void resize(const unsigned int nRows, const unsigned int nCols);
+    VMatrix transpose() const;
+    inline double& operator()(unsigned int i, unsigned int j);
+    inline double operator()(unsigned int i, unsigned int j) const;
+    unsigned int getNumRows() const;
+    unsigned int getNumCols() const;
+    void print() const;
+    VVector operator*(const VVector& aVector) const;
+    VMatrix operator*(const VMatrix& aMatrix) const;
+    VMatrix operator+(const VMatrix& aMatrix) const;
+    VMatrix& operator=(const VMatrix& aMatrix);
+  private:
+    unsigned int numRows; ///< Number of rows
+    unsigned int numCols; ///< Number of columns
+    std::vector<double> theVec; ///< Data
+  };
 
 /// Simple symmetric Matrix based on std::vector<double>
-class VSymMatrix {
-public:
-	VSymMatrix(const unsigned int nRows = 0);
-	virtual ~VSymMatrix();
-	void resize(const unsigned int nRows);
-	unsigned int invert();
-	inline double &operator()(unsigned int i, unsigned int j);
-	inline double operator()(unsigned int i, unsigned int j) const;
-	unsigned int getNumRows() const;
-	void print() const;
-	VSymMatrix operator-(const VMatrix &aMatrix) const;
-	VVector operator*(const VVector &aVector) const;
-	VMatrix operator*(const VMatrix &aMatrix) const;
-private:
-	unsigned int numRows; ///< Number of rows
-	std::vector<double> theVec; ///< Data (symmetric storage)
-};
+  class VSymMatrix {
+  public:
+    VSymMatrix(const unsigned int nRows = 0);
+    virtual ~VSymMatrix();
+    void resize(const unsigned int nRows);
+    unsigned int invert();
+    inline double& operator()(unsigned int i, unsigned int j);
+    inline double operator()(unsigned int i, unsigned int j) const;
+    unsigned int getNumRows() const;
+    void print() const;
+    VSymMatrix operator-(const VMatrix& aMatrix) const;
+    VVector operator*(const VVector& aVector) const;
+    VMatrix operator*(const VMatrix& aMatrix) const;
+  private:
+    unsigned int numRows; ///< Number of rows
+    std::vector<double> theVec; ///< Data (symmetric storage)
+  };
 
 /// access element (i,j)
-inline double &VMatrix::operator()(unsigned int iRow, unsigned int iCol) {
-	return theVec[numCols * iRow + iCol];
-}
+  inline double& VMatrix::operator()(unsigned int iRow, unsigned int iCol)
+  {
+    return theVec[numCols * iRow + iCol];
+  }
 
 /// access element (i,j)
-inline double VMatrix::operator()(unsigned int iRow, unsigned int iCol) const {
-	return theVec[numCols * iRow + iCol];
-}
+  inline double VMatrix::operator()(unsigned int iRow, unsigned int iCol) const
+  {
+    return theVec[numCols * iRow + iCol];
+  }
 
 /// access element (i)
-inline double &VVector::operator()(unsigned int iRow) {
-	return theVec[iRow];
-}
+  inline double& VVector::operator()(unsigned int iRow)
+  {
+    return theVec[iRow];
+  }
 
 /// access element (i)
-inline double VVector::operator()(unsigned int iRow) const {
-	return theVec[iRow];
-}
+  inline double VVector::operator()(unsigned int iRow) const
+  {
+    return theVec[iRow];
+  }
 
 /// access element (i,j) assuming i>=j
-inline double &VSymMatrix::operator()(unsigned int iRow, unsigned int iCol) {
-	return theVec[(iRow * iRow + iRow) / 2 + iCol]; // assuming iCol <= iRow
-}
+  inline double& VSymMatrix::operator()(unsigned int iRow, unsigned int iCol)
+  {
+    return theVec[(iRow * iRow + iRow) / 2 + iCol]; // assuming iCol <= iRow
+  }
 
 /// access element (i,j) assuming i>=j
-inline double VSymMatrix::operator()(unsigned int iRow,
-		unsigned int iCol) const {
-	return theVec[(iRow * iRow + iRow) / 2 + iCol]; // assuming iCol <= iRow
-}
+  inline double VSymMatrix::operator()(unsigned int iRow,
+                                       unsigned int iCol) const
+  {
+    return theVec[(iRow * iRow + iRow) / 2 + iCol]; // assuming iCol <= iRow
+  }
 }
 #endif /* VMATRIX_H_ */

--- a/GBL/src/BorderedBandMatrix.cc
+++ b/GBL/src/BorderedBandMatrix.cc
@@ -33,307 +33,315 @@
 namespace gbl {
 
 /// Create bordered band matrix.
-BorderedBandMatrix::BorderedBandMatrix() : numSize(0), numBorder(0), numBand(0), numCol(0) {
-}
+  BorderedBandMatrix::BorderedBandMatrix() : numSize(0), numBorder(0), numBand(0), numCol(0)
+  {
+  }
 
-BorderedBandMatrix::~BorderedBandMatrix() {
-}
+  BorderedBandMatrix::~BorderedBandMatrix()
+  {
+  }
 
 /// Resize bordered band matrix.
-/**
- * \param nSize [in] Size of matrix
- * \param nBorder [in] Size of border (=1 for q/p + additional local parameters)
- * \param nBand [in] Band width (usually = 5, for simplified jacobians = 4)
- */
-void BorderedBandMatrix::resize(unsigned int nSize, unsigned int nBorder,
-		unsigned int nBand) {
-	numSize = nSize;
-	numBorder = nBorder;
-	numCol = nSize - nBorder;
-	numBand = 0;
-	theBorder.resize(numBorder);
-	theMixed.resize(numBorder, numCol);
-	theBand.resize((nBand + 1), numCol);
-}
+  /**
+   * \param nSize [in] Size of matrix
+   * \param nBorder [in] Size of border (=1 for q/p + additional local parameters)
+   * \param nBand [in] Band width (usually = 5, for simplified jacobians = 4)
+   */
+  void BorderedBandMatrix::resize(unsigned int nSize, unsigned int nBorder,
+                                  unsigned int nBand)
+  {
+    numSize = nSize;
+    numBorder = nBorder;
+    numCol = nSize - nBorder;
+    numBand = 0;
+    theBorder.resize(numBorder);
+    theMixed.resize(numBorder, numCol);
+    theBand.resize((nBand + 1), numCol);
+  }
 
 /// Add symmetric block matrix.
-/**
- * Add (extended) block matrix defined by 'aVector * aWeight * aVector.T'
- * to bordered band matrix:
- * BBmatrix(anIndex(i),anIndex(j)) += aVector(i) * aWeight * aVector(j).
- * \param aWeight [in] Weight
- * \param anIndex [in] List of rows/colums to be used
- * \param aVector [in] Vector
- */
-void BorderedBandMatrix::addBlockMatrix(double aWeight,
-		const std::vector<unsigned int>* anIndex,
-		const std::vector<double>* aVector) {
-	int nBorder = numBorder;
-	for (unsigned int i = 0; i < anIndex->size(); ++i) {
-		int iIndex = (*anIndex)[i] - 1; // anIndex has to be sorted
-		for (unsigned int j = 0; j <= i; ++j) {
-			int jIndex = (*anIndex)[j] - 1;
-			if (iIndex < nBorder) {
-				theBorder(iIndex, jIndex) += (*aVector)[i] * aWeight
-						* (*aVector)[j];
-			} else if (jIndex < nBorder) {
-				theMixed(jIndex, iIndex - nBorder) += (*aVector)[i] * aWeight
-						* (*aVector)[j];
-			} else {
-				unsigned int nBand = iIndex - jIndex;
-				theBand(nBand, jIndex - nBorder) += (*aVector)[i] * aWeight
-						* (*aVector)[j];
-				numBand = std::max(numBand, nBand); // update band width
-			}
-		}
-	}
-}
+  /**
+   * Add (extended) block matrix defined by 'aVector * aWeight * aVector.T'
+   * to bordered band matrix:
+   * BBmatrix(anIndex(i),anIndex(j)) += aVector(i) * aWeight * aVector(j).
+   * \param aWeight [in] Weight
+   * \param anIndex [in] List of rows/colums to be used
+   * \param aVector [in] Vector
+   */
+  void BorderedBandMatrix::addBlockMatrix(double aWeight,
+                                          const std::vector<unsigned int>* anIndex,
+                                          const std::vector<double>* aVector)
+  {
+    int nBorder = numBorder;
+    for (unsigned int i = 0; i < anIndex->size(); ++i) {
+      int iIndex = (*anIndex)[i] - 1; // anIndex has to be sorted
+      for (unsigned int j = 0; j <= i; ++j) {
+        int jIndex = (*anIndex)[j] - 1;
+        if (iIndex < nBorder) {
+          theBorder(iIndex, jIndex) += (*aVector)[i] * aWeight
+                                       * (*aVector)[j];
+        } else if (jIndex < nBorder) {
+          theMixed(jIndex, iIndex - nBorder) += (*aVector)[i] * aWeight
+                                                * (*aVector)[j];
+        } else {
+          unsigned int nBand = iIndex - jIndex;
+          theBand(nBand, jIndex - nBorder) += (*aVector)[i] * aWeight
+                                              * (*aVector)[j];
+          numBand = std::max(numBand, nBand); // update band width
+        }
+      }
+    }
+  }
 
 /// Retrieve symmetric block matrix.
-/**
- * Get (compressed) block from bordered band matrix: aMatrix(i,j) = BBmatrix(anIndex(i),anIndex(j)).
- * \param anIndex [in] List of rows/colums to be used
- */
-TMatrixDSym BorderedBandMatrix::getBlockMatrix(
-		const std::vector<unsigned int> &anIndex) const {
+  /**
+   * Get (compressed) block from bordered band matrix: aMatrix(i,j) = BBmatrix(anIndex(i),anIndex(j)).
+   * \param anIndex [in] List of rows/colums to be used
+   */
+  TMatrixDSym BorderedBandMatrix::getBlockMatrix(
+    const std::vector<unsigned int>& anIndex) const
+  {
 
-	TMatrixDSym aMatrix(anIndex.size());
-	int nBorder = numBorder;
-	for (unsigned int i = 0; i < anIndex.size(); ++i) {
-		int iIndex = anIndex[i] - 1; // anIndex has to be sorted
-		for (unsigned int j = 0; j <= i; ++j) {
-			int jIndex = anIndex[j] - 1;
-			if (iIndex < nBorder) {
-				aMatrix(i, j) = theBorder(iIndex, jIndex); // border part of inverse
-			} else if (jIndex < nBorder) {
-				aMatrix(i, j) = -theMixed(jIndex, iIndex - nBorder); // mixed part of inverse
-			} else {
-				unsigned int nBand = iIndex - jIndex;
-				aMatrix(i, j) = theBand(nBand, jIndex - nBorder); // band part of inverse
-			}
-			aMatrix(j, i) = aMatrix(i, j);
-		}
-	}
-	return aMatrix;
-}
+    TMatrixDSym aMatrix(anIndex.size());
+    int nBorder = numBorder;
+    for (unsigned int i = 0; i < anIndex.size(); ++i) {
+      int iIndex = anIndex[i] - 1; // anIndex has to be sorted
+      for (unsigned int j = 0; j <= i; ++j) {
+        int jIndex = anIndex[j] - 1;
+        if (iIndex < nBorder) {
+          aMatrix(i, j) = theBorder(iIndex, jIndex); // border part of inverse
+        } else if (jIndex < nBorder) {
+          aMatrix(i, j) = -theMixed(jIndex, iIndex - nBorder); // mixed part of inverse
+        } else {
+          unsigned int nBand = iIndex - jIndex;
+          aMatrix(i, j) = theBand(nBand, jIndex - nBorder); // band part of inverse
+        }
+        aMatrix(j, i) = aMatrix(i, j);
+      }
+    }
+    return aMatrix;
+  }
 
 /// Solve linear equation system, partially calculate inverse.
-/**
- * Solve linear equation A*x=b system with bordered band matrix A,
- * calculate bordered band part of inverse of A. Use decomposition
- * in border and band part for block matrix algebra:
- *
- *     | A  Ct |   | x1 |   | b1 |        , A  is the border part
- *     |       | * |    | = |    |        , Ct is the mixed part
- *     | C  D  |   | x2 |   | b2 |        , D  is the band part
- *
- * Explicit inversion of D is avoided by using solution X of D*X=C (X=D^-1*C,
- * obtained from Cholesky decomposition and forward/backward substitution)
- *
- *     | x1 |   | E*b1 - E*Xt*b2 |        , E^-1 = A-Ct*D^-1*C = A-Ct*X
- *     |    | = |                |
- *     | x2 |   |  x   - X*x1    |        , x is solution of D*x=b2 (x=D^-1*b2)
- *
- * Inverse matrix is:
- *
- *     |  E   -E*Xt          |
- *     |                     |            , only band part of (D^-1 + X*E*Xt)
- *     | -X*E  D^-1 + X*E*Xt |              is calculated
- *
- *
- * \param [in] aRightHandSide Right hand side (vector) 'b' of A*x=b
- * \param [out] aSolution Solution (vector) x of A*x=b
- */
-void BorderedBandMatrix::solveAndInvertBorderedBand(
-		const VVector &aRightHandSide, VVector &aSolution) {
+  /**
+   * Solve linear equation A*x=b system with bordered band matrix A,
+   * calculate bordered band part of inverse of A. Use decomposition
+   * in border and band part for block matrix algebra:
+   *
+   *     | A  Ct |   | x1 |   | b1 |        , A  is the border part
+   *     |       | * |    | = |    |        , Ct is the mixed part
+   *     | C  D  |   | x2 |   | b2 |        , D  is the band part
+   *
+   * Explicit inversion of D is avoided by using solution X of D*X=C (X=D^-1*C,
+   * obtained from Cholesky decomposition and forward/backward substitution)
+   *
+   *     | x1 |   | E*b1 - E*Xt*b2 |        , E^-1 = A-Ct*D^-1*C = A-Ct*X
+   *     |    | = |                |
+   *     | x2 |   |  x   - X*x1    |        , x is solution of D*x=b2 (x=D^-1*b2)
+   *
+   * Inverse matrix is:
+   *
+   *     |  E   -E*Xt          |
+   *     |                     |            , only band part of (D^-1 + X*E*Xt)
+   *     | -X*E  D^-1 + X*E*Xt |              is calculated
+   *
+   *
+   * \param [in] aRightHandSide Right hand side (vector) 'b' of A*x=b
+   * \param [out] aSolution Solution (vector) x of A*x=b
+   */
+  void BorderedBandMatrix::solveAndInvertBorderedBand(
+    const VVector& aRightHandSide, VVector& aSolution)
+  {
 
-	// decompose band
-	decomposeBand();
-	// invert band
-	VMatrix inverseBand = invertBand();
-	if (numBorder > 0) { // need to use block matrix decomposition to solve
-		// solve for mixed part
-		const VMatrix auxMat = solveBand(theMixed); // = Xt
-		const VMatrix auxMatT = auxMat.transpose(); // = X
-		// solve for border part
-		const VVector auxVec = aRightHandSide.getVec(numBorder)
-				- auxMat * aRightHandSide.getVec(numCol, numBorder); // = b1 - Xt*b2
-		VSymMatrix inverseBorder = theBorder - theMixed * auxMatT;
-		inverseBorder.invert(); // = E
-		const VVector borderSolution = inverseBorder * auxVec; // = x1
-		// solve for band part
-		const VVector bandSolution = solveBand(
-				aRightHandSide.getVec(numCol, numBorder)); // = x
-		aSolution.putVec(borderSolution);
-		aSolution.putVec(bandSolution - auxMatT * borderSolution, numBorder); // = x2
-		// parts of inverse
-		theBorder = inverseBorder; // E
-		theMixed = inverseBorder * auxMat; // E*Xt (-mixed part of inverse) !!!
-		theBand = inverseBand + bandOfAVAT(auxMatT, inverseBorder); // band(D^-1 + X*E*Xt)
-	} else {
-		aSolution.putVec(solveBand(aRightHandSide));
-		theBand = inverseBand;
-	}
-}
+    // decompose band
+    decomposeBand();
+    // invert band
+    VMatrix inverseBand = invertBand();
+    if (numBorder > 0) { // need to use block matrix decomposition to solve
+      // solve for mixed part
+      const VMatrix auxMat = solveBand(theMixed); // = Xt
+      const VMatrix auxMatT = auxMat.transpose(); // = X
+      // solve for border part
+      const VVector auxVec = aRightHandSide.getVec(numBorder)
+                             - auxMat * aRightHandSide.getVec(numCol, numBorder); // = b1 - Xt*b2
+      VSymMatrix inverseBorder = theBorder - theMixed * auxMatT;
+      inverseBorder.invert(); // = E
+      const VVector borderSolution = inverseBorder * auxVec; // = x1
+      // solve for band part
+      const VVector bandSolution = solveBand(
+                                     aRightHandSide.getVec(numCol, numBorder)); // = x
+      aSolution.putVec(borderSolution);
+      aSolution.putVec(bandSolution - auxMatT * borderSolution, numBorder); // = x2
+      // parts of inverse
+      theBorder = inverseBorder; // E
+      theMixed = inverseBorder * auxMat; // E*Xt (-mixed part of inverse) !!!
+      theBand = inverseBand + bandOfAVAT(auxMatT, inverseBorder); // band(D^-1 + X*E*Xt)
+    } else {
+      aSolution.putVec(solveBand(aRightHandSide));
+      theBand = inverseBand;
+    }
+  }
 
 /// Print bordered band matrix.
-void BorderedBandMatrix::printMatrix() const {
-	std::cout << "Border part " << std::endl;
-	theBorder.print();
-	std::cout << "Mixed  part " << std::endl;
-	theMixed.print();
-	std::cout << "Band   part " << std::endl;
-	theBand.print();
-}
+  void BorderedBandMatrix::printMatrix() const
+  {
+    std::cout << "Border part " << std::endl;
+    theBorder.print();
+    std::cout << "Mixed  part " << std::endl;
+    theMixed.print();
+    std::cout << "Band   part " << std::endl;
+    theBand.print();
+  }
 
-/*============================================================================
- from Dbandmatrix.F (MillePede-II by V. Blobel, Univ. Hamburg)
- ============================================================================*/
+  /*============================================================================
+   from Dbandmatrix.F (MillePede-II by V. Blobel, Univ. Hamburg)
+   ============================================================================*/
 /// (root free) Cholesky decomposition of band part: C=LDL^T
-/**
- * Decompose band matrix into diagonal matrix D and lower triangular band matrix
- * L (diagonal=1). Overwrite band matrix with D and off-diagonal part of L.
- *  \exception 2 : matrix is singular.
- *  \exception 3 : matrix is not positive definite.
- */
-void BorderedBandMatrix::decomposeBand() {
+  /**
+   * Decompose band matrix into diagonal matrix D and lower triangular band matrix
+   * L (diagonal=1). Overwrite band matrix with D and off-diagonal part of L.
+   *  \exception 2 : matrix is singular.
+   *  \exception 3 : matrix is not positive definite.
+   */
+  void BorderedBandMatrix::decomposeBand()
+  {
 
-	int nRow = numBand + 1;
-	int nCol = numCol;
-	VVector auxVec(nCol);
-	for (int i = 0; i < nCol; ++i) {
-		auxVec(i) = theBand(0, i) * 16.0; // save diagonal elements
-	}
-	for (int i = 0; i < nCol; ++i) {
-		if ((theBand(0, i) + auxVec(i)) != theBand(0, i)) {
-			theBand(0, i) = 1.0 / theBand(0, i);
-			if (theBand(0, i) < 0.) {
-				throw 3; // not positive definite
-			}
-		} else {
-			theBand(0, i) = 0.0;
-			throw 2; // singular
-		}
-		for (int j = 1; j < std::min(nRow, nCol - i); ++j) {
-			double rxw = theBand(j, i) * theBand(0, i);
-			for (int k = 0; k < std::min(nRow, nCol - i) - j; ++k) {
-				theBand(k, i + j) -= theBand(k + j, i) * rxw;
-			}
-			theBand(j, i) = rxw;
-		}
-	}
-}
+    int nRow = numBand + 1;
+    int nCol = numCol;
+    VVector auxVec(nCol);
+    for (int i = 0; i < nCol; ++i) {
+      auxVec(i) = theBand(0, i) * 16.0; // save diagonal elements
+    }
+    for (int i = 0; i < nCol; ++i) {
+      if ((theBand(0, i) + auxVec(i)) != theBand(0, i)) {
+        theBand(0, i) = 1.0 / theBand(0, i);
+        if (theBand(0, i) < 0.) {
+          throw 3; // not positive definite
+        }
+      } else {
+        theBand(0, i) = 0.0;
+        throw 2; // singular
+      }
+      for (int j = 1; j < std::min(nRow, nCol - i); ++j) {
+        double rxw = theBand(j, i) * theBand(0, i);
+        for (int k = 0; k < std::min(nRow, nCol - i) - j; ++k) {
+          theBand(k, i + j) -= theBand(k + j, i) * rxw;
+        }
+        theBand(j, i) = rxw;
+      }
+    }
+  }
 
 /// Solve for band part.
-/**
- * Solve C*x=b for band part using decomposition C=LDL^T
- * and forward (L*z=b) and backward substitution (L^T*x=D^-1*z).
- * \param [in] aRightHandSide Right hand side (vector) 'b' of C*x=b
- * \return Solution (vector) 'x' of C*x=b
- */
-VVector BorderedBandMatrix::solveBand(const VVector &aRightHandSide) const {
+  /**
+   * Solve C*x=b for band part using decomposition C=LDL^T
+   * and forward (L*z=b) and backward substitution (L^T*x=D^-1*z).
+   * \param [in] aRightHandSide Right hand side (vector) 'b' of C*x=b
+   * \return Solution (vector) 'x' of C*x=b
+   */
+  VVector BorderedBandMatrix::solveBand(const VVector& aRightHandSide) const
+  {
 
-	int nRow = theBand.getNumRows();
-	int nCol = theBand.getNumCols();
-	VVector aSolution(aRightHandSide);
-	for (int i = 0; i < nCol; ++i) // forward substitution
-			{
-		for (int j = 1; j < std::min(nRow, nCol - i); ++j) {
-			aSolution(j + i) -= theBand(j, i) * aSolution(i);
-		}
-	}
-	for (int i = nCol - 1; i >= 0; i--) // backward substitution
-			{
-		double rxw = theBand(0, i) * aSolution(i);
-		for (int j = 1; j < std::min(nRow, nCol - i); ++j) {
-			rxw -= theBand(j, i) * aSolution(j + i);
-		}
-		aSolution(i) = rxw;
-	}
-	return aSolution;
-}
+    int nRow = theBand.getNumRows();
+    int nCol = theBand.getNumCols();
+    VVector aSolution(aRightHandSide);
+    for (int i = 0; i < nCol; ++i) { // forward substitution
+      for (int j = 1; j < std::min(nRow, nCol - i); ++j) {
+        aSolution(j + i) -= theBand(j, i) * aSolution(i);
+      }
+    }
+    for (int i = nCol - 1; i >= 0; i--) { // backward substitution
+      double rxw = theBand(0, i) * aSolution(i);
+      for (int j = 1; j < std::min(nRow, nCol - i); ++j) {
+        rxw -= theBand(j, i) * aSolution(j + i);
+      }
+      aSolution(i) = rxw;
+    }
+    return aSolution;
+  }
 
 /// solve band part for mixed part (border rows).
-/**
- * Solve C*X=B for mixed part using decomposition C=LDL^T
- * and forward and backward substitution.
- * \param [in] aRightHandSide Right hand side (matrix) 'B' of C*X=B
- * \return Solution (matrix) 'X' of C*X=B
- */
-VMatrix BorderedBandMatrix::solveBand(const VMatrix &aRightHandSide) const {
+  /**
+   * Solve C*X=B for mixed part using decomposition C=LDL^T
+   * and forward and backward substitution.
+   * \param [in] aRightHandSide Right hand side (matrix) 'B' of C*X=B
+   * \return Solution (matrix) 'X' of C*X=B
+   */
+  VMatrix BorderedBandMatrix::solveBand(const VMatrix& aRightHandSide) const
+  {
 
-	int nRow = theBand.getNumRows();
-	int nCol = theBand.getNumCols();
-	VMatrix aSolution(aRightHandSide);
-	for (unsigned int iBorder = 0; iBorder < numBorder; iBorder++) {
-		for (int i = 0; i < nCol; ++i) // forward substitution
-				{
-			for (int j = 1; j < std::min(nRow, nCol - i); ++j) {
-				aSolution(iBorder, j + i) -= theBand(j, i)
-						* aSolution(iBorder, i);
-			}
-		}
-		for (int i = nCol - 1; i >= 0; i--) // backward substitution
-				{
-			double rxw = theBand(0, i) * aSolution(iBorder, i);
-			for (int j = 1; j < std::min(nRow, nCol - i); ++j) {
-				rxw -= theBand(j, i) * aSolution(iBorder, j + i);
-			}
-			aSolution(iBorder, i) = rxw;
-		}
-	}
-	return aSolution;
-}
+    int nRow = theBand.getNumRows();
+    int nCol = theBand.getNumCols();
+    VMatrix aSolution(aRightHandSide);
+    for (unsigned int iBorder = 0; iBorder < numBorder; iBorder++) {
+      for (int i = 0; i < nCol; ++i) { // forward substitution
+        for (int j = 1; j < std::min(nRow, nCol - i); ++j) {
+          aSolution(iBorder, j + i) -= theBand(j, i)
+                                       * aSolution(iBorder, i);
+        }
+      }
+      for (int i = nCol - 1; i >= 0; i--) { // backward substitution
+        double rxw = theBand(0, i) * aSolution(iBorder, i);
+        for (int j = 1; j < std::min(nRow, nCol - i); ++j) {
+          rxw -= theBand(j, i) * aSolution(iBorder, j + i);
+        }
+        aSolution(iBorder, i) = rxw;
+      }
+    }
+    return aSolution;
+  }
 
 /// Invert band part.
-/**
- * \return Inverted band
- */
-VMatrix BorderedBandMatrix::invertBand() {
+  /**
+   * \return Inverted band
+   */
+  VMatrix BorderedBandMatrix::invertBand()
+  {
 
-	int nRow = numBand + 1;
-	int nCol = numCol;
-	VMatrix inverseBand(nRow, nCol);
+    int nRow = numBand + 1;
+    int nCol = numCol;
+    VMatrix inverseBand(nRow, nCol);
 
-	for (int i = nCol - 1; i >= 0; i--) {
-		double rxw = theBand(0, i);
-		for (int j = i; j >= std::max(0, i - nRow + 1); j--) {
-			for (int k = j + 1; k < std::min(nCol, j + nRow); ++k) {
-				rxw -= inverseBand(abs(i - k), std::min(i, k))
-						* theBand(k - j, j);
-			}
-			inverseBand(i - j, j) = rxw;
-			rxw = 0.;
-		}
-	}
-	return inverseBand;
-}
+    for (int i = nCol - 1; i >= 0; i--) {
+      double rxw = theBand(0, i);
+      for (int j = i; j >= std::max(0, i - nRow + 1); j--) {
+        for (int k = j + 1; k < std::min(nCol, j + nRow); ++k) {
+          rxw -= inverseBand(abs(i - k), std::min(i, k))
+                 * theBand(k - j, j);
+        }
+        inverseBand(i - j, j) = rxw;
+        rxw = 0.;
+      }
+    }
+    return inverseBand;
+  }
 
 /// Calculate band part of: 'anArray * aSymArray * anArray.T'.
-/**
- * \return Band part of product
- */
-VMatrix BorderedBandMatrix::bandOfAVAT(const VMatrix &anArray,
-		const VSymMatrix &aSymArray) const {
-	int nBand = numBand;
-	int nCol = numCol;
-	int nBorder = numBorder;
-	double sum;
-	VMatrix aBand((nBand + 1), nCol);
-	for (int i = 0; i < nCol; ++i) {
-		for (int j = std::max(0, i - nBand); j <= i; ++j) {
-			sum = 0.;
-			for (int l = 0; l < nBorder; ++l) { // diagonal
-				sum += anArray(i, l) * aSymArray(l, l) * anArray(j, l);
-				for (int k = 0; k < l; ++k) { // off diagonal
-					sum += anArray(i, l) * aSymArray(l, k) * anArray(j, k)
-							+ anArray(i, k) * aSymArray(l, k) * anArray(j, l);
-				}
-			}
-			aBand(i - j, j) = sum;
-		}
-	}
-	return aBand;
-}
+  /**
+   * \return Band part of product
+   */
+  VMatrix BorderedBandMatrix::bandOfAVAT(const VMatrix& anArray,
+                                         const VSymMatrix& aSymArray) const
+  {
+    int nBand = numBand;
+    int nCol = numCol;
+    int nBorder = numBorder;
+    double sum;
+    VMatrix aBand((nBand + 1), nCol);
+    for (int i = 0; i < nCol; ++i) {
+      for (int j = std::max(0, i - nBand); j <= i; ++j) {
+        sum = 0.;
+        for (int l = 0; l < nBorder; ++l) { // diagonal
+          sum += anArray(i, l) * aSymArray(l, l) * anArray(j, l);
+          for (int k = 0; k < l; ++k) { // off diagonal
+            sum += anArray(i, l) * aSymArray(l, k) * anArray(j, k)
+                   + anArray(i, k) * aSymArray(l, k) * anArray(j, l);
+          }
+        }
+        aBand(i - j, j) = sum;
+      }
+    }
+    return aBand;
+  }
 
 }

--- a/GBL/src/GFGbl.cc
+++ b/GBL/src/GFGbl.cc
@@ -117,10 +117,11 @@ TH1I* stats;
 
 
 
-bool writeHistoDataForLabel(double label, TVectorD res, TVectorD measErr, TVectorD resErr, TVectorD downWeights, TVectorD localPar, TMatrixDSym localCov)
+bool writeHistoDataForLabel(double label, TVectorD res, TVectorD measErr, TVectorD resErr, TVectorD downWeights, TVectorD localPar,
+                            TMatrixDSym localCov)
 {
   if (label < 1.) return false;
-  
+
   unsigned int id = floor(label);
   // skip segment (5 bits)
   id = id >> 5;
@@ -136,12 +137,12 @@ bool writeHistoDataForLabel(double label, TVectorD res, TVectorD measErr, TVecto
   } else {
     label = layer + 3;
   }
-  
+
   if (label > 12.) return false;
-  
+
   int i = int(label);
-  
-  #ifdef OUTPUT
+
+#ifdef OUTPUT
   resHistosU[i - 1]->Fill(res[0]);
   resHistosV[i - 1]->Fill(res[1]);
   mhistosU[i - 1]->Fill(res[0] / measErr[0]);
@@ -155,9 +156,9 @@ bool writeHistoDataForLabel(double label, TVectorD res, TVectorD measErr, TVecto
   localPar3[i - 1]->Fill(localPar(2));
   localPar4[i - 1]->Fill(localPar(3));
   localPar5[i - 1]->Fill(localPar(4));
-  #endif
-  
-  
+#endif
+
+
   return true;
 }
 #endif
@@ -173,22 +174,22 @@ using namespace std;
 using namespace genfit;
 
 GFGbl::GFGbl() :
-AbsFitter(), m_milleFileName("millefile.dat"), m_gblInternalIterations("THC"), m_pValueCut(0.), m_minNdf(1),
-m_chi2Cut(0.),
-m_enableScatterers(true),
-m_enableIntermediateScatterer(true)
+  AbsFitter(), m_milleFileName("millefile.dat"), m_gblInternalIterations("THC"), m_pValueCut(0.), m_minNdf(1),
+  m_chi2Cut(0.),
+  m_enableScatterers(true),
+  m_enableIntermediateScatterer(true)
 {
-  
+
 }
 
 void GFGbl::beginRun()
 {
   milleFile = new MilleBinary(m_milleFileName);
-  
-  #ifdef OUTPUT
+
+#ifdef OUTPUT
   diag = new TFile(rootFileName.c_str(), "RECREATE");
   char name[20];
-  
+
   for (int i = 0; i < 12; i++) {
     sprintf(name, "res_u_%i", i + 1);
     resHistosU[i] = new TH1F(name, "Residual (U)", 1000, -0.1, 0.1);
@@ -207,7 +208,7 @@ void GFGbl::beginRun()
     sprintf(name, "downWeights_v_%i", i + 1);
     downWeightsHistosV[i] = new TH1F(name, "Down-weights (V)", 1000, 0., 1.);
     sprintf(name, "localPar1_%i", i + 1);
-    
+
     localPar1[i] = new TH1F(name, "Residual (U)", 1000, -0.1, 0.1);
     sprintf(name, "localPar2_%i", i + 1);
     localPar2[i] = new TH1F(name, "Residual (U)", 1000, -0.1, 0.1);
@@ -222,19 +223,19 @@ void GFGbl::beginRun()
   ndfHisto = new TH1I("ndf", "GBL Track NDF", 41, -1, 40);
   chi2OndfHisto = new TH1F("chi2_ndf", "Track Chi2/NDF", 100, 0., 10.);
   pValueHisto = new TH1F("p_value", "Track P-value", 100, 0., 1.);
-  
+
   stats = new TH1I("stats", "0: NDF>0 | 1: fTel&VXD | 2: all | 3: VXD | 4: SVD | 5: all - PXD | 6: fTel&SVD | 7: bTel", 10, 0, 10);
-  
-  #endif
+
+#endif
 }
 
 void GFGbl::endRun()
 {
-  #ifdef OUTPUT
+#ifdef OUTPUT
   diag->cd();
   diag->Write();
   diag->Close();
-  #endif
+#endif
   // This is needed to close the file before alignment starts
   if (milleFile)
     delete milleFile;
@@ -260,11 +261,12 @@ void GFGbl::endRun()
  * @param steps Vector of material steps from (RKTrackRep) extrapolation
  * @return void
  */
-void getScattererFromMatList(double& length, double& theta, double& s, double& ds, const double p, const double mass, const double charge, const std::vector<MatStep>& steps)
+void getScattererFromMatList(double& length, double& theta, double& s, double& ds, const double p, const double mass,
+                             const double charge, const std::vector<MatStep>& steps)
 {
   theta = 0.; s = 0.; ds = 0.;
   if (steps.empty()) return;
-  
+
   // sum of step lengths
   double len = 0.;
   // normalization
@@ -273,11 +275,11 @@ void getScattererFromMatList(double& length, double& theta, double& s, double& d
   double sumx2x2 = 0.;
   // (part of) second moment / variance (non-normalized)
   double sumx3x3 = 0.;
-  
+
   // cppcheck-suppress unreadVariable
   double xmin = 0.;
   double xmax = 0.;
-  
+
   for (unsigned int i = 0; i < steps.size(); i++) {
     const MatStep step = steps.at(i);
     // inverse of material radiation length ... (in 1/cm) ... "density of scattering"
@@ -286,7 +288,7 @@ void getScattererFromMatList(double& length, double& theta, double& s, double& d
     xmin = xmax;
     xmax = xmin + fabs(step.stepSize_);
     // Compute integrals
-    
+
     // integral of rho(x)
     sumxx   += rho * (xmax - xmin);
     // integral of x*rho(x)
@@ -302,7 +304,7 @@ void getScattererFromMatList(double& length, double& theta, double& s, double& d
   double beta = p / sqrt(p * p + mass * mass);
   theta = (0.0136 / p / beta) * fabs(charge) * sqrt(sumxx) * (1. + 0.038 * log(sumxx));
   //theta = (0.015 / p / beta) * fabs(charge) * sqrt(sumxx);
-  
+
   // track length
   length = len;
   // Normalization factor
@@ -313,14 +315,14 @@ void getScattererFromMatList(double& length, double& theta, double& s, double& d
   // integral of (x - s)*(x - s)*rho(x)
   double ds_2 = N * (sumx3x3 - 2. * sumx2x2 * s + sumxx * s * s);
   ds = sqrt(ds_2);
-  
-  #ifdef DEBUG
+
+#ifdef DEBUG
   //cout << "Thick scatterer parameters:" << endl;
   //cout << "Variance of theta: " << theta << endl;
   //cout << "Mean s           : " << s << endl;
   //cout << "Variance of s    : " << ds << endl;
-  
-  #endif
+
+#endif
 }
 
 
@@ -338,37 +340,37 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
   double Bfield = genfit::FieldManager::getInstance()->getFieldVal(TVector3(0., 0., 0.)).Mag();
   if (!(Bfield > 0.))
     fitQoverP = false;
-  
+
   // Dimesion of repository/state
   int dim = rep->getDim();
   // current measurement point
   TrackPoint* point_meas;
   // current raw measurement
   AbsMeasurement* raw_meas;
-  
+
   // We assume no initial kinks, this will be reused several times
   TVectorD scatResidual(2);
   scatResidual.Zero();
-  
+
   // All measurement points in ref. track
   int npoints_meas = trk->getNumPointsWithMeasurement();
-  
-  #ifdef DEBUG
+
+#ifdef DEBUG
   int npoints_all = trk->getNumPoints();
-  
+
   if (resortHits)
     cout << "WARNING: Hits resorting in GBL interface not supported." << endl;
-  
+
   cout << "-------------------------------------------------------" << endl;
   cout << "               GBL processing genfit::Track            " << endl;
   cout << "-------------------------------------------------------" << endl;
   cout << " # Ref. Track Points  :  " << npoints_all  << endl;
   cout << " # Meas. Points       :  " << npoints_meas << endl;
-  
-  #endif
+
+#endif
   // List of prepared GBL points for GBL trajectory construction
   std::vector<GblPoint> listOfPoints;
-  
+
   std::vector<double> listOfLayers;
   //TODO: Add internal/external seed (from CDC) option in the future
   // index of point with seed information (0 for none)
@@ -377,25 +379,25 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
   // TMatrixDSym clCov(dim);
   // Seed state
   TMatrixDSym clSeed(dim);
-  
+
   // propagation Jacobian to next point from current measurement point
   TMatrixD jacPointToPoint(dim, dim);
   jacPointToPoint.UnitMatrix();
-  
+
   int n_gbl_points = 0;
   int n_gbl_meas_points = 0;
   int Ndf = 0;
   double Chi2 = 0.;
   double lostWeight = 0.;
-  
+
   // Momentum of track at current plane
   double trackMomMag = 0.;
   // Charge of particle at current plane :-)
   double particleCharge = 1.;
-  
+
   for (int ipoint_meas = 0; ipoint_meas < npoints_meas; ipoint_meas++) {
     point_meas = trk->getPointWithMeasurement(ipoint_meas);
-    
+
     if (!point_meas->hasFitterInfo(rep)) {
       cout << " ERROR: Measurement point does not have a fitter info. Track will be skipped." << endl;
       return;
@@ -413,7 +415,8 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
       return;
     }
     // Reference StateOnPlane for extrapolation
-    ReferenceStateOnPlane* reference = new ReferenceStateOnPlane(*fi->getReferenceState());//(dynamic_cast<const genfit::ReferenceStateOnPlane&>(*fi->getReferenceState()));
+    ReferenceStateOnPlane* reference = new ReferenceStateOnPlane(
+      *fi->getReferenceState());//(dynamic_cast<const genfit::ReferenceStateOnPlane&>(*fi->getReferenceState()));
     // Representation state at plane
     TVectorD state = reference->getState();
     // track direction at plane (in global coords)
@@ -424,7 +427,7 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
     particleCharge = rep->getCharge(*reference);
     // mass of particle
     double particleMass = rep->getMass(*reference);
-    
+
     // Parameters of a thick scatterer between measurements
     double trackLen = 0.;
     double scatTheta = 0.;
@@ -435,14 +438,14 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
     double theta2 = 0.;
     double s1 = 0.;
     double s2 = 0.;
-    
+
     TMatrixDSym noise;
     TVectorD deltaState;
     // jacobian from s2 to M2
     TMatrixD jacMeas2Scat(dim, dim);
     jacMeas2Scat.UnitMatrix();
-    
-    
+
+
     // Now get measurement. First have a look if we need to combine SVD clusters...
     // Load Jacobian from previous extrapolation
     // rep->getForwardJacobianAndNoise(jacPointToPoint, noise, deltaState);
@@ -450,48 +453,48 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
     int sensorId = 0;
     PlanarMeasurement* measPlanar = dynamic_cast<PlanarMeasurement*>(point_meas->getRawMeasurement(0));
     if (measPlanar) sensorId = measPlanar->getPlaneId();
-    
+
     //WARNING: Now we only support 2D measurements. If 2 raw measurements are stored at the track
     // point, these are checked if they correspond to "u" and "v" measurement (for SVD clusters) and these
     // measurements are combined. SLANTED SENSORS NOT YET SUPPORTED!!!
     if (point_meas->getRawMeasurement(0)->getDim() != 2
-      && trk->getPointWithMeasurement(ipoint_meas)->getNumRawMeasurements() == 2
-      && point_meas->getRawMeasurement(0)->getDim() == 1
-      && point_meas->getRawMeasurement(1)->getDim() == 1) {
+        && trk->getPointWithMeasurement(ipoint_meas)->getNumRawMeasurements() == 2
+        && point_meas->getRawMeasurement(0)->getDim() == 1
+        && point_meas->getRawMeasurement(1)->getDim() == 1) {
       AbsMeasurement* raw_measU = 0;
       AbsMeasurement* raw_measV = 0;
-    
+
       // cout << " Two 1D Measurements encountered. " << endl;
-    
+
       int sensorId2 = -1;
       PlanarMeasurement* measPlanar2 = dynamic_cast<PlanarMeasurement*>(point_meas->getRawMeasurement(0));
       if (measPlanar2) sensorId2 = measPlanar->getPlaneId();
-    
+
       // We only try to combine if at same sensor id (should be always, but who knows)
       // otherwise ignore this point
       if (sensorId != sensorId2) {
-	skipMeasurement = true;
-	cout << " ERROR: Incompatible sensorIDs at measurement point " << ipoint_meas << ". Measurement will be skipped." << endl;
+        skipMeasurement = true;
+        cout << " ERROR: Incompatible sensorIDs at measurement point " << ipoint_meas << ". Measurement will be skipped." << endl;
       }
-    
+
       // We have to combine two SVD 1D Clusters at the same plane into one 2D recohit
       AbsMeasurement* raw_meas1 = point_meas->getRawMeasurement(0);
       AbsMeasurement* raw_meas2 = point_meas->getRawMeasurement(1);
       // Decide which cluster is u and which v based on H-matrix
       if (raw_meas1->constructHMatrix(rep)->isEqual(genfit::HMatrixU())
-	  && raw_meas2->constructHMatrix(rep)->isEqual(genfit::HMatrixV())) {
-	// right order U, V
-	raw_measU = raw_meas1;
-	raw_measV = raw_meas2;
+          && raw_meas2->constructHMatrix(rep)->isEqual(genfit::HMatrixV())) {
+        // right order U, V
+        raw_measU = raw_meas1;
+        raw_measV = raw_meas2;
       } else if (raw_meas2->constructHMatrix(rep)->isEqual(genfit::HMatrixU())
-		 && raw_meas1->constructHMatrix(rep)->isEqual(genfit::HMatrixV())) {
+                 && raw_meas1->constructHMatrix(rep)->isEqual(genfit::HMatrixV())) {
         // inversed order V, U
         raw_measU = raw_meas2;
-	raw_measV = raw_meas1;
+        raw_measV = raw_meas1;
       } else {
-	// Incompatible measurements ... skip track ... I saw this once and just before a segfault ...
-	cout << " ERROR: Incompatible 1D measurements at meas. point " << ipoint_meas << ". Track will be skipped." << endl;
-	return;
+        // Incompatible measurements ... skip track ... I saw this once and just before a segfault ...
+        cout << " ERROR: Incompatible 1D measurements at meas. point " << ipoint_meas << ". Track will be skipped." << endl;
+        return;
       }
       // Combine raw measurements
       TVectorD _raw_coor(2);
@@ -511,11 +514,11 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
     //TODO: We only support 2D measurements in GBL (ot two 1D combined above)
     if (raw_meas->getRawHitCoords().GetNoElements() != 2) {
       skipMeasurement = true;
-      #ifdef DEBUG
+#ifdef DEBUG
       cout << " WARNING: Measurement " << (ipoint_meas + 1) << " is not 2D. Measurement Will be skipped. " << endl;
-      #endif
+#endif
     }
-      
+
     // Now we have all necessary information, so lets insert current measurement point
     // if we don't want to skip it (e.g. ghost SVD hit ... just 1D information)
     if (!skipMeasurement) {
@@ -529,7 +532,7 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
       TVectorD residual = -1. * (raw_coor - HitHMatrix->Hv(state));
 
       trkChi2 += residual(0) * residual(0) / raw_cov(0, 0) + residual(1) * residual(1) / raw_cov(1, 1);
-        
+
       // Measurement point
       GblPoint measPoint(jacPointToPoint);
       // Projection from local (state) coordinates to measurement coordinates (inverted)
@@ -545,18 +548,18 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
       //raw_cov *= 100.;
       //proL2m.Print();
       measPoint.addMeasurement(proL2m, residual, raw_cov.Invert());
-        
+
       //Add global derivatives to the point
-        
+
       // sensor label = sensorID * 10, then last digit is label for global derivative for the sensor
       int label = sensorId * 10;
       // values for global derivatives
       //TMatrixD derGlobal(2, 6);
       TMatrixD derGlobal(2, 12);
-        
+
       // labels for global derivatives
       std::vector<int> labGlobal;
-        
+
       // track direction in global coords
       TVector3 tDir = trackDir;
       // sensor u direction in global coords
@@ -571,17 +574,17 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
       //outputVector(nDir, "Normal");
       // track direction in local sensor system
       TVector3 tLoc = TVector3(uDir.Dot(tDir), vDir.Dot(tDir), nDir.Dot(tDir));
-        
+
       // track u-slope in local sensor system
       double uSlope = tLoc[0] / tLoc[2];
       // track v-slope in local sensor system
       double vSlope = tLoc[1] / tLoc[2];
-        
+
       // Measured track u-position in local sensor system
       double uPos = raw_coor[0];
       // Measured track v-position in local sensor system
       double vPos = raw_coor[1];
-        
+
       //Global derivatives for alignment in sensor local coordinates
       derGlobal(0, 0) = 1.0;
       derGlobal(0, 1) = 0.0;
@@ -589,7 +592,7 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
       derGlobal(0, 3) = vPos * uSlope;
       derGlobal(0, 4) = -uPos * uSlope;
       derGlobal(0, 5) = vPos;
-        
+
       derGlobal(1, 0) = 0.0;
       derGlobal(1, 1) = 1.0;
       derGlobal(1, 2) = - vSlope;
@@ -606,7 +609,7 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
 
       // Global derivatives for movement of whole detector system in global coordinates
       //TODO: Usage of this requires Hierarchy Constraints to be provided to MP2
-  
+
       // sensor centre position in global system
       TVector3 detPos = plane->getO();
       //cout << "detPos" << endl;
@@ -630,8 +633,8 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
       TMatrixD drdm(3, 3);
       drdm.UnitMatrix();
       for (int row = 0; row < 3; row++)
-	for (int col = 0; col < 3; col++)
-	  drdm(row, col) -= tDir[row] * nDir[col] / tn;
+        for (int col = 0; col < 3; col++)
+          drdm(row, col) -= tDir[row] * nDir[col] / tn;
 
       //cout << "drdm" << endl;
       //drdm.Print();
@@ -699,9 +702,9 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
       listOfLayers.push_back((unsigned int) sensorId);
       n_gbl_points++;
       skipMeasurement = false;
-      #ifdef DEBUG
+#ifdef DEBUG
       cout << " Dummy point inserted. " << endl;
-      #endif
+#endif
     }
 
 
@@ -710,46 +713,47 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
 
       // Extrapolate to next measurement to get material distribution
       if (ipoint_meas < npoints_meas - 1) {
-	// Check if fitter info is in place
-	if (!trk->getPoint(ipoint_meas + 1)->hasFitterInfo(rep)) {
-	  cout << " ERROR: Measurement point does not have a fitter info. Track will be skipped." << endl;
-	  return;
-	}
-	// Fitter of next point info which is only used now to get the plane
-	KalmanFitterInfo* fi_i_plus_1 = dynamic_cast<KalmanFitterInfo*>(trk->getPoint(ipoint_meas + 1)->getFitterInfo(rep));
-	if (!fi_i_plus_1) {
-	  cout << " ERROR: KalmanFitterInfo (with reference state) for measurement does not exist. Track will be skipped." << endl;
-	  return;
-	}
-	StateOnPlane refCopy(*reference);
-	// Extrap to point + 1, do NOT stop at boundary
-	rep->extrapolateToPlane(refCopy, trk->getPoint(ipoint_meas + 1)->getFitterInfo(rep)->getPlane(), false, false);
-	getScattererFromMatList(trackLen,
-				scatTheta,
-				scatSMean,
-				scatDeltaS,
-				trackMomMag,
-				particleMass,
-				particleCharge,
-				rep->getSteps());
-	// Now calculate positions and scattering variance for equivalent scatterers
-	// (Solution from Claus Kleinwort (DESY))
-	s1 = 0.;
-	s2 = scatSMean + scatDeltaS * scatDeltaS / (scatSMean - s1);
-	theta1 = sqrt(scatTheta * scatTheta * scatDeltaS * scatDeltaS / (scatDeltaS * scatDeltaS + (scatSMean - s1) * (scatSMean - s1)));
-	theta2 = sqrt(scatTheta * scatTheta * (scatSMean - s1) * (scatSMean - s1) / (scatDeltaS * scatDeltaS + (scatSMean - s1) * (scatSMean - s1)));
+        // Check if fitter info is in place
+        if (!trk->getPoint(ipoint_meas + 1)->hasFitterInfo(rep)) {
+          cout << " ERROR: Measurement point does not have a fitter info. Track will be skipped." << endl;
+          return;
+        }
+        // Fitter of next point info which is only used now to get the plane
+        KalmanFitterInfo* fi_i_plus_1 = dynamic_cast<KalmanFitterInfo*>(trk->getPoint(ipoint_meas + 1)->getFitterInfo(rep));
+        if (!fi_i_plus_1) {
+          cout << " ERROR: KalmanFitterInfo (with reference state) for measurement does not exist. Track will be skipped." << endl;
+          return;
+        }
+        StateOnPlane refCopy(*reference);
+        // Extrap to point + 1, do NOT stop at boundary
+        rep->extrapolateToPlane(refCopy, trk->getPoint(ipoint_meas + 1)->getFitterInfo(rep)->getPlane(), false, false);
+        getScattererFromMatList(trackLen,
+                                scatTheta,
+                                scatSMean,
+                                scatDeltaS,
+                                trackMomMag,
+                                particleMass,
+                                particleCharge,
+                                rep->getSteps());
+        // Now calculate positions and scattering variance for equivalent scatterers
+        // (Solution from Claus Kleinwort (DESY))
+        s1 = 0.;
+        s2 = scatSMean + scatDeltaS * scatDeltaS / (scatSMean - s1);
+        theta1 = sqrt(scatTheta * scatTheta * scatDeltaS * scatDeltaS / (scatDeltaS * scatDeltaS + (scatSMean - s1) * (scatSMean - s1)));
+        theta2 = sqrt(scatTheta * scatTheta * (scatSMean - s1) * (scatSMean - s1) / (scatDeltaS * scatDeltaS + (scatSMean - s1) *
+                      (scatSMean - s1)));
 
-	if (m_enableScatterers && !m_enableIntermediateScatterer) {
-	  theta1 = scatTheta;
-	  theta2 = 0;
-	} else if (!m_enableScatterers) {
-	  theta1 = 0.;
-	  theta2 = 0.;
-	}
+        if (m_enableScatterers && !m_enableIntermediateScatterer) {
+          theta1 = scatTheta;
+          theta2 = 0;
+        } else if (!m_enableScatterers) {
+          theta1 = 0.;
+          theta2 = 0.;
+        }
 
-	if (s2 < 1.e-4 || s2 >= trackLen - 1.e-4 || s2 <= 1.e-4) {
-	  cout << " WARNING: GBL points will be too close. GBLTrajectory construction might fail. Let's try it..." << endl;
-	}
+        if (s2 < 1.e-4 || s2 >= trackLen - 1.e-4 || s2 <= 1.e-4) {
+          cout << " WARNING: GBL points will be too close. GBLTrajectory construction might fail. Let's try it..." << endl;
+        }
 
       }
       // Return back to state on current plane
@@ -758,29 +762,30 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
 
       // If not last measurement, extrapolate and get jacobians for scattering points between this and next measurement
       if (ipoint_meas < npoints_meas - 1) {
-	if (theta2 > scatEpsilon) {
-	  // First scatterer will be placed at current measurement point (see bellow)
+        if (theta2 > scatEpsilon) {
+          // First scatterer will be placed at current measurement point (see bellow)
 
-	  // theta2 > 0 ... we want second scatterer:
-	  // Extrapolate to s2 (remember we have s1 = 0)
-	  rep->extrapolateBy(*reference, s2, false, true);
-	  rep->getForwardJacobianAndNoise(jacMeas2Scat, noise, deltaState);
-	  // Finish extrapolation to next measurement
-	  double nextStep = rep->extrapolateToPlane(*reference, trk->getPoint(ipoint_meas + 1)->getFitterInfo(rep)->getPlane(), false, true);
-	  if (0. > nextStep) {
-	    cout << " ERROR: The extrapolation to measurement point " << (ipoint_meas + 2) << " stepped back by " << nextStep << "cm !!! Track will be skipped." << endl;
-	    return;
-	  }
-	  rep->getForwardJacobianAndNoise(jacPointToPoint, noise, deltaState);
+          // theta2 > 0 ... we want second scatterer:
+          // Extrapolate to s2 (remember we have s1 = 0)
+          rep->extrapolateBy(*reference, s2, false, true);
+          rep->getForwardJacobianAndNoise(jacMeas2Scat, noise, deltaState);
+          // Finish extrapolation to next measurement
+          double nextStep = rep->extrapolateToPlane(*reference, trk->getPoint(ipoint_meas + 1)->getFitterInfo(rep)->getPlane(), false, true);
+          if (0. > nextStep) {
+            cout << " ERROR: The extrapolation to measurement point " << (ipoint_meas + 2) << " stepped back by " << nextStep <<
+                 "cm !!! Track will be skipped." << endl;
+            return;
+          }
+          rep->getForwardJacobianAndNoise(jacPointToPoint, noise, deltaState);
 
-	} else {
-	  // No scattering: extrapolate whole distance between measurements
-	  rep->extrapolateToPlane(*reference, trk->getPoint(ipoint_meas + 1)->getFitterInfo(rep)->getPlane(), false, true);
-	  //NOTE: we will load the jacobian from this extrapolation in next loop into measurement point
-	  //jacPointToPoint.Print();
-	  rep->getForwardJacobianAndNoise(jacPointToPoint, noise, deltaState);
-	  //jacPointToPoint.Print();
-	}
+        } else {
+          // No scattering: extrapolate whole distance between measurements
+          rep->extrapolateToPlane(*reference, trk->getPoint(ipoint_meas + 1)->getFitterInfo(rep)->getPlane(), false, true);
+          //NOTE: we will load the jacobian from this extrapolation in next loop into measurement point
+          //jacPointToPoint.Print();
+          rep->getForwardJacobianAndNoise(jacPointToPoint, noise, deltaState);
+          //jacPointToPoint.Print();
+        }
       }
     } catch (...) {
       cout << " ERROR: Extrapolation failed. Track will be skipped." << endl;
@@ -795,39 +800,39 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
     if (ipoint_meas < npoints_meas - 1) {
 
       if (theta1 > scatEpsilon) {
-	// We have to insert first scatterer at measurement point
-	// Therefore (because state is perpendicular to plane, NOT track)
-	// we have non-diaonal matrix of multiple scattering covariance
-	// We have to project scattering into plane coordinates
-	double c1 = trackDir.Dot(plane->getU());
-	double c2 = trackDir.Dot(plane->getV());
-	TMatrixDSym scatCov(2);
-	scatCov(0, 0) = 1. - c2 * c2;
-	scatCov(1, 1) = 1. - c1 * c1;
-	scatCov(0, 1) = c1 * c2;
-	scatCov(1, 0) = c1 * c2;
-	scatCov *= theta1 * theta1 / (1. - c1 * c1 - c2 * c2) / (1. - c1 * c1 - c2 * c2) ;
+        // We have to insert first scatterer at measurement point
+        // Therefore (because state is perpendicular to plane, NOT track)
+        // we have non-diaonal matrix of multiple scattering covariance
+        // We have to project scattering into plane coordinates
+        double c1 = trackDir.Dot(plane->getU());
+        double c2 = trackDir.Dot(plane->getV());
+        TMatrixDSym scatCov(2);
+        scatCov(0, 0) = 1. - c2 * c2;
+        scatCov(1, 1) = 1. - c1 * c1;
+        scatCov(0, 1) = c1 * c2;
+        scatCov(1, 0) = c1 * c2;
+        scatCov *= theta1 * theta1 / (1. - c1 * c1 - c2 * c2) / (1. - c1 * c1 - c2 * c2) ;
 
-	// last point is the just inserted measurement (or dummy point)
-	GblPoint& lastPoint = listOfPoints.at(n_gbl_points - 1);
-	lastPoint.addScatterer(scatResidual, scatCov.Invert());
+        // last point is the just inserted measurement (or dummy point)
+        GblPoint& lastPoint = listOfPoints.at(n_gbl_points - 1);
+        lastPoint.addScatterer(scatResidual, scatCov.Invert());
 
       }
 
       if (theta2 > scatEpsilon) {
-	// second scatterer is somewhere between measurements
-	// TrackRep state is perpendicular to track direction if using extrapolateBy (I asked Johannes Rauch),
-	// therefore scattering covariance is diagonal (and both elements are equal)
-	TMatrixDSym scatCov(2);
-	scatCov.Zero();
-	scatCov(0, 0) = theta2 * theta2;
-	scatCov(1, 1) = theta2 * theta2;
+        // second scatterer is somewhere between measurements
+        // TrackRep state is perpendicular to track direction if using extrapolateBy (I asked Johannes Rauch),
+        // therefore scattering covariance is diagonal (and both elements are equal)
+        TMatrixDSym scatCov(2);
+        scatCov.Zero();
+        scatCov(0, 0) = theta2 * theta2;
+        scatCov(1, 1) = theta2 * theta2;
 
-	GblPoint scatPoint(jacMeas2Scat);
-	scatPoint.addScatterer(scatResidual, scatCov.Invert());
-	listOfPoints.push_back(scatPoint);
-	listOfLayers.push_back(((unsigned int) sensorId) + 0.5);
-	n_gbl_points++;
+        GblPoint scatPoint(jacMeas2Scat);
+        scatPoint.addScatterer(scatResidual, scatCov.Invert());
+        listOfPoints.push_back(scatPoint);
+        listOfLayers.push_back(((unsigned int) sensorId) + 0.5);
+        n_gbl_points++;
       }
 
 
@@ -856,20 +861,20 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
       // Gbl failed critically (usually GblPoint::getDerivatives ... singular matrix inversion)
       return;
     }
-    
+
     pvalue = TMath::Prob(Chi2, Ndf);
-    
+
     //traj->printTrajectory(100);
     //traj->printData();
     //traj->printPoints(100);
-    
-    #ifdef OUTPUT
+
+#ifdef OUTPUT
     // Fill histogram with fit result
     fitResHisto->Fill(fitRes);
     ndfHisto->Fill(Ndf);
-    #endif
-    
-    #ifdef DEBUG
+#endif
+
+#ifdef DEBUG
     cout << " Ref. Track Chi2      :  " << trkChi2 << endl;
     cout << " Ref. end momentum    :  " << trackMomMag << " GeV/c ";
     if (abs(trk->getCardinalRep()->getPDG()) == 11) {
@@ -892,24 +897,24 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
       cout << " < p-value cut " << m_pValueCut;
     cout << endl;
     cout << "-------------------------------------------------------" << endl;
-    #endif
-    
-    #ifdef OUTPUT
+#endif
+
+#ifdef OUTPUT
     bool hittedLayers[12];
     for (int hl = 0; hl < 12; hl++) {
       hittedLayers[hl] = false;
     }
-    #endif
-    
+#endif
+
     // GBL fit succeded if Ndf >= 0, but Ndf = 0 is useless
     //TODO: Here should be some track quality check
     //    if (Ndf > 0 && fitRes == 0) {
     if (traj->isValid() && pvalue >= m_pValueCut && Ndf >= m_minNdf) {
-      
+
       // In case someone forgot to use beginRun and dind't reset mille file name to ""
       if (!milleFile && m_milleFileName != "")
         milleFile = new MilleBinary(m_milleFileName);
-      
+
       // Loop over all GBL points
       for (unsigned int p = 0; p < listOfPoints.size(); p++) {
         unsigned int label = p + 1;
@@ -921,8 +926,8 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
         //TODO: now we only provide info about measurements, not kinks
         if (!listOfPoints.at(p).hasMeasurement())
           continue;
-        
-        #ifdef OUTPUT
+
+#ifdef OUTPUT
         // Decode VxdId and get layer in TB setup
         unsigned int l = 0;
         unsigned int id = listOfLayers.at(p);
@@ -933,7 +938,7 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
         unsigned int ladder = id & 31;
         id = id >> 5;
         unsigned int layer = id & 7;
-        
+
         if (layer == 7 && ladder == 2) {
           l = sensor;
         } else if (layer == 7 && ladder == 3) {
@@ -941,9 +946,9 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
         } else {
           l = layer + 3;
         }
-        
+
         hittedLayers[l - 1] = true;
-        #endif
+#endif
         TVectorD localPar(5);
         TMatrixDSym localCov(5);
         traj->getResults(label, localPar, localCov);
@@ -952,23 +957,23 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
         if (m_chi2Cut && (fabs(residuals[0] / resErrors[0]) > m_chi2Cut || fabs(residuals[1] / resErrors[1]) > m_chi2Cut))
           return;
         // Write layer-wise data
-        #ifdef OUTPUT
+#ifdef OUTPUT
         if (!writeHistoDataForLabel(listOfLayers.at(p), residuals, measErrors, resErrors, downWeights, localPar, localCov))
           return;
-        #endif
-        
+#endif
+
       } // end for points
-      
+
       // Write binary data to mille binary
       if (milleFile && m_milleFileName != "" && pvalue >= m_pValueCut && Ndf >= m_minNdf) {
         traj->milleOut(*milleFile);
-        #ifdef DEBUG
+#ifdef DEBUG
         cout << " GBL Track written to Millepede II binary file." << endl;
         cout << "-------------------------------------------------------" << endl;
-        #endif
+#endif
       }
-      
-      #ifdef OUTPUT
+
+#ifdef OUTPUT
       // Fill histograms
       chi2OndfHisto->Fill(Chi2 / Ndf);
       pValueHisto->Fill(TMath::Prob(Chi2, Ndf));
@@ -989,7 +994,7 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
         // front tel + pxd + svd
         stats->Fill(1);
       }
-      
+
       if (
         hittedLayers[0] &&
         hittedLayers[1] &&
@@ -1031,7 +1036,7 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
         hittedLayers[0] &&
         hittedLayers[1] &&
         hittedLayers[2] &&
-        
+
         hittedLayers[5] &&
         hittedLayers[6] &&
         hittedLayers[7] &&
@@ -1047,7 +1052,7 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
         hittedLayers[0] &&
         hittedLayers[1] &&
         hittedLayers[2] &&
-        
+
         hittedLayers[5] &&
         hittedLayers[6] &&
         hittedLayers[7] &&
@@ -1064,9 +1069,9 @@ void GFGbl::processTrackWithRep(Track* trk, const AbsTrackRep* rep, bool /*resor
         // backward tel
         stats->Fill(7);
       }
-      #endif
+#endif
     }
-    
+
     // Free memory
     delete traj;
   }

--- a/GBL/src/GblData.cc
+++ b/GBL/src/GblData.cc
@@ -33,238 +33,241 @@
 namespace gbl {
 
 /// Create data block.
-/**
- * \param [in] aLabel Label of corresponding point
- * \param [in] aValue Value of (scalar) measurement
- * \param [in] aPrec Precision of (scalar) measurement
- */
-GblData::GblData(unsigned int aLabel, double aValue, double aPrec) :
-		theLabel(aLabel), theValue(aValue), thePrecision(aPrec), theDownWeight(
-				1.), thePrediction(0.), theParameters(), theDerivatives(), globalLabels(), globalDerivatives() {
+  /**
+   * \param [in] aLabel Label of corresponding point
+   * \param [in] aValue Value of (scalar) measurement
+   * \param [in] aPrec Precision of (scalar) measurement
+   */
+  GblData::GblData(unsigned int aLabel, double aValue, double aPrec) :
+    theLabel(aLabel), theValue(aValue), thePrecision(aPrec), theDownWeight(
+      1.), thePrediction(0.), theParameters(), theDerivatives(), globalLabels(), globalDerivatives()
+  {
 
-}
+  }
 
-GblData::~GblData() {
-}
+  GblData::~GblData()
+  {
+  }
 
 /// Add derivatives from measurement.
-/**
- * Add (non-zero) derivatives to data block. Fill list of labels of used fit parameters.
- * \param [in] iRow Row index (0-4) in up to 5D measurement
- * \param [in] labDer Labels for derivatives
- * \param [in] matDer Derivatives (matrix) 'measurement vs track fit parameters'
- * \param [in] iOff Offset for row index for additional parameters
- * \param [in] derLocal Derivatives (matrix) for additional local parameters
- * \param [in] labGlobal Labels for additional global (MP-II) parameters
- * \param [in] derGlobal Derivatives (matrix) for additional global (MP-II) parameters
- * \param [in] extOff Offset for external parameters
- * \param [in] extDer Derivatives for external Parameters
- */
-void GblData::addDerivatives(unsigned int iRow,
-		const std::vector<unsigned int> &labDer, const SMatrix55 &matDer,
-		unsigned int iOff, const TMatrixD &derLocal,
-		const std::vector<int> &labGlobal, const TMatrixD &derGlobal,
-		unsigned int extOff, const TMatrixD &extDer) {
+  /**
+   * Add (non-zero) derivatives to data block. Fill list of labels of used fit parameters.
+   * \param [in] iRow Row index (0-4) in up to 5D measurement
+   * \param [in] labDer Labels for derivatives
+   * \param [in] matDer Derivatives (matrix) 'measurement vs track fit parameters'
+   * \param [in] iOff Offset for row index for additional parameters
+   * \param [in] derLocal Derivatives (matrix) for additional local parameters
+   * \param [in] labGlobal Labels for additional global (MP-II) parameters
+   * \param [in] derGlobal Derivatives (matrix) for additional global (MP-II) parameters
+   * \param [in] extOff Offset for external parameters
+   * \param [in] extDer Derivatives for external Parameters
+   */
+  void GblData::addDerivatives(unsigned int iRow,
+                               const std::vector<unsigned int>& labDer, const SMatrix55& matDer,
+                               unsigned int iOff, const TMatrixD& derLocal,
+                               const std::vector<int>& labGlobal, const TMatrixD& derGlobal,
+                               unsigned int extOff, const TMatrixD& extDer)
+  {
 
-	unsigned int nParMax = 5 + derLocal.GetNcols() + extDer.GetNcols();
-	theParameters.reserve(nParMax); // have to be sorted
-	theDerivatives.reserve(nParMax);
+    unsigned int nParMax = 5 + derLocal.GetNcols() + extDer.GetNcols();
+    theParameters.reserve(nParMax); // have to be sorted
+    theDerivatives.reserve(nParMax);
 
-	for (int i = 0; i < derLocal.GetNcols(); ++i) // local derivatives
-			{
-		if (derLocal(iRow - iOff, i)) {
-			theParameters.push_back(i + 1);
-			theDerivatives.push_back(derLocal(iRow - iOff, i));
-		}
-	}
+    for (int i = 0; i < derLocal.GetNcols(); ++i) { // local derivatives
+      if (derLocal(iRow - iOff, i)) {
+        theParameters.push_back(i + 1);
+        theDerivatives.push_back(derLocal(iRow - iOff, i));
+      }
+    }
 
-	for (int i = 0; i < extDer.GetNcols(); ++i) // external derivatives
-			{
-		if (extDer(iRow - iOff, i)) {
-			theParameters.push_back(extOff + i + 1);
-			theDerivatives.push_back(extDer(iRow - iOff, i));
-		}
-	}
+    for (int i = 0; i < extDer.GetNcols(); ++i) { // external derivatives
+      if (extDer(iRow - iOff, i)) {
+        theParameters.push_back(extOff + i + 1);
+        theDerivatives.push_back(extDer(iRow - iOff, i));
+      }
+    }
 
-	for (unsigned int i = 0; i < 5; ++i) // curvature, offset derivatives
-			{
-		if (labDer[i] and matDer(iRow, i)) {
-			theParameters.push_back(labDer[i]);
-			theDerivatives.push_back(matDer(iRow, i));
-		}
-	}
+    for (unsigned int i = 0; i < 5; ++i) { // curvature, offset derivatives
+      if (labDer[i] and matDer(iRow, i)) {
+        theParameters.push_back(labDer[i]);
+        theDerivatives.push_back(matDer(iRow, i));
+      }
+    }
 
-	globalLabels = labGlobal;
-	for (int i = 0; i < derGlobal.GetNcols(); ++i) // global derivatives
-		globalDerivatives.push_back(derGlobal(iRow - iOff, i));
-}
+    globalLabels = labGlobal;
+    for (int i = 0; i < derGlobal.GetNcols(); ++i) // global derivatives
+      globalDerivatives.push_back(derGlobal(iRow - iOff, i));
+  }
 
 /// Add derivatives from kink.
-/**
- * Add (non-zero) derivatives to data block. Fill list of labels of used fit parameters.
- * \param [in] iRow Row index (0-1) in 2D kink
- * \param [in] labDer Labels for derivatives
- * \param [in] matDer Derivatives (matrix) 'kink vs track fit parameters'
- * \param [in] extOff Offset for external parameters
- * \param [in] extDer Derivatives for external Parameters
- */
-void GblData::addDerivatives(unsigned int iRow,
-		const std::vector<unsigned int> &labDer, const SMatrix27 &matDer,
-		unsigned int extOff, const TMatrixD &extDer) {
+  /**
+   * Add (non-zero) derivatives to data block. Fill list of labels of used fit parameters.
+   * \param [in] iRow Row index (0-1) in 2D kink
+   * \param [in] labDer Labels for derivatives
+   * \param [in] matDer Derivatives (matrix) 'kink vs track fit parameters'
+   * \param [in] extOff Offset for external parameters
+   * \param [in] extDer Derivatives for external Parameters
+   */
+  void GblData::addDerivatives(unsigned int iRow,
+                               const std::vector<unsigned int>& labDer, const SMatrix27& matDer,
+                               unsigned int extOff, const TMatrixD& extDer)
+  {
 
-	unsigned int nParMax = 7 + extDer.GetNcols();
-	theParameters.reserve(nParMax); // have to be sorted
-	theDerivatives.reserve(nParMax);
+    unsigned int nParMax = 7 + extDer.GetNcols();
+    theParameters.reserve(nParMax); // have to be sorted
+    theDerivatives.reserve(nParMax);
 
-	for (int i = 0; i < extDer.GetNcols(); ++i) // external derivatives
-			{
-		if (extDer(iRow, i)) {
-			theParameters.push_back(extOff + i + 1);
-			theDerivatives.push_back(extDer(iRow, i));
-		}
-	}
+    for (int i = 0; i < extDer.GetNcols(); ++i) { // external derivatives
+      if (extDer(iRow, i)) {
+        theParameters.push_back(extOff + i + 1);
+        theDerivatives.push_back(extDer(iRow, i));
+      }
+    }
 
-	for (unsigned int i = 0; i < 7; ++i) // curvature, offset derivatives
-			{
-		if (labDer[i] and matDer(iRow, i)) {
-			theParameters.push_back(labDer[i]);
-			theDerivatives.push_back(matDer(iRow, i));
-		}
-	}
-}
+    for (unsigned int i = 0; i < 7; ++i) { // curvature, offset derivatives
+      if (labDer[i] and matDer(iRow, i)) {
+        theParameters.push_back(labDer[i]);
+        theDerivatives.push_back(matDer(iRow, i));
+      }
+    }
+  }
 
 /// Add derivatives from external seed.
-/**
- * Add (non-zero) derivatives to data block. Fill list of labels of used fit parameters.
- * \param [in] index Labels for derivatives
- * \param [in] derivatives Derivatives (vector)
- */
-void GblData::addDerivatives(const std::vector<unsigned int> &index,
-		const std::vector<double> &derivatives) {
-	for (unsigned int i = 0; i < derivatives.size(); ++i) // any derivatives
-			{
-		if (derivatives[i]) {
-			theParameters.push_back(index[i]);
-			theDerivatives.push_back(derivatives[i]);
-		}
-	}
-}
+  /**
+   * Add (non-zero) derivatives to data block. Fill list of labels of used fit parameters.
+   * \param [in] index Labels for derivatives
+   * \param [in] derivatives Derivatives (vector)
+   */
+  void GblData::addDerivatives(const std::vector<unsigned int>& index,
+                               const std::vector<double>& derivatives)
+  {
+    for (unsigned int i = 0; i < derivatives.size(); ++i) { // any derivatives
+      if (derivatives[i]) {
+        theParameters.push_back(index[i]);
+        theDerivatives.push_back(derivatives[i]);
+      }
+    }
+  }
 
 /// Calculate prediction for data from fit (by GblTrajectory::fit).
-void GblData::setPrediction(const VVector &aVector) {
+  void GblData::setPrediction(const VVector& aVector)
+  {
 
-	thePrediction = 0.;
-	for (unsigned int i = 0; i < theDerivatives.size(); ++i) {
-		thePrediction += theDerivatives[i] * aVector(theParameters[i] - 1);
-	}
-}
+    thePrediction = 0.;
+    for (unsigned int i = 0; i < theDerivatives.size(); ++i) {
+      thePrediction += theDerivatives[i] * aVector(theParameters[i] - 1);
+    }
+  }
 
 /// Outlier down weighting with M-estimators (by GblTrajectory::fit).
-/**
- * \param [in] aMethod M-estimator (1: Tukey, 2:Huber, 3:Cauchy)
- */
-double GblData::setDownWeighting(unsigned int aMethod) {
+  /**
+   * \param [in] aMethod M-estimator (1: Tukey, 2:Huber, 3:Cauchy)
+   */
+  double GblData::setDownWeighting(unsigned int aMethod)
+  {
 
-	double aWeight = 1.;
-	double scaledResidual = fabs(theValue - thePrediction) * sqrt(thePrecision);
-	if (aMethod == 1) // Tukey
-			{
-		if (scaledResidual < 4.6851) {
-			aWeight = (1.0 - 0.045558 * scaledResidual * scaledResidual);
-			aWeight *= aWeight;
-		} else {
-			aWeight = 0.;
-		}
-	} else if (aMethod == 2) //Huber
-			{
-		if (scaledResidual >= 1.345) {
-			aWeight = 1.345 / scaledResidual;
-		}
-	} else if (aMethod == 3) //Cauchy
-			{
-		aWeight = 1.0 / (1.0 + (scaledResidual * scaledResidual / 5.6877));
-	}
-	theDownWeight = aWeight;
-	return aWeight;
-}
+    double aWeight = 1.;
+    double scaledResidual = fabs(theValue - thePrediction) * sqrt(thePrecision);
+    if (aMethod == 1) { // Tukey
+      if (scaledResidual < 4.6851) {
+        aWeight = (1.0 - 0.045558 * scaledResidual * scaledResidual);
+        aWeight *= aWeight;
+      } else {
+        aWeight = 0.;
+      }
+    } else if (aMethod == 2) { //Huber
+      if (scaledResidual >= 1.345) {
+        aWeight = 1.345 / scaledResidual;
+      }
+    } else if (aMethod == 3) { //Cauchy
+      aWeight = 1.0 / (1.0 + (scaledResidual * scaledResidual / 5.6877));
+    }
+    theDownWeight = aWeight;
+    return aWeight;
+  }
 
 /// Calculate Chi2 contribution.
-/**
- * \return (down-weighted) Chi2
- */
-double GblData::getChi2() const {
-	double aDiff = theValue - thePrediction;
-	return aDiff * aDiff * thePrecision * theDownWeight;
-}
+  /**
+   * \return (down-weighted) Chi2
+   */
+  double GblData::getChi2() const
+  {
+    double aDiff = theValue - thePrediction;
+    return aDiff * aDiff * thePrecision * theDownWeight;
+  }
 
 /// Print data block.
-void GblData::printData() const {
+  void GblData::printData() const
+  {
 
-	std::cout << " measurement at label " << theLabel << ": " << theValue
-			<< ", " << thePrecision << std::endl;
-	std::cout << "  param " << theParameters.size() << ":";
-	for (unsigned int i = 0; i < theParameters.size(); ++i) {
-		std::cout << " " << theParameters[i];
-	}
-	std::cout << std::endl;
-	std::cout << "  deriv " << theDerivatives.size() << ":";
-	for (unsigned int i = 0; i < theDerivatives.size(); ++i) {
-		std::cout << " " << theDerivatives[i];
-	}
-	std::cout << std::endl;
-}
+    std::cout << " measurement at label " << theLabel << ": " << theValue
+              << ", " << thePrecision << std::endl;
+    std::cout << "  param " << theParameters.size() << ":";
+    for (unsigned int i = 0; i < theParameters.size(); ++i) {
+      std::cout << " " << theParameters[i];
+    }
+    std::cout << std::endl;
+    std::cout << "  deriv " << theDerivatives.size() << ":";
+    for (unsigned int i = 0; i < theDerivatives.size(); ++i) {
+      std::cout << " " << theDerivatives[i];
+    }
+    std::cout << std::endl;
+  }
 
 /// Get Data for local fit.
-/**
- * \param [out] aValue Value
- * \param [out] aWeight Weight
- * \param [out] indLocal List of labels of used (local) fit parameters
- * \param [out] derLocal List of derivatives for used (local) fit parameters
- */
-void GblData::getLocalData(double &aValue, double &aWeight,
-		std::vector<unsigned int>* &indLocal, std::vector<double>* &derLocal) {
+  /**
+   * \param [out] aValue Value
+   * \param [out] aWeight Weight
+   * \param [out] indLocal List of labels of used (local) fit parameters
+   * \param [out] derLocal List of derivatives for used (local) fit parameters
+   */
+  void GblData::getLocalData(double& aValue, double& aWeight,
+                             std::vector<unsigned int>*& indLocal, std::vector<double>*& derLocal)
+  {
 
-	aValue = theValue;
-	aWeight = thePrecision * theDownWeight;
-	indLocal = &theParameters;
-	derLocal = &theDerivatives;
-}
+    aValue = theValue;
+    aWeight = thePrecision * theDownWeight;
+    indLocal = &theParameters;
+    derLocal = &theDerivatives;
+  }
 
 /// Get all Data for MP-II binary record.
-/**
- * \param [out] aValue Value
- * \param [out] aErr Error
- * \param [out] indLocal List of labels of local parameters
- * \param [out] derLocal List of derivatives for local parameters
- * \param [out] labGlobal List of labels of global parameters
- * \param [out] derGlobal List of derivatives for global parameters
- */
-void GblData::getAllData(double &aValue, double &aErr,
-		std::vector<unsigned int>* &indLocal, std::vector<double>* &derLocal,
-		std::vector<int>* &labGlobal, std::vector<double>* &derGlobal) {
-	aValue = theValue;
-	aErr = 1.0 / sqrt(thePrecision);
-	indLocal = &theParameters;
-	derLocal = &theDerivatives;
-	labGlobal = &globalLabels;
-	derGlobal = &globalDerivatives;
-}
+  /**
+   * \param [out] aValue Value
+   * \param [out] aErr Error
+   * \param [out] indLocal List of labels of local parameters
+   * \param [out] derLocal List of derivatives for local parameters
+   * \param [out] labGlobal List of labels of global parameters
+   * \param [out] derGlobal List of derivatives for global parameters
+   */
+  void GblData::getAllData(double& aValue, double& aErr,
+                           std::vector<unsigned int>*& indLocal, std::vector<double>*& derLocal,
+                           std::vector<int>*& labGlobal, std::vector<double>*& derGlobal)
+  {
+    aValue = theValue;
+    aErr = 1.0 / sqrt(thePrecision);
+    indLocal = &theParameters;
+    derLocal = &theDerivatives;
+    labGlobal = &globalLabels;
+    derGlobal = &globalDerivatives;
+  }
 
 /// Get data for residual (and errors).
-/**
- * \param [out] aResidual Measurement-Prediction
- * \param [out] aVariance Variance (of measurement)
- * \param [out] aDownWeight Down-weighting factor
- * \param [out] indLocal List of labels of used (local) fit parameters
- * \param [out] derLocal List of derivatives for used (local) fit parameters
- */
-void GblData::getResidual(double &aResidual, double &aVariance,
-		double &aDownWeight, std::vector<unsigned int>* &indLocal,
-		std::vector<double>* &derLocal) {
-	aResidual = theValue - thePrediction;
-	aVariance = 1.0 / thePrecision;
-	aDownWeight = theDownWeight;
-	indLocal = &theParameters;
-	derLocal = &theDerivatives;
-}
+  /**
+   * \param [out] aResidual Measurement-Prediction
+   * \param [out] aVariance Variance (of measurement)
+   * \param [out] aDownWeight Down-weighting factor
+   * \param [out] indLocal List of labels of used (local) fit parameters
+   * \param [out] derLocal List of derivatives for used (local) fit parameters
+   */
+  void GblData::getResidual(double& aResidual, double& aVariance,
+                            double& aDownWeight, std::vector<unsigned int>*& indLocal,
+                            std::vector<double>*& derLocal)
+  {
+    aResidual = theValue - thePrediction;
+    aVariance = 1.0 / thePrecision;
+    aDownWeight = theDownWeight;
+    indLocal = &theParameters;
+    derLocal = &theDerivatives;
+  }
 }

--- a/GBL/src/GblFitterInfo.cc
+++ b/GBL/src/GblFitterInfo.cc
@@ -7,26 +7,16 @@
 //! Namespace for the general broken lines package
 namespace genfit {
 
-  GblFitterInfo::GblFitterInfo() : AbsFitterInfo(), jacobian_(TMatrixD(5, 5)) {
-    reset();      
-  }
-  
-  GblFitterInfo::GblFitterInfo(const TrackPoint* trackPoint, const AbsTrackRep* rep) : AbsFitterInfo(trackPoint, rep), jacobian_(TMatrixD(5, 5)) {
+  GblFitterInfo::GblFitterInfo() : AbsFitterInfo(), jacobian_(TMatrixD(5, 5))
+  {
     reset();
-    
-    // Retrieve jacobian from rep by default (may not be used ... at 1st point)
-    unsigned int dim = rep->getDim();
-    if (dim != 5)
-      throw new genfit::Exception("GblFitterInfo: Representation state is not 5D", __LINE__, __FILE__);
-    TMatrixDSym noise(dim, dim);
-    TVectorD dState(dim);
-    rep->getForwardJacobianAndNoise(jacobian_, noise, dState);      
-    
   }
- 
-  GblFitterInfo::GblFitterInfo(const TrackPoint* trackPoint, const AbsTrackRep* rep, StateOnPlane& referenceState) : AbsFitterInfo(trackPoint, rep), jacobian_(TMatrixD(5, 5)) {
+
+  GblFitterInfo::GblFitterInfo(const TrackPoint* trackPoint, const AbsTrackRep* rep) : AbsFitterInfo(trackPoint, rep),
+    jacobian_(TMatrixD(5, 5))
+  {
     reset();
-    
+
     // Retrieve jacobian from rep by default (may not be used ... at 1st point)
     unsigned int dim = rep->getDim();
     if (dim != 5)
@@ -34,14 +24,30 @@ namespace genfit {
     TMatrixDSym noise(dim, dim);
     TVectorD dState(dim);
     rep->getForwardJacobianAndNoise(jacobian_, noise, dState);
-        
+
+  }
+
+  GblFitterInfo::GblFitterInfo(const TrackPoint* trackPoint, const AbsTrackRep* rep,
+                               StateOnPlane& referenceState) : AbsFitterInfo(trackPoint, rep), jacobian_(TMatrixD(5, 5))
+  {
+    reset();
+
+    // Retrieve jacobian from rep by default (may not be used ... at 1st point)
+    unsigned int dim = rep->getDim();
+    if (dim != 5)
+      throw new genfit::Exception("GblFitterInfo: Representation state is not 5D", __LINE__, __FILE__);
+    TMatrixDSym noise(dim, dim);
+    TVectorD dState(dim);
+    rep->getForwardJacobianAndNoise(jacobian_, noise, dState);
+
     setReferenceState(referenceState);
   }
-  
-  void GblFitterInfo::reset(unsigned int measurementDim, unsigned int repDim) {
+
+  void GblFitterInfo::reset(unsigned int measurementDim, unsigned int repDim)
+  {
     refPrediction_.ResizeTo(repDim);
     refPrediction_.Zero();
-    
+
     measResiduals_.ResizeTo(measurementDim);
     measResiduals_.Zero();
     kinkResiduals_.ResizeTo(measurementDim);
@@ -54,10 +60,10 @@ namespace genfit {
     measDownWeights_.Zero();
     kinkDownWeights_.ResizeTo(measurementDim);
     kinkDownWeights_.Zero();
-    
+
     TMatrixDSym zero(repDim);
     zero.Zero();
-    
+
     fwdStateCorrection_.ResizeTo(repDim);
     fwdCov_.ResizeTo(zero);
     bwdStateCorrection_.ResizeTo(repDim);
@@ -65,8 +71,8 @@ namespace genfit {
     fwdPrediction_.ResizeTo(repDim);
     bwdPrediction_.ResizeTo(repDim);
     fwdCov_.SetMatrixArray(zero.GetMatrixArray());
-    bwdCov_.SetMatrixArray(zero.GetMatrixArray());  
-    
+    bwdCov_.SetMatrixArray(zero.GetMatrixArray());
+
     measurement_.ResizeTo(2);
     measurement_.Zero();
     measCov_.ResizeTo(TMatrixDSym(2));
@@ -74,51 +80,57 @@ namespace genfit {
     hMatrix_.ResizeTo(HMatrixUV().getMatrix());
     hMatrix_ = HMatrixUV().getMatrix();
   }
-  
-  void GblFitterInfo::setReferenceState(StateOnPlane& referenceState) {
+
+  void GblFitterInfo::setReferenceState(StateOnPlane& referenceState)
+  {
     updateMeasurementAndPlane(referenceState);
-    
+
     refPrediction_ = referenceState.getState();
     fwdPrediction_ = referenceState.getState();
     bwdPrediction_ = referenceState.getState();
-    
-    //TODO: reset even if already fitted?      
-    fittedStateBwd_.reset(new MeasuredStateOnPlane(referenceState.getState(), trackPoint_->getTrack()->getCovSeed(), sharedPlane_, rep_, referenceState.getAuxInfo()));
-    fittedStateFwd_.reset(new MeasuredStateOnPlane(referenceState.getState(), trackPoint_->getTrack()->getCovSeed(), sharedPlane_, rep_, referenceState.getAuxInfo()));
-    
+
+    //TODO: reset even if already fitted?
+    fittedStateBwd_.reset(new MeasuredStateOnPlane(referenceState.getState(), trackPoint_->getTrack()->getCovSeed(), sharedPlane_, rep_,
+                                                   referenceState.getAuxInfo()));
+    fittedStateFwd_.reset(new MeasuredStateOnPlane(referenceState.getState(), trackPoint_->getTrack()->getCovSeed(), sharedPlane_, rep_,
+                                                   referenceState.getAuxInfo()));
+
   }
-  
-  void GblFitterInfo::setJacobian(TMatrixD jacobian) {
+
+  void GblFitterInfo::setJacobian(TMatrixD jacobian)
+  {
     jacobian_.ResizeTo(jacobian);
-    jacobian_ = jacobian; 
+    jacobian_ = jacobian;
   }
-  
-  TMatrixDSym GblFitterInfo::getCovariance(double variance, TVector3 trackDirection, SharedPlanePtr measurementPlane) const {
-    
+
+  TMatrixDSym GblFitterInfo::getCovariance(double variance, TVector3 trackDirection, SharedPlanePtr measurementPlane) const
+  {
+
     double c1 = trackDirection.Dot(measurementPlane->getU());
     double c2 = trackDirection.Dot(measurementPlane->getV());
-    
+
     TMatrixDSym scatCov(2);
     scatCov(0, 0) = 1. - c2 * c2;
     scatCov(1, 1) = 1. - c1 * c1;
     scatCov(0, 1) = c1 * c2;
     scatCov(1, 0) = c1 * c2;
     scatCov *= variance * variance / (1. - c1 * c1 - c2 * c2) / (1. - c1 * c1 - c2 * c2) ;
-    
+
     return scatCov;
   }
-  
-  gbl::GblPoint GblFitterInfo::constructGblPoint() {
+
+  gbl::GblPoint GblFitterInfo::constructGblPoint()
+  {
     // All meas/scat info is added from genfit data again (to cope with possible RecoHit update)
-    
+
     // Create GBL point with current jacobian
     gbl::GblPoint thePoint(jacobian_);
-    
+
     //NOTE: 3rd update and update anytime GblPoint is requested
     // mostly likely will update with reference as on 2nd update
     StateOnPlane sop(getFittedState().getState(), sharedPlane_, rep_, getFittedState(true).getAuxInfo());
-    
-    
+
+
     // Scatterer
     if (trackPoint_->hasThinScatterer()) {
       if (!hasMeasurements()) {
@@ -133,16 +145,16 @@ namespace genfit {
       } else {
         TMatrixDSym kinkCov = getCovariance(trackPoint_->getMaterialInfo()->getMaterial().density, sop.getDir(), sop.getPlane());
         thePoint.addScatterer(getKinks(), kinkCov.Invert());
-      }      
+      }
     }
-    
-    
-    
+
+
+
     // Measurement
     if (hasMeasurements()) {
-      MeasuredStateOnPlane measurement = getResidual(0, true, true);    
+      MeasuredStateOnPlane measurement = getResidual(0, true, true);
       TVectorD aResiduals(measurement.getState());
-      TMatrixDSym aPrecision(measurement.getCov().Invert()); 
+      TMatrixDSym aPrecision(measurement.getCov().Invert());
       if (HMatrixU().getMatrix() == hMatrix_) {
         double res = aResiduals(0);
         double prec = aPrecision(0, 0);
@@ -152,7 +164,7 @@ namespace genfit {
         aResiduals(0) = res;
         aPrecision.Zero();
         aPrecision(0, 0) = prec;
-      }      
+      }
       if (HMatrixV().getMatrix() == hMatrix_) {
         double res = aResiduals(0);
         double prec = aPrecision(0, 0);
@@ -166,18 +178,18 @@ namespace genfit {
       // always 2D, U/V set by precision (=0 to disable)
       thePoint.addMeasurement(aResiduals, aPrecision);
     }
-    
-    // Derivatives      
+
+    // Derivatives
     ICalibrationParametersDerivatives* globals = nullptr;
-    if (hasMeasurements() && (globals = dynamic_cast<ICalibrationParametersDerivatives*>(trackPoint_->getRawMeasurement(0)) )) {    
+    if (hasMeasurements() && (globals = dynamic_cast<ICalibrationParametersDerivatives*>(trackPoint_->getRawMeasurement(0)))) {
       std::pair<std::vector<int>, TMatrixD> labelsAndMatrix = globals->globalDerivatives(&sop);
       std::vector<int> labels = labelsAndMatrix.first;
       TMatrixD derivs = labelsAndMatrix.second;
-      
+
       if (derivs.GetNcols() > 0 && !labels.empty() && (unsigned int)derivs.GetNcols() == labels.size()) {
         thePoint.addGlobals(labels, derivs);
-      }        
-      TMatrixD locals = globals->localDerivatives(&sop);      
+      }
+      TMatrixD locals = globals->localDerivatives(&sop);
       if (locals.GetNcols() > 0) {
         thePoint.addLocals(locals);
         GblFitStatus* gblfs = dynamic_cast<GblFitStatus*>(trackPoint_->getTrack()->getFitStatus(rep_));
@@ -187,12 +199,13 @@ namespace genfit {
         }
       }
     }
-    
+
     return thePoint;
-    
+
   }
-  
-  void GblFitterInfo::updateMeasurementAndPlane(const StateOnPlane & sop) {
+
+  void GblFitterInfo::updateMeasurementAndPlane(const StateOnPlane& sop)
+  {
     if (!trackPoint_)
       return;
     if (!trackPoint_->hasRawMeasurements()) {
@@ -201,7 +214,7 @@ namespace genfit {
       return;
     }
     std::vector<MeasurementOnPlane*> allMeas = trackPoint_->getRawMeasurement(0)->constructMeasurementsOnPlane(sop);
-    
+
     /*
     double normMin(9.99E99);
     unsigned int imop(0);
@@ -212,7 +225,7 @@ namespace genfit {
         e.setFatal();
         throw e;
       }
-      
+
       TVectorD res = allMeas[i]->getState() - H->Hv(sop.getState());
       double norm = sqrt(res.Norm2Sqr());
       if (norm < normMin) {
@@ -233,20 +246,21 @@ namespace genfit {
     measCov_ = allMeas.at(imop)->getCov();
     hMatrix_.ResizeTo(allMeas.at(imop)->getHMatrix()->getMatrix());
     hMatrix_ = allMeas.at(imop)->getHMatrix()->getMatrix();
-    
+
     setPlane(allMeas.at(imop)->getPlane());
-    
+
     for (unsigned int imeas = 0; imeas < allMeas.size(); imeas++)
       delete allMeas[imeas];
     allMeas.clear();
-    
+
 
   }
-  
-  void GblFitterInfo::updateFitResults(gbl::GblTrajectory& traj) {  
+
+  void GblFitterInfo::updateFitResults(gbl::GblTrajectory& traj)
+  {
     if (!traj.isValid())
       return;
-    
+
     // Deduce our position in the trajectory
     //----------------------------------------------
     unsigned int label = 0;
@@ -254,7 +268,7 @@ namespace genfit {
     genfit::Track* trk = trackPoint_->getTrack();
     for (unsigned int ip = 0; ip < trk->getNumPoints(); ip++) {
       // Indexing of GblFitter info in track (each gives one point to trajectory at trackpoint position)
-      if (dynamic_cast<GblFitterInfo*>( trk->getPoint(ip)->getFitterInfo(rep_) )) {
+      if (dynamic_cast<GblFitterInfo*>(trk->getPoint(ip)->getFitterInfo(rep_))) {
         // First fitter info has label 1 (for point in GBL traj)
         label++;
         // We found itself = we have our label
@@ -263,41 +277,41 @@ namespace genfit {
       }
     }
     if (label == 0)
-      throw genfit::Exception("GblFitterInfo: fitter info did not found itself in track to update", __LINE__, __FILE__);      
+      throw genfit::Exception("GblFitterInfo: fitter info did not found itself in track to update", __LINE__, __FILE__);
     if (label > traj.getNumPoints())
-      throw genfit::Exception("GblFitterInfo: Deduced point label not valid", __LINE__, __FILE__);    
+      throw genfit::Exception("GblFitterInfo: Deduced point label not valid", __LINE__, __FILE__);
     //----------------------------------------------
-    
+
     // Residuals (in plane)
-    unsigned int numMRes = 2;    
-    TVectorD mResiduals(2), mMeasErrors(2), mResErrors(2), mDownWeights(2);    
+    unsigned int numMRes = 2;
+    TVectorD mResiduals(2), mMeasErrors(2), mResErrors(2), mDownWeights(2);
     if (0 != traj.getMeasResults(label, numMRes, mResiduals, mMeasErrors, mResErrors, mDownWeights))
-      throw genfit::Exception(" NO measurement results ", __LINE__, __FILE__);  
-    
+      throw genfit::Exception(" NO measurement results ", __LINE__, __FILE__);
+
     // Kinks
     unsigned int numKRes = 2;
-    TVectorD kResiduals(2), kMeasErrors(2), kResErrors(2), kDownWeights(2);    
+    TVectorD kResiduals(2), kMeasErrors(2), kResErrors(2), kDownWeights(2);
     if (0 != traj.getScatResults(label, numKRes, kResiduals, kMeasErrors, kResErrors, kDownWeights))
-      throw genfit::Exception(" NO scattering results ", __LINE__, __FILE__);        
-    
-    // Check for local derivatives    
+      throw genfit::Exception(" NO scattering results ", __LINE__, __FILE__);
+
+    // Check for local derivatives
     int nLocals = 0;
     GblFitStatus* gblfs = dynamic_cast<GblFitStatus*>(trackPoint_->getTrack()->getFitStatus(rep_));
     if (gblfs)
       nLocals = gblfs->getMaxLocalFitParams();
-     
+
     // Predictions (different at scatterer)
     TVectorD bwdUpdate(5 + nLocals), fwdUpdate(5 + nLocals);
     TMatrixDSym bwdCov(5 + nLocals), fwdCov(5 + nLocals);
-    
+
     // forward prediction
     if (0 != traj.getResults(label, fwdUpdate, fwdCov))
-      throw genfit::Exception(" NO forward results ", __LINE__, __FILE__);        
-    
+      throw genfit::Exception(" NO forward results ", __LINE__, __FILE__);
+
     // backward prediction
     if (0 != traj.getResults(-1 * label, bwdUpdate, bwdCov))
-      throw genfit::Exception(" NO backward results ", __LINE__, __FILE__);        
-    
+      throw genfit::Exception(" NO backward results ", __LINE__, __FILE__);
+
     if (nLocals > 0) {
       TVectorD _bwdUpdate(5 + nLocals), _fwdUpdate(5 + nLocals);
       TMatrixDSym _bwdCov(5 + nLocals), _fwdCov(5 + nLocals);
@@ -315,7 +329,7 @@ namespace genfit {
         for (int j = 0; j < 5; j++) {
           bwdCov(i, j) = _bwdCov(i, j);
           fwdCov(i, j) = _fwdCov(i, j);
-        }        
+        }
       }
     }
     // Now update the the fitter info
@@ -328,58 +342,59 @@ namespace genfit {
     fwdCov_ = fwdCov;
     fwdPrediction_ += fwdStateCorrection_; // This is the update!
     bwdPrediction_ += bwdStateCorrection_; // This is the update!
-    
-    fittedStateFwd_.reset( new MeasuredStateOnPlane(fwdPrediction_, fwdCov_, sharedPlane_, rep_, getFittedState(true).getAuxInfo()) );         
-    fittedStateBwd_.reset( new MeasuredStateOnPlane(bwdPrediction_, bwdCov_, sharedPlane_, rep_, getFittedState(true).getAuxInfo()) );
-    
+
+    fittedStateFwd_.reset(new MeasuredStateOnPlane(fwdPrediction_, fwdCov_, sharedPlane_, rep_, getFittedState(true).getAuxInfo()));
+    fittedStateBwd_.reset(new MeasuredStateOnPlane(bwdPrediction_, bwdCov_, sharedPlane_, rep_, getFittedState(true).getAuxInfo()));
+
     // Set scattering/measurement residual data
     kinkResiduals_ = kResiduals;
     measResiduals_ = mResiduals;
     kinkResidualErrors_ = kResErrors;
     measResidualErrors_ = mResErrors;
     measDownWeights_ = mDownWeights;
-    kinkDownWeights_ = kDownWeights;   
-    
+    kinkDownWeights_ = kDownWeights;
+
     //-------------------------------------------------
   }
-  
+
   void GblFitterInfo::recalculateJacobian(GblFitterInfo* prevFitterInfo)
   {
     // Invalidates errors and corrections from last iteration
     // (will be defined in different plane). But fitted state and residual is ok.
-        
+
     if (!prevFitterInfo) {
       jacobian_.UnitMatrix();
-      
+
       //TODO: For 1st plane this has no sense
       //return;
       prevFitterInfo = this;
-    }    
-    
+    }
+
     //TODO
     SharedPlanePtr oldPlane(new genfit::DetPlane(*sharedPlane_));
 
     //updateMeasurementAndPlane(StateOnPlane(fwdPrediction_, sharedPlane_, rep_));
     //
-    
+
     TMatrixDSym noise;
     TVectorD dstate;
     // Take forward state from previous fitter info,
     // its (maybe updated) plane
     // and our rep
-    StateOnPlane prevState(prevFitterInfo->getFittedState(true).getState(), prevFitterInfo->getPlane(), rep_, getFittedState(true).getAuxInfo());
-    
+    StateOnPlane prevState(prevFitterInfo->getFittedState(true).getState(), prevFitterInfo->getPlane(), rep_,
+                           getFittedState(true).getAuxInfo());
+
     if (hasMeasurements()) {
       SharedPlanePtr newPlane = trackPoint_->getRawMeasurement(0)->constructPlane(prevState);
       rep_->extrapolateToPlane(prevState, newPlane, false, true);
     } else {
-      rep_->extrapolateToPlane(prevState, sharedPlane_, false, true);      
+      rep_->extrapolateToPlane(prevState, sharedPlane_, false, true);
     }
-    
+
     rep_->getForwardJacobianAndNoise(jacobian_, noise, dstate);
     // Now update meas data
     updateMeasurementAndPlane(prevState);
-    
+
     //
     // Extrap predictions to new plane
     //
@@ -394,35 +409,36 @@ namespace genfit {
     //
   }
 
-  
-  const MeasuredStateOnPlane& GblFitterInfo::getFittedState(bool afterKink) const {      
+
+  const MeasuredStateOnPlane& GblFitterInfo::getFittedState(bool afterKink) const
+  {
     // ALways biased from GBL (global fit!)
-    
-    if (!fittedStateFwd_ || !fittedStateBwd_) { 
+
+    if (!fittedStateFwd_ || !fittedStateBwd_) {
       //NOTE: This should be already set (from reference)! The auxInfo is being book-kept by it. If reference is not set, default auxInfo is used
-      fittedStateFwd_.reset(new MeasuredStateOnPlane(fwdPrediction_, fwdCov_, sharedPlane_, rep_));        
+      fittedStateFwd_.reset(new MeasuredStateOnPlane(fwdPrediction_, fwdCov_, sharedPlane_, rep_));
       fittedStateBwd_.reset(new MeasuredStateOnPlane(bwdPrediction_, bwdCov_, sharedPlane_, rep_));
     }
-    
+
     if (afterKink) {
-      return *fittedStateFwd_;        
+      return *fittedStateFwd_;
+    } else {
+      return *fittedStateBwd_;
     }
-    else {   
-      return *fittedStateBwd_;        
-    }
-    
+
   }
-  
-  MeasurementOnPlane GblFitterInfo::getResidual(unsigned int, bool, bool onlyMeasurementErrors) const { 
+
+  MeasurementOnPlane GblFitterInfo::getResidual(unsigned int, bool, bool onlyMeasurementErrors) const
+  {
     // Return error of resduals (=0, none, for reference track, no errors known before fit (seed covariance might not be correct)
     TMatrixDSym localCovariance(2);
     localCovariance.Zero();
     // combined meas+fit errors:
     //TODO: 1D covariance + more dimensions of residuals
-    
+
     localCovariance(0, 0) = measResidualErrors_(0) * measResidualErrors_(0);
-    localCovariance(1, 1) = measResidualErrors_(1) * measResidualErrors_(1); 
-    
+    localCovariance(1, 1) = measResidualErrors_(1) * measResidualErrors_(1);
+
     if (HMatrixU().getMatrix() == hMatrix_) {
       localCovariance.ResizeTo(TMatrixDSym(1));
       localCovariance(0, 0) = measResidualErrors_(0) * measResidualErrors_(0);
@@ -431,60 +447,66 @@ namespace genfit {
       localCovariance.ResizeTo(TMatrixDSym(1));
       localCovariance(0, 0) = measResidualErrors_(1) * measResidualErrors_(1);
     }
-    
-    if (hasMeasurements()){
+
+    if (hasMeasurements()) {
       // this means only for reference state before gbl fit, this way will be used
-      TVectorD res( measurement_ - hMatrix_ * getFittedState(true).getState() );      
-      
+      TVectorD res(measurement_ - hMatrix_ * getFittedState(true).getState());
+
       if (onlyMeasurementErrors) {
         localCovariance.ResizeTo(measCov_);
         localCovariance = measCov_;
       }
-      return MeasurementOnPlane(res, localCovariance, sharedPlane_, rep_, trackPoint_->getRawMeasurement(0)->constructHMatrix(getRep()));    
+      return MeasurementOnPlane(res, localCovariance, sharedPlane_, rep_, trackPoint_->getRawMeasurement(0)->constructHMatrix(getRep()));
     }
     TVectorD zeroRes(2);
     zeroRes.Zero();
     // Else return 0's or whatever
     //TODO: or throw?
     return MeasurementOnPlane(zeroRes, localCovariance, sharedPlane_, rep_, new HMatrixUV());
-    
+
   } // calculate residual, track and measurement errors are added if onlyMeasurementErrors is false
-  
-  MeasurementOnPlane GblFitterInfo::getKink() const { 
+
+  MeasurementOnPlane GblFitterInfo::getKink() const
+  {
     TMatrixDSym localCovariance(2);
     localCovariance.Zero();
     localCovariance(0, 0) = kinkResidualErrors_(0) * kinkResidualErrors_(0);
-    localCovariance(1, 1) = kinkResidualErrors_(1) * kinkResidualErrors_(1);      
+    localCovariance(1, 1) = kinkResidualErrors_(1) * kinkResidualErrors_(1);
     return MeasurementOnPlane(getKinks(), localCovariance, sharedPlane_, rep_, new genfit::HMatrixUV());
-    
-  } 
-  
-  TVectorD GblFitterInfo::getKinks() const {
+
+  }
+
+  TVectorD GblFitterInfo::getKinks() const
+  {
     TVectorD kinks(2);
     kinks.Zero();
-    
+
     TVectorD stateDiff(getFittedState(true).getState() - getFittedState(false).getState());
     kinks(0) = -stateDiff(1);
     kinks(1) = -stateDiff(2);
-    
-    return kinks;      
+
+    return kinks;
   }
-  
-  MeasurementOnPlane GblFitterInfo::getMeasurement() const{
-    return MeasurementOnPlane(measurement_, measCov_, sharedPlane_, rep_, hasMeasurements() ? trackPoint_->getRawMeasurement(0)->constructHMatrix(rep_) : new HMatrixUV() );
+
+  MeasurementOnPlane GblFitterInfo::getMeasurement() const
+  {
+    return MeasurementOnPlane(measurement_, measCov_, sharedPlane_, rep_,
+                              hasMeasurements() ? trackPoint_->getRawMeasurement(0)->constructHMatrix(rep_) : new HMatrixUV());
   }
-  
-  bool GblFitterInfo::checkConsistency(const genfit::PruneFlags*) const {
+
+  bool GblFitterInfo::checkConsistency(const genfit::PruneFlags*) const
+  {
     //TODO
-    return true;      
+    return true;
   }
-  
-  GblFitterInfo* GblFitterInfo::clone() const {
-    
+
+  GblFitterInfo* GblFitterInfo::clone() const
+  {
+
     GblFitterInfo* retVal = new GblFitterInfo(this->getTrackPoint(), this->getRep());
-    
+
     retVal->setPlane(sharedPlane_);
-    
+
     retVal->jacobian_ = jacobian_;
     retVal->measResiduals_ = measResiduals_;
     retVal->measResidualErrors_ = measResidualErrors_;
@@ -505,110 +527,112 @@ namespace genfit {
     retVal->measurement_ = measurement_;
     retVal->measCov_ = measCov_;
     retVal->hMatrix_ = hMatrix_;
-    
+
     return retVal;
   }
-  
-  void GblFitterInfo::Print(const Option_t*) const {
+
+  void GblFitterInfo::Print(const Option_t*) const
+  {
     //TODO
     std::cout << "=============================================================================================" << std::endl;
     std::cout << " >>>  GblFitterInfo " << std::endl;
     std::cout << "      ************* " << std::endl;
-    
-    std::cout << "                      rep: " << rep_ << ", trackpoint: " << trackPoint_ << ", plane: " << sharedPlane_.get() << std::endl;
+
+    std::cout << "                      rep: " << rep_ << ", trackpoint: " << trackPoint_ << ", plane: " << sharedPlane_.get() <<
+              std::endl;
     sharedPlane_->Print();
     std::cout << std::endl;
-    
+
     std::cout << "=============================================================================================" << std::endl;
     std::cout << "     |          PREDICTIONS            |   REFERENCE    |  Corrections from last iteration  |" << std::endl;
     std::cout << "     | (+)prediction  | (-)prediction  |     state      |  (+)correction |  (-) correction  |" << std::endl;
     std::cout << "---------------------------------------------------------------------------------------------" << std::endl;
-    
-    for (int i = 0; i <5; i++) {
+
+    for (int i = 0; i < 5; i++) {
       std::cout << std::left;
       std::cout << " ";
-      if (i==0)
+      if (i == 0)
         std::cout << "q/p";
-      if (i==1)
+      if (i == 1)
         std::cout << "u' ";
-      if (i==2)
+      if (i == 2)
         std::cout << "v' ";
-      if (i==3)
+      if (i == 3)
         std::cout << "u  ";
-      if (i==4)
+      if (i == 4)
         std::cout << "v  ";
-      std::cout << " | " 
-      << std::setw(12) << fwdPrediction_(i)              << "   | "
-      << std::setw(12) << bwdPrediction_(i)              << "   | "
-      << std::setw(12) << refPrediction_(i)              << "   | "
-      << std::setw(12) << fwdStateCorrection_(i)           << "   | "
-      << std::setw(12) << bwdStateCorrection_(i)           << std::endl;
+      std::cout << " | "
+                << std::setw(12) << fwdPrediction_(i)              << "   | "
+                << std::setw(12) << bwdPrediction_(i)              << "   | "
+                << std::setw(12) << refPrediction_(i)              << "   | "
+                << std::setw(12) << fwdStateCorrection_(i)           << "   | "
+                << std::setw(12) << bwdStateCorrection_(i)           << std::endl;
     }
-    std::cout << "=============================================================================================" << std::endl;    
-    
+    std::cout << "=============================================================================================" << std::endl;
+
     if (hasMeasurements()) {
       std::cout << "     | Meas. residual |     measurement - prediction    |   Down-weight  |   Fit+meas Err.  |" << std::endl;
       std::cout << "     |                |                                 |                |   -diagonaliz.   |" << std::endl;
       std::cout << "---------------------------------------------------------------------------------------------" << std::endl;
-      
+
       TVectorD residual = getResidual().getState();
-      if (residual.GetNoElements()<2) {
+      if (residual.GetNoElements() < 2) {
         residual.ResizeTo(2);
         residual.Zero();
         if (trackPoint_->getRawMeasurement(0)->constructHMatrix(getRep())->isEqual(genfit::HMatrixU()))
           residual(0) = getResidual().getState()(0);
         else
           residual(1) = getResidual().getState()(0);
-        
+
       }
-      std::cout << " u   | " 
-      << std::setw(12) << measResiduals_(0)      << "   |  "      
-      << std::setw(12) << residual(0)            << "                   |  "
-      << std::setw(12) << measDownWeights_(0)    << "  |  "
-      << std::setw(12) << measResidualErrors_(0) 
-      << std::endl;
-      
-      std::cout << " v   | " 
-      << std::setw(12) << measResiduals_(1)      << "   |  "      
-      << std::setw(12) << residual(1)            << "                   |  "
-      << std::setw(12) << measDownWeights_(1)    << "  |  "
-      << std::setw(12) << measResidualErrors_(1) 
-      << std::endl;
-      
+      std::cout << " u   | "
+                << std::setw(12) << measResiduals_(0)      << "   |  "
+                << std::setw(12) << residual(0)            << "                   |  "
+                << std::setw(12) << measDownWeights_(0)    << "  |  "
+                << std::setw(12) << measResidualErrors_(0)
+                << std::endl;
+
+      std::cout << " v   | "
+                << std::setw(12) << measResiduals_(1)      << "   |  "
+                << std::setw(12) << residual(1)            << "                   |  "
+                << std::setw(12) << measDownWeights_(1)    << "  |  "
+                << std::setw(12) << measResidualErrors_(1)
+                << std::endl;
+
       std::cout << "---------------------------------------------------------------------------------------------" << std::endl;
     }
-    
+
     std::cout << "     | Kink residual  |  Residual of slope difference   |   Down-weight  |   Fit Kink Err.  |" << std::endl;
     std::cout << "     | -diagonalized  |   - (   (+)pred - (-)pred   )   |                |   -diagonaliz.   |" << std::endl;
     std::cout << "---------------------------------------------------------------------------------------------" << std::endl;
-    
-    std::cout << " u'  | " 
-    << std::setw(12) << kinkResiduals_(0)        << "   |  "            
-    << std::setw(12) << getKinks()(0)            << "                   |  "
-    << std::setw(12) << kinkDownWeights_(0)      << "  |  "
-    << std::setw(12) << kinkResidualErrors_(0) 
-    << std::endl;
-    
-    std::cout << " v'  | " 
-    << std::setw(12) << kinkResiduals_(1)        << "   |  "            
-    << std::setw(12) << getKinks()(1)            << "                   |  "
-    << std::setw(12) << kinkDownWeights_(1)      << "  |  "
-    << std::setw(12) << kinkResidualErrors_(1) 
-    << std::endl;
-    std::cout << "=============================================================================================" << std::endl;    
+
+    std::cout << " u'  | "
+              << std::setw(12) << kinkResiduals_(0)        << "   |  "
+              << std::setw(12) << getKinks()(0)            << "                   |  "
+              << std::setw(12) << kinkDownWeights_(0)      << "  |  "
+              << std::setw(12) << kinkResidualErrors_(0)
+              << std::endl;
+
+    std::cout << " v'  | "
+              << std::setw(12) << kinkResiduals_(1)        << "   |  "
+              << std::setw(12) << getKinks()(1)            << "                   |  "
+              << std::setw(12) << kinkDownWeights_(1)      << "  |  "
+              << std::setw(12) << kinkResidualErrors_(1)
+              << std::endl;
+    std::cout << "=============================================================================================" << std::endl;
     std::cout << "Measurement: "; measurement_.Print();
-    
+
     std::cout << "H Matrix: "; hMatrix_.Print();
-    
+
     std::cout << "Measurement covariance: "; measCov_.Print();
-    
+
     std::cout << "Jacobian: "; jacobian_.Print();
     std::cout << "Backward covariance: "; bwdCov_.Print();
     std::cout << "Forward covariance : "; fwdCov_.Print();
-    
-    std::cout << "=============================================================================================" << std::endl;    
-    
+
+    std::cout << "=============================================================================================" << std::endl;
+
   }
 
-  
+
 } // end of namespace genfit

--- a/GBL/src/GblPoint.cc
+++ b/GBL/src/GblPoint.cc
@@ -33,479 +33,510 @@
 namespace gbl {
 
 /// Create a point.
-/**
- * Create point on (initial) trajectory. Needs transformation jacobian from previous point.
- * \param [in] aJacobian Transformation jacobian from previous point
- */
-GblPoint::GblPoint(const TMatrixD &aJacobian) :
-		theLabel(0), theOffset(0), measDim(0), transFlag(false), measTransformation(), scatFlag(
-				false), localDerivatives(), globalLabels(), globalDerivatives() {
+  /**
+   * Create point on (initial) trajectory. Needs transformation jacobian from previous point.
+   * \param [in] aJacobian Transformation jacobian from previous point
+   */
+  GblPoint::GblPoint(const TMatrixD& aJacobian) :
+    theLabel(0), theOffset(0), measDim(0), transFlag(false), measTransformation(), scatFlag(
+      false), localDerivatives(), globalLabels(), globalDerivatives()
+  {
 
-	for (unsigned int i = 0; i < 5; ++i) {
-		for (unsigned int j = 0; j < 5; ++j) {
-			p2pJacobian(i, j) = aJacobian(i, j);
-		}
-	}
-}
+    for (unsigned int i = 0; i < 5; ++i) {
+      for (unsigned int j = 0; j < 5; ++j) {
+        p2pJacobian(i, j) = aJacobian(i, j);
+      }
+    }
+  }
 
-GblPoint::GblPoint(const SMatrix55 &aJacobian) :
-		theLabel(0), theOffset(0), p2pJacobian(aJacobian), measDim(0), transFlag(
-				false), measTransformation(), scatFlag(false), localDerivatives(), globalLabels(), globalDerivatives() {
+  GblPoint::GblPoint(const SMatrix55& aJacobian) :
+    theLabel(0), theOffset(0), p2pJacobian(aJacobian), measDim(0), transFlag(
+      false), measTransformation(), scatFlag(false), localDerivatives(), globalLabels(), globalDerivatives()
+  {
 
-}
+  }
 
-GblPoint::~GblPoint() {
-}
-
-/// Add a measurement to a point.
-/**
- * Add measurement (in meas. system) with diagonal precision (inverse covariance) matrix.
- * ((up to) 2D: position, 4D: slope+position, 5D: curvature+slope+position)
- * \param [in] aProjection Projection from local to measurement system
- * \param [in] aResiduals Measurement residuals
- * \param [in] aPrecision Measurement precision (diagonal)
- * \param [in] minPrecision Minimal precision to accept measurement
- */
-void GblPoint::addMeasurement(const TMatrixD &aProjection,
-		const TVectorD &aResiduals, const TVectorD &aPrecision,
-		double minPrecision) {
-	measDim = aResiduals.GetNrows();
-	unsigned int iOff = 5 - measDim;
-	for (unsigned int i = 0; i < measDim; ++i) {
-		measResiduals(iOff + i) = aResiduals[i];
-		measPrecision(iOff + i) = (
-				aPrecision[i] >= minPrecision ? aPrecision[i] : 0.);
-		for (unsigned int j = 0; j < measDim; ++j) {
-			measProjection(iOff + i, iOff + j) = aProjection(i, j);
-		}
-	}
-}
+  GblPoint::~GblPoint()
+  {
+  }
 
 /// Add a measurement to a point.
-/**
- * Add measurement (in meas. system) with arbitrary precision (inverse covariance) matrix.
- * Will be diagonalized.
- * ((up to) 2D: position, 4D: slope+position, 5D: curvature+slope+position)
- * \param [in] aProjection Projection from local to measurement system
- * \param [in] aResiduals Measurement residuals
- * \param [in] aPrecision Measurement precision (matrix)
- * \param [in] minPrecision Minimal precision to accept measurement
- */
-void GblPoint::addMeasurement(const TMatrixD &aProjection,
-		const TVectorD &aResiduals, const TMatrixDSym &aPrecision,
-		double minPrecision) {
-	measDim = aResiduals.GetNrows();
-	TMatrixDSymEigen measEigen(aPrecision);
-	measTransformation.ResizeTo(measDim, measDim);
-	measTransformation = measEigen.GetEigenVectors();
-	measTransformation.T();
-	transFlag = true;
-	TVectorD transResiduals = measTransformation * aResiduals;
-	TVectorD transPrecision = measEigen.GetEigenValues();
-	TMatrixD transProjection = measTransformation * aProjection;
-	unsigned int iOff = 5 - measDim;
-	for (unsigned int i = 0; i < measDim; ++i) {
-		measResiduals(iOff + i) = transResiduals[i];
-		measPrecision(iOff + i) = (
-				transPrecision[i] >= minPrecision ? transPrecision[i] : 0.);
-		for (unsigned int j = 0; j < measDim; ++j) {
-			measProjection(iOff + i, iOff + j) = transProjection(i, j);
-		}
-	}
-}
+  /**
+   * Add measurement (in meas. system) with diagonal precision (inverse covariance) matrix.
+   * ((up to) 2D: position, 4D: slope+position, 5D: curvature+slope+position)
+   * \param [in] aProjection Projection from local to measurement system
+   * \param [in] aResiduals Measurement residuals
+   * \param [in] aPrecision Measurement precision (diagonal)
+   * \param [in] minPrecision Minimal precision to accept measurement
+   */
+  void GblPoint::addMeasurement(const TMatrixD& aProjection,
+                                const TVectorD& aResiduals, const TVectorD& aPrecision,
+                                double minPrecision)
+  {
+    measDim = aResiduals.GetNrows();
+    unsigned int iOff = 5 - measDim;
+    for (unsigned int i = 0; i < measDim; ++i) {
+      measResiduals(iOff + i) = aResiduals[i];
+      measPrecision(iOff + i) = (
+                                  aPrecision[i] >= minPrecision ? aPrecision[i] : 0.);
+      for (unsigned int j = 0; j < measDim; ++j) {
+        measProjection(iOff + i, iOff + j) = aProjection(i, j);
+      }
+    }
+  }
 
 /// Add a measurement to a point.
-/**
- * Add measurement in local system with diagonal precision (inverse covariance) matrix.
- * ((up to) 2D: position, 4D: slope+position, 5D: curvature+slope+position)
- * \param [in] aResiduals Measurement residuals
- * \param [in] aPrecision Measurement precision (diagonal)
- * \param [in] minPrecision Minimal precision to accept measurement
- */
-void GblPoint::addMeasurement(const TVectorD &aResiduals,
-		const TVectorD &aPrecision, double minPrecision) {
-	measDim = aResiduals.GetNrows();
-	unsigned int iOff = 5 - measDim;
-	for (unsigned int i = 0; i < measDim; ++i) {
-		measResiduals(iOff + i) = aResiduals[i];
-		measPrecision(iOff + i) = (
-				aPrecision[i] >= minPrecision ? aPrecision[i] : 0.);
-	}
-	measProjection = ROOT::Math::SMatrixIdentity();
-}
+  /**
+   * Add measurement (in meas. system) with arbitrary precision (inverse covariance) matrix.
+   * Will be diagonalized.
+   * ((up to) 2D: position, 4D: slope+position, 5D: curvature+slope+position)
+   * \param [in] aProjection Projection from local to measurement system
+   * \param [in] aResiduals Measurement residuals
+   * \param [in] aPrecision Measurement precision (matrix)
+   * \param [in] minPrecision Minimal precision to accept measurement
+   */
+  void GblPoint::addMeasurement(const TMatrixD& aProjection,
+                                const TVectorD& aResiduals, const TMatrixDSym& aPrecision,
+                                double minPrecision)
+  {
+    measDim = aResiduals.GetNrows();
+    TMatrixDSymEigen measEigen(aPrecision);
+    measTransformation.ResizeTo(measDim, measDim);
+    measTransformation = measEigen.GetEigenVectors();
+    measTransformation.T();
+    transFlag = true;
+    TVectorD transResiduals = measTransformation * aResiduals;
+    TVectorD transPrecision = measEigen.GetEigenValues();
+    TMatrixD transProjection = measTransformation * aProjection;
+    unsigned int iOff = 5 - measDim;
+    for (unsigned int i = 0; i < measDim; ++i) {
+      measResiduals(iOff + i) = transResiduals[i];
+      measPrecision(iOff + i) = (
+                                  transPrecision[i] >= minPrecision ? transPrecision[i] : 0.);
+      for (unsigned int j = 0; j < measDim; ++j) {
+        measProjection(iOff + i, iOff + j) = transProjection(i, j);
+      }
+    }
+  }
 
 /// Add a measurement to a point.
-/**
- * Add measurement in local system with arbitrary precision (inverse covariance) matrix.
- * Will be diagonalized.
- * ((up to) 2D: position, 4D: slope+position, 5D: curvature+slope+position)
- * \param [in] aResiduals Measurement residuals
- * \param [in] aPrecision Measurement precision (matrix)
- * \param [in] minPrecision Minimal precision to accept measurement
- */
-void GblPoint::addMeasurement(const TVectorD &aResiduals,
-		const TMatrixDSym &aPrecision, double minPrecision) {
-	measDim = aResiduals.GetNrows();
-	TMatrixDSymEigen measEigen(aPrecision);
-	measTransformation.ResizeTo(measDim, measDim);
-	measTransformation = measEigen.GetEigenVectors();
-	measTransformation.T();
-	transFlag = true;
-	TVectorD transResiduals = measTransformation * aResiduals;
-	TVectorD transPrecision = measEigen.GetEigenValues();
-	unsigned int iOff = 5 - measDim;
-	for (unsigned int i = 0; i < measDim; ++i) {
-		measResiduals(iOff + i) = transResiduals[i];
-		measPrecision(iOff + i) = (
-				transPrecision[i] >= minPrecision ? transPrecision[i] : 0.);
-		for (unsigned int j = 0; j < measDim; ++j) {
-			measProjection(iOff + i, iOff + j) = measTransformation(i, j);
-		}
-	}
-}
+  /**
+   * Add measurement in local system with diagonal precision (inverse covariance) matrix.
+   * ((up to) 2D: position, 4D: slope+position, 5D: curvature+slope+position)
+   * \param [in] aResiduals Measurement residuals
+   * \param [in] aPrecision Measurement precision (diagonal)
+   * \param [in] minPrecision Minimal precision to accept measurement
+   */
+  void GblPoint::addMeasurement(const TVectorD& aResiduals,
+                                const TVectorD& aPrecision, double minPrecision)
+  {
+    measDim = aResiduals.GetNrows();
+    unsigned int iOff = 5 - measDim;
+    for (unsigned int i = 0; i < measDim; ++i) {
+      measResiduals(iOff + i) = aResiduals[i];
+      measPrecision(iOff + i) = (
+                                  aPrecision[i] >= minPrecision ? aPrecision[i] : 0.);
+    }
+    measProjection = ROOT::Math::SMatrixIdentity();
+  }
+
+/// Add a measurement to a point.
+  /**
+   * Add measurement in local system with arbitrary precision (inverse covariance) matrix.
+   * Will be diagonalized.
+   * ((up to) 2D: position, 4D: slope+position, 5D: curvature+slope+position)
+   * \param [in] aResiduals Measurement residuals
+   * \param [in] aPrecision Measurement precision (matrix)
+   * \param [in] minPrecision Minimal precision to accept measurement
+   */
+  void GblPoint::addMeasurement(const TVectorD& aResiduals,
+                                const TMatrixDSym& aPrecision, double minPrecision)
+  {
+    measDim = aResiduals.GetNrows();
+    TMatrixDSymEigen measEigen(aPrecision);
+    measTransformation.ResizeTo(measDim, measDim);
+    measTransformation = measEigen.GetEigenVectors();
+    measTransformation.T();
+    transFlag = true;
+    TVectorD transResiduals = measTransformation * aResiduals;
+    TVectorD transPrecision = measEigen.GetEigenValues();
+    unsigned int iOff = 5 - measDim;
+    for (unsigned int i = 0; i < measDim; ++i) {
+      measResiduals(iOff + i) = transResiduals[i];
+      measPrecision(iOff + i) = (
+                                  transPrecision[i] >= minPrecision ? transPrecision[i] : 0.);
+      for (unsigned int j = 0; j < measDim; ++j) {
+        measProjection(iOff + i, iOff + j) = measTransformation(i, j);
+      }
+    }
+  }
 
 /// Check for measurement at a point.
-/**
- * Get dimension of measurement (0 = none).
- * \return measurement dimension
- */
-unsigned int GblPoint::hasMeasurement() const {
-	return measDim;
-}
+  /**
+   * Get dimension of measurement (0 = none).
+   * \return measurement dimension
+   */
+  unsigned int GblPoint::hasMeasurement() const
+  {
+    return measDim;
+  }
 
 /// Retrieve measurement of a point.
-/**
- * \param [out] aProjection Projection from (diagonalized) measurement to local system
- * \param [out] aResiduals Measurement residuals
- * \param [out] aPrecision Measurement precision (diagonal)
- */
-void GblPoint::getMeasurement(SMatrix55 &aProjection, SVector5 &aResiduals,
-		SVector5 &aPrecision) const {
-	aProjection = measProjection;
-	aResiduals = measResiduals;
-	aPrecision = measPrecision;
-}
+  /**
+   * \param [out] aProjection Projection from (diagonalized) measurement to local system
+   * \param [out] aResiduals Measurement residuals
+   * \param [out] aPrecision Measurement precision (diagonal)
+   */
+  void GblPoint::getMeasurement(SMatrix55& aProjection, SVector5& aResiduals,
+                                SVector5& aPrecision) const
+  {
+    aProjection = measProjection;
+    aResiduals = measResiduals;
+    aPrecision = measPrecision;
+  }
 
 /// Get measurement transformation (from diagonalization).
-/**
- * \param [out] aTransformation Transformation matrix
- */
-void GblPoint::getMeasTransformation(TMatrixD &aTransformation) const {
-	aTransformation.ResizeTo(measDim, measDim);
-	if (transFlag) {
-		aTransformation = measTransformation;
-	} else {
-		aTransformation.UnitMatrix();
-	}
-}
+  /**
+   * \param [out] aTransformation Transformation matrix
+   */
+  void GblPoint::getMeasTransformation(TMatrixD& aTransformation) const
+  {
+    aTransformation.ResizeTo(measDim, measDim);
+    if (transFlag) {
+      aTransformation = measTransformation;
+    } else {
+      aTransformation.UnitMatrix();
+    }
+  }
 
 /// Add a (thin) scatterer to a point.
-/**
- * Add scatterer with diagonal precision (inverse covariance) matrix.
- * Changes local track direction.
- *
- * \param [in] aResiduals Scatterer residuals
- * \param [in] aPrecision Scatterer precision (diagonal of inverse covariance matrix)
- */
-void GblPoint::addScatterer(const TVectorD &aResiduals,
-		const TVectorD &aPrecision) {
-	scatFlag = true;
-	scatResiduals(0) = aResiduals[0];
-	scatResiduals(1) = aResiduals[1];
-	scatPrecision(0) = aPrecision[0];
-	scatPrecision(1) = aPrecision[1];
-	scatTransformation = ROOT::Math::SMatrixIdentity();
-}
+  /**
+   * Add scatterer with diagonal precision (inverse covariance) matrix.
+   * Changes local track direction.
+   *
+   * \param [in] aResiduals Scatterer residuals
+   * \param [in] aPrecision Scatterer precision (diagonal of inverse covariance matrix)
+   */
+  void GblPoint::addScatterer(const TVectorD& aResiduals,
+                              const TVectorD& aPrecision)
+  {
+    scatFlag = true;
+    scatResiduals(0) = aResiduals[0];
+    scatResiduals(1) = aResiduals[1];
+    scatPrecision(0) = aPrecision[0];
+    scatPrecision(1) = aPrecision[1];
+    scatTransformation = ROOT::Math::SMatrixIdentity();
+  }
 
 /// Add a (thin) scatterer to a point.
-/**
- * Add scatterer with arbitrary precision (inverse covariance) matrix.
- * Will be diagonalized. Changes local track direction.
- *
- * The precision matrix for the local slopes is defined by the
- * angular scattering error theta_0 and the scalar products c_1, c_2 of the
- * offset directions in the local frame with the track direction:
- *
- *            (1 - c_1*c_1 - c_2*c_2)   |  1 - c_1*c_1     - c_1*c_2  |
- *       P =  ----------------------- * |                             |
- *                theta_0*theta_0       |    - c_1*c_2   1 - c_2*c_2  |
- *
- * \param [in] aResiduals Scatterer residuals
- * \param [in] aPrecision Scatterer precision (matrix)
- */
-void GblPoint::addScatterer(const TVectorD &aResiduals,
-		const TMatrixDSym &aPrecision) {
-	scatFlag = true;
-	TMatrixDSymEigen scatEigen(aPrecision);
-	TMatrixD aTransformation = scatEigen.GetEigenVectors();
-	aTransformation.T();
-	TVectorD transResiduals = aTransformation * aResiduals;
-	TVectorD transPrecision = scatEigen.GetEigenValues();
-	for (unsigned int i = 0; i < 2; ++i) {
-		scatResiduals(i) = transResiduals[i];
-		scatPrecision(i) = transPrecision[i];
-		for (unsigned int j = 0; j < 2; ++j) {
-			scatTransformation(i, j) = aTransformation(i, j);
-		}
-	}
-}
+  /**
+   * Add scatterer with arbitrary precision (inverse covariance) matrix.
+   * Will be diagonalized. Changes local track direction.
+   *
+   * The precision matrix for the local slopes is defined by the
+   * angular scattering error theta_0 and the scalar products c_1, c_2 of the
+   * offset directions in the local frame with the track direction:
+   *
+   *            (1 - c_1*c_1 - c_2*c_2)   |  1 - c_1*c_1     - c_1*c_2  |
+   *       P =  ----------------------- * |                             |
+   *                theta_0*theta_0       |    - c_1*c_2   1 - c_2*c_2  |
+   *
+   * \param [in] aResiduals Scatterer residuals
+   * \param [in] aPrecision Scatterer precision (matrix)
+   */
+  void GblPoint::addScatterer(const TVectorD& aResiduals,
+                              const TMatrixDSym& aPrecision)
+  {
+    scatFlag = true;
+    TMatrixDSymEigen scatEigen(aPrecision);
+    TMatrixD aTransformation = scatEigen.GetEigenVectors();
+    aTransformation.T();
+    TVectorD transResiduals = aTransformation * aResiduals;
+    TVectorD transPrecision = scatEigen.GetEigenValues();
+    for (unsigned int i = 0; i < 2; ++i) {
+      scatResiduals(i) = transResiduals[i];
+      scatPrecision(i) = transPrecision[i];
+      for (unsigned int j = 0; j < 2; ++j) {
+        scatTransformation(i, j) = aTransformation(i, j);
+      }
+    }
+  }
 
 /// Check for scatterer at a point.
-bool GblPoint::hasScatterer() const {
-	return scatFlag;
-}
+  bool GblPoint::hasScatterer() const
+  {
+    return scatFlag;
+  }
 
 /// Retrieve scatterer of a point.
-/**
- * \param [out] aTransformation Scatterer transformation from diagonalization
- * \param [out] aResiduals Scatterer residuals
- * \param [out] aPrecision Scatterer precision (diagonal)
- */
-void GblPoint::getScatterer(SMatrix22 &aTransformation, SVector2 &aResiduals,
-		SVector2 &aPrecision) const {
-	aTransformation = scatTransformation;
-	aResiduals = scatResiduals;
-	aPrecision = scatPrecision;
-}
+  /**
+   * \param [out] aTransformation Scatterer transformation from diagonalization
+   * \param [out] aResiduals Scatterer residuals
+   * \param [out] aPrecision Scatterer precision (diagonal)
+   */
+  void GblPoint::getScatterer(SMatrix22& aTransformation, SVector2& aResiduals,
+                              SVector2& aPrecision) const
+  {
+    aTransformation = scatTransformation;
+    aResiduals = scatResiduals;
+    aPrecision = scatPrecision;
+  }
 
 /// Get scatterer transformation (from diagonalization).
-/**
- * \param [out] aTransformation Transformation matrix
- */
-void GblPoint::getScatTransformation(TMatrixD &aTransformation) const {
-	aTransformation.ResizeTo(2, 2);
-	if (scatFlag) {
-		for (unsigned int i = 0; i < 2; ++i) {
-			for (unsigned int j = 0; j < 2; ++j) {
-				aTransformation(i, j) = scatTransformation(i, j);
-			}
-		}
-	} else {
-		aTransformation.UnitMatrix();
-	}
-}
+  /**
+   * \param [out] aTransformation Transformation matrix
+   */
+  void GblPoint::getScatTransformation(TMatrixD& aTransformation) const
+  {
+    aTransformation.ResizeTo(2, 2);
+    if (scatFlag) {
+      for (unsigned int i = 0; i < 2; ++i) {
+        for (unsigned int j = 0; j < 2; ++j) {
+          aTransformation(i, j) = scatTransformation(i, j);
+        }
+      }
+    } else {
+      aTransformation.UnitMatrix();
+    }
+  }
 
 /// Add local derivatives to a point.
-/**
- * Point needs to have a measurement.
- * \param [in] aDerivatives Local derivatives (matrix)
- */
-void GblPoint::addLocals(const TMatrixD &aDerivatives) {
-	if (measDim) {
-		localDerivatives.ResizeTo(aDerivatives);
-		if (transFlag) {
-			localDerivatives = measTransformation * aDerivatives;
-		} else {
-			localDerivatives = aDerivatives;
-		}
-	}
-}
+  /**
+   * Point needs to have a measurement.
+   * \param [in] aDerivatives Local derivatives (matrix)
+   */
+  void GblPoint::addLocals(const TMatrixD& aDerivatives)
+  {
+    if (measDim) {
+      localDerivatives.ResizeTo(aDerivatives);
+      if (transFlag) {
+        localDerivatives = measTransformation * aDerivatives;
+      } else {
+        localDerivatives = aDerivatives;
+      }
+    }
+  }
 
 /// Retrieve number of local derivatives from a point.
-unsigned int GblPoint::getNumLocals() const {
-	return localDerivatives.GetNcols();
-}
+  unsigned int GblPoint::getNumLocals() const
+  {
+    return localDerivatives.GetNcols();
+  }
 
 /// Retrieve local derivatives from a point.
-const TMatrixD& GblPoint::getLocalDerivatives() const {
-	return localDerivatives;
-}
+  const TMatrixD& GblPoint::getLocalDerivatives() const
+  {
+    return localDerivatives;
+  }
 
 /// Add global derivatives to a point.
-/**
- * Point needs to have a measurement.
- * \param [in] aLabels Global derivatives labels
- * \param [in] aDerivatives Global derivatives (matrix)
- */
-void GblPoint::addGlobals(const std::vector<int> &aLabels,
-		const TMatrixD &aDerivatives) {
-	if (measDim) {
-		globalLabels = aLabels;
-		globalDerivatives.ResizeTo(aDerivatives);
-		if (transFlag) {
-			globalDerivatives = measTransformation * aDerivatives;
-		} else {
-			globalDerivatives = aDerivatives;
-		}
+  /**
+   * Point needs to have a measurement.
+   * \param [in] aLabels Global derivatives labels
+   * \param [in] aDerivatives Global derivatives (matrix)
+   */
+  void GblPoint::addGlobals(const std::vector<int>& aLabels,
+                            const TMatrixD& aDerivatives)
+  {
+    if (measDim) {
+      globalLabels = aLabels;
+      globalDerivatives.ResizeTo(aDerivatives);
+      if (transFlag) {
+        globalDerivatives = measTransformation * aDerivatives;
+      } else {
+        globalDerivatives = aDerivatives;
+      }
 
-	}
-}
+    }
+  }
 
 /// Retrieve number of global derivatives from a point.
-unsigned int GblPoint::getNumGlobals() const {
-	return globalDerivatives.GetNcols();
-}
+  unsigned int GblPoint::getNumGlobals() const
+  {
+    return globalDerivatives.GetNcols();
+  }
 
 /// Retrieve global derivatives labels from a point.
-std::vector<int> GblPoint::getGlobalLabels() const {
-	return globalLabels;
-}
+  std::vector<int> GblPoint::getGlobalLabels() const
+  {
+    return globalLabels;
+  }
 
 /// Retrieve global derivatives from a point.
-const TMatrixD& GblPoint::getGlobalDerivatives() const {
-	return globalDerivatives;
-}
+  const TMatrixD& GblPoint::getGlobalDerivatives() const
+  {
+    return globalDerivatives;
+  }
 
 /// Define label of point (by GBLTrajectory constructor)
-/**
- * \param [in] aLabel Label identifying point
- */
-void GblPoint::setLabel(unsigned int aLabel) {
-	theLabel = aLabel;
-}
+  /**
+   * \param [in] aLabel Label identifying point
+   */
+  void GblPoint::setLabel(unsigned int aLabel)
+  {
+    theLabel = aLabel;
+  }
 
 /// Retrieve label of point
-unsigned int GblPoint::getLabel() const {
-	return theLabel;
-}
+  unsigned int GblPoint::getLabel() const
+  {
+    return theLabel;
+  }
 
 /// Define offset for point (by GBLTrajectory constructor)
-/**
- * \param [in] anOffset Offset number
- */
-void GblPoint::setOffset(int anOffset) {
-	theOffset = anOffset;
-}
+  /**
+   * \param [in] anOffset Offset number
+   */
+  void GblPoint::setOffset(int anOffset)
+  {
+    theOffset = anOffset;
+  }
 
 /// Retrieve offset for point
-int GblPoint::getOffset() const {
-	return theOffset;
-}
+  int GblPoint::getOffset() const
+  {
+    return theOffset;
+  }
 
 /// Retrieve point-to-(previous)point jacobian
-const SMatrix55& GblPoint::getP2pJacobian() const {
-	return p2pJacobian;
-}
+  const SMatrix55& GblPoint::getP2pJacobian() const
+  {
+    return p2pJacobian;
+  }
 
 /// Define jacobian to previous scatterer (by GBLTrajectory constructor)
-/**
- * \param [in] aJac Jacobian
- */
-void GblPoint::addPrevJacobian(const SMatrix55 &aJac) {
-	int ifail = 0;
+  /**
+   * \param [in] aJac Jacobian
+   */
+  void GblPoint::addPrevJacobian(const SMatrix55& aJac)
+  {
+    int ifail = 0;
 // to optimize: need only two last rows of inverse
-//	prevJacobian = aJac.InverseFast(ifail);
+//  prevJacobian = aJac.InverseFast(ifail);
 //  block matrix algebra
-	SMatrix23 CA = aJac.Sub<SMatrix23>(3, 0)
-			* aJac.Sub<SMatrix33>(0, 0).InverseFast(ifail); // C*A^-1
-	SMatrix22 DCAB = aJac.Sub<SMatrix22>(3, 3) - CA * aJac.Sub<SMatrix32>(0, 3); // D - C*A^-1 *B
-	DCAB.InvertFast();
-	prevJacobian.Place_at(DCAB, 3, 3);
-	prevJacobian.Place_at(-DCAB * CA, 3, 0);
-}
+    SMatrix23 CA = aJac.Sub<SMatrix23>(3, 0)
+                   * aJac.Sub<SMatrix33>(0, 0).InverseFast(ifail); // C*A^-1
+    SMatrix22 DCAB = aJac.Sub<SMatrix22>(3, 3) - CA * aJac.Sub<SMatrix32>(0, 3); // D - C*A^-1 *B
+    DCAB.InvertFast();
+    prevJacobian.Place_at(DCAB, 3, 3);
+    prevJacobian.Place_at(-DCAB * CA, 3, 0);
+  }
 
 /// Define jacobian to next scatterer (by GBLTrajectory constructor)
-/**
- * \param [in] aJac Jacobian
- */
-void GblPoint::addNextJacobian(const SMatrix55 &aJac) {
-	nextJacobian = aJac;
-}
+  /**
+   * \param [in] aJac Jacobian
+   */
+  void GblPoint::addNextJacobian(const SMatrix55& aJac)
+  {
+    nextJacobian = aJac;
+  }
 
 /// Retrieve derivatives of local track model
-/**
- * Linearized track model: F_u(q/p,u',u) = J*u + S*u' + d*q/p,
- * W is inverse of S, negated for backward propagation.
- * \param [in] aDirection Propagation direction (>0 forward, else backward)
- * \param [out] matW W
- * \param [out] matWJ W*J
- * \param [out] vecWd W*d
- * \exception std::overflow_error : matrix S is singular.
- */
-void GblPoint::getDerivatives(int aDirection, SMatrix22 &matW, SMatrix22 &matWJ,
-		SVector2 &vecWd) const {
+  /**
+   * Linearized track model: F_u(q/p,u',u) = J*u + S*u' + d*q/p,
+   * W is inverse of S, negated for backward propagation.
+   * \param [in] aDirection Propagation direction (>0 forward, else backward)
+   * \param [out] matW W
+   * \param [out] matWJ W*J
+   * \param [out] vecWd W*d
+   * \exception std::overflow_error : matrix S is singular.
+   */
+  void GblPoint::getDerivatives(int aDirection, SMatrix22& matW, SMatrix22& matWJ,
+                                SVector2& vecWd) const
+  {
 
-	SMatrix22 matJ;
-	SVector2 vecd;
-	if (aDirection < 1) {
-		matJ = prevJacobian.Sub<SMatrix22>(3, 3);
-		matW = -prevJacobian.Sub<SMatrix22>(3, 1);
-		vecd = prevJacobian.SubCol<SVector2>(0, 3);
-	} else {
-		matJ = nextJacobian.Sub<SMatrix22>(3, 3);
-		matW = nextJacobian.Sub<SMatrix22>(3, 1);
-		vecd = nextJacobian.SubCol<SVector2>(0, 3);
-	}
+    SMatrix22 matJ;
+    SVector2 vecd;
+    if (aDirection < 1) {
+      matJ = prevJacobian.Sub<SMatrix22>(3, 3);
+      matW = -prevJacobian.Sub<SMatrix22>(3, 1);
+      vecd = prevJacobian.SubCol<SVector2>(0, 3);
+    } else {
+      matJ = nextJacobian.Sub<SMatrix22>(3, 3);
+      matW = nextJacobian.Sub<SMatrix22>(3, 1);
+      vecd = nextJacobian.SubCol<SVector2>(0, 3);
+    }
 
-	if (!matW.InvertFast()) {
-		std::cout << " GblPoint::getDerivatives failed to invert matrix: "
-				<< matW << std::endl;
-		std::cout
-				<< " Possible reason for singular matrix: multiple GblPoints at same arc-length"
-				<< std::endl;
-		throw std::overflow_error("Singular matrix inversion exception");
-	}
-	matWJ = matW * matJ;
-	vecWd = matW * vecd;
+    if (!matW.InvertFast()) {
+      std::cout << " GblPoint::getDerivatives failed to invert matrix: "
+                << matW << std::endl;
+      std::cout
+          << " Possible reason for singular matrix: multiple GblPoints at same arc-length"
+          << std::endl;
+      throw std::overflow_error("Singular matrix inversion exception");
+    }
+    matWJ = matW * matJ;
+    vecWd = matW * vecd;
 
-}
+  }
 
 /// Print GblPoint
-/**
- * \param [in] level print level (0: minimum, >0: more)
- */
-void GblPoint::printPoint(unsigned int level) const {
-	std::cout << " GblPoint";
-	if (theLabel) {
-		std::cout << ", label " << theLabel;
-		if (theOffset >= 0) {
-			std::cout << ", offset " << theOffset;
-		}
-	}
-	if (measDim) {
-		std::cout << ", " << measDim << " measurements";
-	}
-	if (scatFlag) {
-		std::cout << ", scatterer";
-	}
-	if (transFlag) {
-		std::cout << ", diagonalized";
-	}
-	if (localDerivatives.GetNcols()) {
-		std::cout << ", " << localDerivatives.GetNcols()
-				<< " local derivatives";
-	}
-	if (globalDerivatives.GetNcols()) {
-		std::cout << ", " << globalDerivatives.GetNcols()
-				<< " global derivatives";
-	}
-	std::cout << std::endl;
-	if (level > 0) {
-		if (measDim) {
-			std::cout << "  Measurement" << std::endl;
-			std::cout << "   Projection: " << std::endl << measProjection
-					<< std::endl;
-			std::cout << "   Residuals: " << measResiduals << std::endl;
-			std::cout << "   Precision: " << measPrecision << std::endl;
-		}
-		if (scatFlag) {
-			std::cout << "  Scatterer" << std::endl;
-			std::cout << "   Residuals: " << scatResiduals << std::endl;
-			std::cout << "   Precision: " << scatPrecision << std::endl;
-		}
-		if (localDerivatives.GetNcols()) {
-			std::cout << "  Local Derivatives:" << std::endl;
-			localDerivatives.Print();
-		}
-		if (globalDerivatives.GetNcols()) {
-			std::cout << "  Global Labels:";
-			for (unsigned int i = 0; i < globalLabels.size(); ++i) {
-				std::cout << " " << globalLabels[i];
-			}
-			std::cout << std::endl;
-			std::cout << "  Global Derivatives:" << std::endl;
-			globalDerivatives.Print();
-		}
-		std::cout << "  Jacobian " << std::endl;
-		std::cout << "   Point-to-point " << std::endl << p2pJacobian
-				<< std::endl;
-		if (theLabel) {
-			std::cout << "   To previous offset " << std::endl << prevJacobian
-					<< std::endl;
-			std::cout << "   To next offset " << std::endl << nextJacobian
-					<< std::endl;
-		}
-	}
-}
+  /**
+   * \param [in] level print level (0: minimum, >0: more)
+   */
+  void GblPoint::printPoint(unsigned int level) const
+  {
+    std::cout << " GblPoint";
+    if (theLabel) {
+      std::cout << ", label " << theLabel;
+      if (theOffset >= 0) {
+        std::cout << ", offset " << theOffset;
+      }
+    }
+    if (measDim) {
+      std::cout << ", " << measDim << " measurements";
+    }
+    if (scatFlag) {
+      std::cout << ", scatterer";
+    }
+    if (transFlag) {
+      std::cout << ", diagonalized";
+    }
+    if (localDerivatives.GetNcols()) {
+      std::cout << ", " << localDerivatives.GetNcols()
+                << " local derivatives";
+    }
+    if (globalDerivatives.GetNcols()) {
+      std::cout << ", " << globalDerivatives.GetNcols()
+                << " global derivatives";
+    }
+    std::cout << std::endl;
+    if (level > 0) {
+      if (measDim) {
+        std::cout << "  Measurement" << std::endl;
+        std::cout << "   Projection: " << std::endl << measProjection
+                  << std::endl;
+        std::cout << "   Residuals: " << measResiduals << std::endl;
+        std::cout << "   Precision: " << measPrecision << std::endl;
+      }
+      if (scatFlag) {
+        std::cout << "  Scatterer" << std::endl;
+        std::cout << "   Residuals: " << scatResiduals << std::endl;
+        std::cout << "   Precision: " << scatPrecision << std::endl;
+      }
+      if (localDerivatives.GetNcols()) {
+        std::cout << "  Local Derivatives:" << std::endl;
+        localDerivatives.Print();
+      }
+      if (globalDerivatives.GetNcols()) {
+        std::cout << "  Global Labels:";
+        for (unsigned int i = 0; i < globalLabels.size(); ++i) {
+          std::cout << " " << globalLabels[i];
+        }
+        std::cout << std::endl;
+        std::cout << "  Global Derivatives:" << std::endl;
+        globalDerivatives.Print();
+      }
+      std::cout << "  Jacobian " << std::endl;
+      std::cout << "   Point-to-point " << std::endl << p2pJacobian
+                << std::endl;
+      if (theLabel) {
+        std::cout << "   To previous offset " << std::endl << prevJacobian
+                  << std::endl;
+        std::cout << "   To next offset " << std::endl << nextJacobian
+                  << std::endl;
+      }
+    }
+  }
 
 }

--- a/GBL/src/GblTrajectory.cc
+++ b/GBL/src/GblTrajectory.cc
@@ -26,7 +26,7 @@
  *  details); if not, write to the Free Software Foundation, Inc.,
  *  675 Mass Ave, Cambridge, MA 02139, USA.
  *
- *  
+ *
  *  General information
  *
  *  Introduction
@@ -136,1068 +136,1100 @@
 namespace gbl {
 
 /// Create new (simple) trajectory from list of points.
-/**
- * Curved trajectory in space (default) or without curvature (q/p) or in one
- * plane (u-direction) only.
- * \param [in] aPointList List of points
- * \param [in] flagCurv Use q/p
- * \param [in] flagU1dir Use in u1 direction
- * \param [in] flagU2dir Use in u2 direction
- */
-GblTrajectory::GblTrajectory(const std::vector<GblPoint> &aPointList,
-		bool flagCurv, bool flagU1dir, bool flagU2dir) :
-		numAllPoints(aPointList.size()), numPoints(), numOffsets(0), numInnerTrans(
-				0), numCurvature(flagCurv ? 1 : 0), numParameters(0), numLocals(
-				0), numMeasurements(0), externalPoint(0), theDimension(0), thePoints(), theData(), measDataIndex(), scatDataIndex(), externalSeed(), innerTransformations(), externalDerivatives(), externalMeasurements(), externalPrecisions() {
+  /**
+   * Curved trajectory in space (default) or without curvature (q/p) or in one
+   * plane (u-direction) only.
+   * \param [in] aPointList List of points
+   * \param [in] flagCurv Use q/p
+   * \param [in] flagU1dir Use in u1 direction
+   * \param [in] flagU2dir Use in u2 direction
+   */
+  GblTrajectory::GblTrajectory(const std::vector<GblPoint>& aPointList,
+                               bool flagCurv, bool flagU1dir, bool flagU2dir) :
+    numAllPoints(aPointList.size()), numPoints(), numOffsets(0), numInnerTrans(
+      0), numCurvature(flagCurv ? 1 : 0), numParameters(0), numLocals(
+        0), numMeasurements(0), externalPoint(0), theDimension(0), thePoints(), theData(), measDataIndex(), scatDataIndex(), externalSeed(),
+    innerTransformations(), externalDerivatives(), externalMeasurements(), externalPrecisions()
+  {
 
-	if (flagU1dir)
-		theDimension.push_back(0);
-	if (flagU2dir)
-		theDimension.push_back(1);
-	// simple (single) trajectory
-	thePoints.push_back(aPointList);
-	numPoints.push_back(numAllPoints);
-	construct(); // construct trajectory
-}
+    if (flagU1dir)
+      theDimension.push_back(0);
+    if (flagU2dir)
+      theDimension.push_back(1);
+    // simple (single) trajectory
+    thePoints.push_back(aPointList);
+    numPoints.push_back(numAllPoints);
+    construct(); // construct trajectory
+  }
 
 /// Create new (simple) trajectory from list of points with external seed.
-/**
- * Curved trajectory in space (default) or without curvature (q/p) or in one
- * plane (u-direction) only.
- * \param [in] aPointList List of points
- * \param [in] aLabel (Signed) label of point for external seed
- * (<0: in front, >0: after point, slope changes at scatterer!)
- * \param [in] aSeed Precision matrix of external seed
- * \param [in] flagCurv Use q/p
- * \param [in] flagU1dir Use in u1 direction
- * \param [in] flagU2dir Use in u2 direction
- */
-GblTrajectory::GblTrajectory(const std::vector<GblPoint> &aPointList,
-		unsigned int aLabel, const TMatrixDSym &aSeed, bool flagCurv,
-		bool flagU1dir, bool flagU2dir) :
-		numAllPoints(aPointList.size()), numPoints(), numOffsets(0), numInnerTrans(
-				0), numCurvature(flagCurv ? 1 : 0), numParameters(0), numLocals(
-				0), numMeasurements(0), externalPoint(aLabel), theDimension(0), thePoints(), theData(), measDataIndex(), scatDataIndex(), externalSeed(
-				aSeed), innerTransformations(), externalDerivatives(), externalMeasurements(), externalPrecisions() {
+  /**
+   * Curved trajectory in space (default) or without curvature (q/p) or in one
+   * plane (u-direction) only.
+   * \param [in] aPointList List of points
+   * \param [in] aLabel (Signed) label of point for external seed
+   * (<0: in front, >0: after point, slope changes at scatterer!)
+   * \param [in] aSeed Precision matrix of external seed
+   * \param [in] flagCurv Use q/p
+   * \param [in] flagU1dir Use in u1 direction
+   * \param [in] flagU2dir Use in u2 direction
+   */
+  GblTrajectory::GblTrajectory(const std::vector<GblPoint>& aPointList,
+                               unsigned int aLabel, const TMatrixDSym& aSeed, bool flagCurv,
+                               bool flagU1dir, bool flagU2dir) :
+    numAllPoints(aPointList.size()), numPoints(), numOffsets(0), numInnerTrans(
+      0), numCurvature(flagCurv ? 1 : 0), numParameters(0), numLocals(
+        0), numMeasurements(0), externalPoint(aLabel), theDimension(0), thePoints(), theData(), measDataIndex(), scatDataIndex(),
+    externalSeed(
+      aSeed), innerTransformations(), externalDerivatives(), externalMeasurements(), externalPrecisions()
+  {
 
-	if (flagU1dir)
-		theDimension.push_back(0);
-	if (flagU2dir)
-		theDimension.push_back(1);
-	// simple (single) trajectory
-	thePoints.push_back(aPointList);
-	numPoints.push_back(numAllPoints);
-	construct(); // construct trajectory
-}
+    if (flagU1dir)
+      theDimension.push_back(0);
+    if (flagU2dir)
+      theDimension.push_back(1);
+    // simple (single) trajectory
+    thePoints.push_back(aPointList);
+    numPoints.push_back(numAllPoints);
+    construct(); // construct trajectory
+  }
 
 /// Create new composed trajectory from list of points and transformations.
-/**
- * Composed of curved trajectory in space.
- * \param [in] aPointsAndTransList List containing pairs with list of points and transformation (at inner (first) point)
- */
-GblTrajectory::GblTrajectory(
-		const std::vector<std::pair<std::vector<GblPoint>, TMatrixD> > &aPointsAndTransList) :
-		numAllPoints(), numPoints(), numOffsets(0), numInnerTrans(
-				aPointsAndTransList.size()), numParameters(0), numLocals(0), numMeasurements(
-				0), externalPoint(0), theDimension(0), thePoints(), theData(), measDataIndex(), scatDataIndex(), externalSeed(), innerTransformations(), externalDerivatives(), externalMeasurements(), externalPrecisions() {
+  /**
+   * Composed of curved trajectory in space.
+   * \param [in] aPointsAndTransList List containing pairs with list of points and transformation (at inner (first) point)
+   */
+  GblTrajectory::GblTrajectory(
+    const std::vector<std::pair<std::vector<GblPoint>, TMatrixD> >& aPointsAndTransList) :
+    numAllPoints(), numPoints(), numOffsets(0), numInnerTrans(
+      aPointsAndTransList.size()), numParameters(0), numLocals(0), numMeasurements(
+        0), externalPoint(0), theDimension(0), thePoints(), theData(), measDataIndex(), scatDataIndex(), externalSeed(),
+    innerTransformations(), externalDerivatives(), externalMeasurements(), externalPrecisions()
+  {
 
-	for (unsigned int iTraj = 0; iTraj < aPointsAndTransList.size(); ++iTraj) {
-		thePoints.push_back(aPointsAndTransList[iTraj].first);
-		numPoints.push_back(thePoints.back().size());
-		numAllPoints += numPoints.back();
-		innerTransformations.push_back(aPointsAndTransList[iTraj].second);
-	}
-	theDimension.push_back(0);
-	theDimension.push_back(1);
-	numCurvature = innerTransformations[0].GetNcols();
-	construct(); // construct (composed) trajectory
-}
+    for (unsigned int iTraj = 0; iTraj < aPointsAndTransList.size(); ++iTraj) {
+      thePoints.push_back(aPointsAndTransList[iTraj].first);
+      numPoints.push_back(thePoints.back().size());
+      numAllPoints += numPoints.back();
+      innerTransformations.push_back(aPointsAndTransList[iTraj].second);
+    }
+    theDimension.push_back(0);
+    theDimension.push_back(1);
+    numCurvature = innerTransformations[0].GetNcols();
+    construct(); // construct (composed) trajectory
+  }
 
 /// Create new composed trajectory from list of points and transformations with (independent) external measurements.
-/**
- * Composed of curved trajectory in space.
- * \param [in] aPointsAndTransList List containing pairs with list of points and transformation (at inner (first) point)
- * \param [in] extDerivatives Derivatives of external measurements vs external parameters
- * \param [in] extMeasurements External measurements (residuals)
- * \param [in] extPrecisions Precision of external measurements
- */
-GblTrajectory::GblTrajectory(
-		const std::vector<std::pair<std::vector<GblPoint>, TMatrixD> > &aPointsAndTransList,
-		const TMatrixD &extDerivatives, const TVectorD &extMeasurements,
-		const TVectorD &extPrecisions) :
-		numAllPoints(), numPoints(), numOffsets(0), numInnerTrans(
-				aPointsAndTransList.size()), numParameters(0), numLocals(0), numMeasurements(
-				0), externalPoint(0), theDimension(0), thePoints(), theData(), measDataIndex(), scatDataIndex(), externalSeed(), innerTransformations(), externalDerivatives(
-				extDerivatives), externalMeasurements(extMeasurements), externalPrecisions(
-				extPrecisions) {
+  /**
+   * Composed of curved trajectory in space.
+   * \param [in] aPointsAndTransList List containing pairs with list of points and transformation (at inner (first) point)
+   * \param [in] extDerivatives Derivatives of external measurements vs external parameters
+   * \param [in] extMeasurements External measurements (residuals)
+   * \param [in] extPrecisions Precision of external measurements
+   */
+  GblTrajectory::GblTrajectory(
+    const std::vector<std::pair<std::vector<GblPoint>, TMatrixD> >& aPointsAndTransList,
+    const TMatrixD& extDerivatives, const TVectorD& extMeasurements,
+    const TVectorD& extPrecisions) :
+    numAllPoints(), numPoints(), numOffsets(0), numInnerTrans(
+      aPointsAndTransList.size()), numParameters(0), numLocals(0), numMeasurements(
+        0), externalPoint(0), theDimension(0), thePoints(), theData(), measDataIndex(), scatDataIndex(), externalSeed(),
+    innerTransformations(), externalDerivatives(
+      extDerivatives), externalMeasurements(extMeasurements), externalPrecisions(
+        extPrecisions)
+  {
 
-	for (unsigned int iTraj = 0; iTraj < aPointsAndTransList.size(); ++iTraj) {
-		thePoints.push_back(aPointsAndTransList[iTraj].first);
-		numPoints.push_back(thePoints.back().size());
-		numAllPoints += numPoints.back();
-		innerTransformations.push_back(aPointsAndTransList[iTraj].second);
-	}
-	theDimension.push_back(0);
-	theDimension.push_back(1);
-	numCurvature = innerTransformations[0].GetNcols();
-	construct(); // construct (composed) trajectory
-}
+    for (unsigned int iTraj = 0; iTraj < aPointsAndTransList.size(); ++iTraj) {
+      thePoints.push_back(aPointsAndTransList[iTraj].first);
+      numPoints.push_back(thePoints.back().size());
+      numAllPoints += numPoints.back();
+      innerTransformations.push_back(aPointsAndTransList[iTraj].second);
+    }
+    theDimension.push_back(0);
+    theDimension.push_back(1);
+    numCurvature = innerTransformations[0].GetNcols();
+    construct(); // construct (composed) trajectory
+  }
 
 /// Create new composed trajectory from list of points and transformations with (correlated) external measurements.
-/**
- * Composed of curved trajectory in space.
- * \param [in] aPointsAndTransList List containing pairs with list of points and transformation (at inner (first) point)
- * \param [in] extDerivatives Derivatives of external measurements vs external parameters
- * \param [in] extMeasurements External measurements (residuals)
- * \param [in] extPrecisions Precision of external measurements
- */
-GblTrajectory::GblTrajectory(
-		const std::vector<std::pair<std::vector<GblPoint>, TMatrixD> > &aPointsAndTransList,
-		const TMatrixD &extDerivatives, const TVectorD &extMeasurements,
-		const TMatrixDSym &extPrecisions) :
-		numAllPoints(), numPoints(), numOffsets(0), numInnerTrans(
-				aPointsAndTransList.size()), numParameters(0), numLocals(0), numMeasurements(
-				0), externalPoint(0), theDimension(0), thePoints(), theData(), measDataIndex(), scatDataIndex(), externalSeed(), innerTransformations() {
+  /**
+   * Composed of curved trajectory in space.
+   * \param [in] aPointsAndTransList List containing pairs with list of points and transformation (at inner (first) point)
+   * \param [in] extDerivatives Derivatives of external measurements vs external parameters
+   * \param [in] extMeasurements External measurements (residuals)
+   * \param [in] extPrecisions Precision of external measurements
+   */
+  GblTrajectory::GblTrajectory(
+    const std::vector<std::pair<std::vector<GblPoint>, TMatrixD> >& aPointsAndTransList,
+    const TMatrixD& extDerivatives, const TVectorD& extMeasurements,
+    const TMatrixDSym& extPrecisions) :
+    numAllPoints(), numPoints(), numOffsets(0), numInnerTrans(
+      aPointsAndTransList.size()), numParameters(0), numLocals(0), numMeasurements(
+        0), externalPoint(0), theDimension(0), thePoints(), theData(), measDataIndex(), scatDataIndex(), externalSeed(),
+    innerTransformations()
+  {
 
-	// diagonalize external measurement
-	TMatrixDSymEigen extEigen(extPrecisions);
-	TMatrixD extTransformation = extEigen.GetEigenVectors();
-	extTransformation.T();
-	externalDerivatives.ResizeTo(extDerivatives);
-	externalDerivatives = extTransformation * extDerivatives;
-	externalMeasurements.ResizeTo(extMeasurements);
-	externalMeasurements = extTransformation * extMeasurements;
-	externalPrecisions.ResizeTo(extMeasurements);
-	externalPrecisions = extEigen.GetEigenValues();
+    // diagonalize external measurement
+    TMatrixDSymEigen extEigen(extPrecisions);
+    TMatrixD extTransformation = extEigen.GetEigenVectors();
+    extTransformation.T();
+    externalDerivatives.ResizeTo(extDerivatives);
+    externalDerivatives = extTransformation * extDerivatives;
+    externalMeasurements.ResizeTo(extMeasurements);
+    externalMeasurements = extTransformation * extMeasurements;
+    externalPrecisions.ResizeTo(extMeasurements);
+    externalPrecisions = extEigen.GetEigenValues();
 
-	for (unsigned int iTraj = 0; iTraj < aPointsAndTransList.size(); ++iTraj) {
-		thePoints.push_back(aPointsAndTransList[iTraj].first);
-		numPoints.push_back(thePoints.back().size());
-		numAllPoints += numPoints.back();
-		innerTransformations.push_back(aPointsAndTransList[iTraj].second);
-	}
-	theDimension.push_back(0);
-	theDimension.push_back(1);
-	numCurvature = innerTransformations[0].GetNcols();
-	construct(); // construct (composed) trajectory
-}
+    for (unsigned int iTraj = 0; iTraj < aPointsAndTransList.size(); ++iTraj) {
+      thePoints.push_back(aPointsAndTransList[iTraj].first);
+      numPoints.push_back(thePoints.back().size());
+      numAllPoints += numPoints.back();
+      innerTransformations.push_back(aPointsAndTransList[iTraj].second);
+    }
+    theDimension.push_back(0);
+    theDimension.push_back(1);
+    numCurvature = innerTransformations[0].GetNcols();
+    construct(); // construct (composed) trajectory
+  }
 
-GblTrajectory::~GblTrajectory() {
-}
+  GblTrajectory::~GblTrajectory()
+  {
+  }
 
 /// Retrieve validity of trajectory
-bool GblTrajectory::isValid() const {
-	return constructOK;
-}
+  bool GblTrajectory::isValid() const
+  {
+    return constructOK;
+  }
 
 /// Retrieve number of point from trajectory
-unsigned int GblTrajectory::getNumPoints() const {
-	return numAllPoints;
-}
+  unsigned int GblTrajectory::getNumPoints() const
+  {
+    return numAllPoints;
+  }
 
 /// Construct trajectory from list of points.
-/**
- * Trajectory is prepared for fit or output to binary file, may consists of sub-trajectories.
- */
-void GblTrajectory::construct() {
+  /**
+   * Trajectory is prepared for fit or output to binary file, may consists of sub-trajectories.
+   */
+  void GblTrajectory::construct()
+  {
 
-	constructOK = false;
-	fitOK = false;
-	unsigned int aLabel = 0;
-	if (numAllPoints < 2) {
-		std::cout << " GblTrajectory construction failed: too few GblPoints "
-				<< std::endl;
-		return;
-	}
-	// loop over trajectories
-	numTrajectories = thePoints.size();
-	//std::cout << " numTrajectories: " << numTrajectories << ", " << innerTransformations.size() << std::endl;
-	for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
-		std::vector<GblPoint>::iterator itPoint;
-		for (itPoint = thePoints[iTraj].begin();
-				itPoint < thePoints[iTraj].end(); ++itPoint) {
-			numLocals = std::max(numLocals, itPoint->getNumLocals());
-			numMeasurements += itPoint->hasMeasurement();
-			itPoint->setLabel(++aLabel);
-		}
-	}
-	defineOffsets();
-	calcJacobians();
-	try {
-		prepare();
-	} catch (std::overflow_error &e) {
-		std::cout << " GblTrajectory construction failed: " << e.what()
-				<< std::endl;
-		return;
-	}
-	constructOK = true;
-	// number of fit parameters
-	numParameters = (numOffsets - 2 * numInnerTrans) * theDimension.size()
-			+ numCurvature + numLocals;
-}
+    constructOK = false;
+    fitOK = false;
+    unsigned int aLabel = 0;
+    if (numAllPoints < 2) {
+      std::cout << " GblTrajectory construction failed: too few GblPoints "
+                << std::endl;
+      return;
+    }
+    // loop over trajectories
+    numTrajectories = thePoints.size();
+    //std::cout << " numTrajectories: " << numTrajectories << ", " << innerTransformations.size() << std::endl;
+    for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
+      std::vector<GblPoint>::iterator itPoint;
+      for (itPoint = thePoints[iTraj].begin();
+           itPoint < thePoints[iTraj].end(); ++itPoint) {
+        numLocals = std::max(numLocals, itPoint->getNumLocals());
+        numMeasurements += itPoint->hasMeasurement();
+        itPoint->setLabel(++aLabel);
+      }
+    }
+    defineOffsets();
+    calcJacobians();
+    try {
+      prepare();
+    } catch (std::overflow_error& e) {
+      std::cout << " GblTrajectory construction failed: " << e.what()
+                << std::endl;
+      return;
+    }
+    constructOK = true;
+    // number of fit parameters
+    numParameters = (numOffsets - 2 * numInnerTrans) * theDimension.size()
+                    + numCurvature + numLocals;
+  }
 
 /// Define offsets from list of points.
-/**
- * Define offsets at points with scatterers and first and last point.
- * All other points need interpolation from adjacent points with offsets.
- */
-void GblTrajectory::defineOffsets() {
+  /**
+   * Define offsets at points with scatterers and first and last point.
+   * All other points need interpolation from adjacent points with offsets.
+   */
+  void GblTrajectory::defineOffsets()
+  {
 
-	// loop over trajectories
-	for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
-		// first point is offset
-		thePoints[iTraj].front().setOffset(numOffsets++);
-		// intermediate scatterers are offsets
-		std::vector<GblPoint>::iterator itPoint;
-		for (itPoint = thePoints[iTraj].begin() + 1;
-				itPoint < thePoints[iTraj].end() - 1; ++itPoint) {
-			if (itPoint->hasScatterer()) {
-				itPoint->setOffset(numOffsets++);
-			} else {
-				itPoint->setOffset(-numOffsets);
-			}
-		}
-		// last point is offset
-		thePoints[iTraj].back().setOffset(numOffsets++);
-	}
-}
+    // loop over trajectories
+    for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
+      // first point is offset
+      thePoints[iTraj].front().setOffset(numOffsets++);
+      // intermediate scatterers are offsets
+      std::vector<GblPoint>::iterator itPoint;
+      for (itPoint = thePoints[iTraj].begin() + 1;
+           itPoint < thePoints[iTraj].end() - 1; ++itPoint) {
+        if (itPoint->hasScatterer()) {
+          itPoint->setOffset(numOffsets++);
+        } else {
+          itPoint->setOffset(-numOffsets);
+        }
+      }
+      // last point is offset
+      thePoints[iTraj].back().setOffset(numOffsets++);
+    }
+  }
 
 /// Calculate Jacobians to previous/next scatterer from point to point ones.
-void GblTrajectory::calcJacobians() {
+  void GblTrajectory::calcJacobians()
+  {
 
-	SMatrix55 scatJacobian;
-	// loop over trajectories
-	for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
-		// forward propagation (all)
-		GblPoint* previousPoint = &thePoints[iTraj].front();
-		unsigned int numStep = 0;
-		std::vector<GblPoint>::iterator itPoint;
-		for (itPoint = thePoints[iTraj].begin() + 1;
-				itPoint < thePoints[iTraj].end(); ++itPoint) {
-			if (numStep == 0) {
-				scatJacobian = itPoint->getP2pJacobian();
-			} else {
-				scatJacobian = itPoint->getP2pJacobian() * scatJacobian;
-			}
-			numStep++;
-			itPoint->addPrevJacobian(scatJacobian); // iPoint -> previous scatterer
-			if (itPoint->getOffset() >= 0) {
-				previousPoint->addNextJacobian(scatJacobian); // lastPoint -> next scatterer
-				numStep = 0;
-				previousPoint = &(*itPoint);
-			}
-		}
-		// backward propagation (without scatterers)
-		for (itPoint = thePoints[iTraj].end() - 1;
-				itPoint > thePoints[iTraj].begin(); --itPoint) {
-			if (itPoint->getOffset() >= 0) {
-				scatJacobian = itPoint->getP2pJacobian();
-				continue; // skip offsets
-			}
-			itPoint->addNextJacobian(scatJacobian); // iPoint -> next scatterer
-			scatJacobian = scatJacobian * itPoint->getP2pJacobian();
-		}
-	}
-}
+    SMatrix55 scatJacobian;
+    // loop over trajectories
+    for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
+      // forward propagation (all)
+      GblPoint* previousPoint = &thePoints[iTraj].front();
+      unsigned int numStep = 0;
+      std::vector<GblPoint>::iterator itPoint;
+      for (itPoint = thePoints[iTraj].begin() + 1;
+           itPoint < thePoints[iTraj].end(); ++itPoint) {
+        if (numStep == 0) {
+          scatJacobian = itPoint->getP2pJacobian();
+        } else {
+          scatJacobian = itPoint->getP2pJacobian() * scatJacobian;
+        }
+        numStep++;
+        itPoint->addPrevJacobian(scatJacobian); // iPoint -> previous scatterer
+        if (itPoint->getOffset() >= 0) {
+          previousPoint->addNextJacobian(scatJacobian); // lastPoint -> next scatterer
+          numStep = 0;
+          previousPoint = &(*itPoint);
+        }
+      }
+      // backward propagation (without scatterers)
+      for (itPoint = thePoints[iTraj].end() - 1;
+           itPoint > thePoints[iTraj].begin(); --itPoint) {
+        if (itPoint->getOffset() >= 0) {
+          scatJacobian = itPoint->getP2pJacobian();
+          continue; // skip offsets
+        }
+        itPoint->addNextJacobian(scatJacobian); // iPoint -> next scatterer
+        scatJacobian = scatJacobian * itPoint->getP2pJacobian();
+      }
+    }
+  }
 
 /// Get jacobian for transformation from fit to track parameters at point.
-/**
- * Jacobian broken lines (q/p,..,u_i,u_i+1..) to track (q/p,u',u) parameters
- * including additional local parameters.
- * \param [in] aSignedLabel (Signed) label of point for external seed
- * (<0: in front, >0: after point, slope changes at scatterer!)
- * \return List of fit parameters with non zero derivatives and
- * corresponding transformation matrix
- */
-std::pair<std::vector<unsigned int>, TMatrixD> GblTrajectory::getJacobian(
-		int aSignedLabel) const {
+  /**
+   * Jacobian broken lines (q/p,..,u_i,u_i+1..) to track (q/p,u',u) parameters
+   * including additional local parameters.
+   * \param [in] aSignedLabel (Signed) label of point for external seed
+   * (<0: in front, >0: after point, slope changes at scatterer!)
+   * \return List of fit parameters with non zero derivatives and
+   * corresponding transformation matrix
+   */
+  std::pair<std::vector<unsigned int>, TMatrixD> GblTrajectory::getJacobian(
+    int aSignedLabel) const
+  {
 
-	unsigned int nDim = theDimension.size();
-	unsigned int nCurv = numCurvature;
-	unsigned int nLocals = numLocals;
-	unsigned int nBorder = nCurv + nLocals;
-	unsigned int nParBRL = nBorder + 2 * nDim;
-	unsigned int nParLoc = nLocals + 5;
-	std::vector<unsigned int> anIndex;
-	anIndex.reserve(nParBRL);
-	TMatrixD aJacobian(nParLoc, nParBRL);
-	aJacobian.Zero();
+    unsigned int nDim = theDimension.size();
+    unsigned int nCurv = numCurvature;
+    unsigned int nLocals = numLocals;
+    unsigned int nBorder = nCurv + nLocals;
+    unsigned int nParBRL = nBorder + 2 * nDim;
+    unsigned int nParLoc = nLocals + 5;
+    std::vector<unsigned int> anIndex;
+    anIndex.reserve(nParBRL);
+    TMatrixD aJacobian(nParLoc, nParBRL);
+    aJacobian.Zero();
 
-	unsigned int aLabel = abs(aSignedLabel);
-	unsigned int firstLabel = 1;
-	unsigned int lastLabel = 0;
-	unsigned int aTrajectory = 0;
-	// loop over trajectories
-	for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
-		aTrajectory = iTraj;
-		lastLabel += numPoints[iTraj];
-		if (aLabel <= lastLabel)
-			break;
-		if (iTraj < numTrajectories - 1)
-			firstLabel += numPoints[iTraj];
-	}
-	int nJacobian; // 0: prev, 1: next
-	// check consistency of (index, direction)
-	if (aSignedLabel > 0) {
-		nJacobian = 1;
-		if (aLabel >= lastLabel) {
-			aLabel = lastLabel;
-			nJacobian = 0;
-		}
-	} else {
-		nJacobian = 0;
-		if (aLabel <= firstLabel) {
-			aLabel = firstLabel;
-			nJacobian = 1;
-		}
-	}
-	const GblPoint aPoint = thePoints[aTrajectory][aLabel - firstLabel];
-	std::vector<unsigned int> labDer(5);
-	SMatrix55 matDer;
-	getFitToLocalJacobian(labDer, matDer, aPoint, 5, nJacobian);
+    unsigned int aLabel = abs(aSignedLabel);
+    unsigned int firstLabel = 1;
+    unsigned int lastLabel = 0;
+    unsigned int aTrajectory = 0;
+    // loop over trajectories
+    for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
+      aTrajectory = iTraj;
+      lastLabel += numPoints[iTraj];
+      if (aLabel <= lastLabel)
+        break;
+      if (iTraj < numTrajectories - 1)
+        firstLabel += numPoints[iTraj];
+    }
+    int nJacobian; // 0: prev, 1: next
+    // check consistency of (index, direction)
+    if (aSignedLabel > 0) {
+      nJacobian = 1;
+      if (aLabel >= lastLabel) {
+        aLabel = lastLabel;
+        nJacobian = 0;
+      }
+    } else {
+      nJacobian = 0;
+      if (aLabel <= firstLabel) {
+        aLabel = firstLabel;
+        nJacobian = 1;
+      }
+    }
+    const GblPoint aPoint = thePoints[aTrajectory][aLabel - firstLabel];
+    std::vector<unsigned int> labDer(5);
+    SMatrix55 matDer;
+    getFitToLocalJacobian(labDer, matDer, aPoint, 5, nJacobian);
 
-	// from local parameters
-	for (unsigned int i = 0; i < nLocals; ++i) {
-		aJacobian(i + 5, i) = 1.0;
-		anIndex.push_back(i + 1);
-	}
-	// from trajectory parameters
-	unsigned int iCol = nLocals;
-	for (unsigned int i = 0; i < 5; ++i) {
-		if (labDer[i] > 0) {
-			anIndex.push_back(labDer[i]);
-			for (unsigned int j = 0; j < 5; ++j) {
-				aJacobian(j, iCol) = matDer(j, i);
-			}
-			++iCol;
-		}
-	}
-	return std::make_pair(anIndex, aJacobian);
-}
+    // from local parameters
+    for (unsigned int i = 0; i < nLocals; ++i) {
+      aJacobian(i + 5, i) = 1.0;
+      anIndex.push_back(i + 1);
+    }
+    // from trajectory parameters
+    unsigned int iCol = nLocals;
+    for (unsigned int i = 0; i < 5; ++i) {
+      if (labDer[i] > 0) {
+        anIndex.push_back(labDer[i]);
+        for (unsigned int j = 0; j < 5; ++j) {
+          aJacobian(j, iCol) = matDer(j, i);
+        }
+        ++iCol;
+      }
+    }
+    return std::make_pair(anIndex, aJacobian);
+  }
 
 /// Get (part of) jacobian for transformation from (trajectory) fit to track parameters at point.
-/**
- * Jacobian broken lines (q/p,..,u_i,u_i+1..) to local (q/p,u',u) parameters.
- * \param [out] anIndex List of fit parameters with non zero derivatives
- * \param [out] aJacobian Corresponding transformation matrix
- * \param [in] aPoint Point to use
- * \param [in] measDim Dimension of 'measurement'
- * (<=2: calculate only offset part, >2: complete matrix)
- * \param [in] nJacobian Direction (0: to previous offset, 1: to next offset)
- */
-void GblTrajectory::getFitToLocalJacobian(std::vector<unsigned int> &anIndex,
-		SMatrix55 &aJacobian, const GblPoint &aPoint, unsigned int measDim,
-		unsigned int nJacobian) const {
+  /**
+   * Jacobian broken lines (q/p,..,u_i,u_i+1..) to local (q/p,u',u) parameters.
+   * \param [out] anIndex List of fit parameters with non zero derivatives
+   * \param [out] aJacobian Corresponding transformation matrix
+   * \param [in] aPoint Point to use
+   * \param [in] measDim Dimension of 'measurement'
+   * (<=2: calculate only offset part, >2: complete matrix)
+   * \param [in] nJacobian Direction (0: to previous offset, 1: to next offset)
+   */
+  void GblTrajectory::getFitToLocalJacobian(std::vector<unsigned int>& anIndex,
+                                            SMatrix55& aJacobian, const GblPoint& aPoint, unsigned int measDim,
+                                            unsigned int nJacobian) const
+  {
 
-	unsigned int nDim = theDimension.size();
-	unsigned int nCurv = numCurvature;
-	unsigned int nLocals = numLocals;
+    unsigned int nDim = theDimension.size();
+    unsigned int nCurv = numCurvature;
+    unsigned int nLocals = numLocals;
 
-	int nOffset = aPoint.getOffset();
+    int nOffset = aPoint.getOffset();
 
-	if (nOffset < 0) // need interpolation
-			{
-		SMatrix22 prevW, prevWJ, nextW, nextWJ, matN;
-		SVector2 prevWd, nextWd;
-		int ierr;
-		aPoint.getDerivatives(0, prevW, prevWJ, prevWd); // W-, W- * J-, W- * d-
-		aPoint.getDerivatives(1, nextW, nextWJ, nextWd); // W-, W- * J-, W- * d-
-		const SMatrix22 sumWJ(prevWJ + nextWJ);
-		matN = sumWJ.Inverse(ierr); // N = (W- * J- + W+ * J+)^-1
-		// derivatives for u_int
-		const SMatrix22 prevNW(matN * prevW); // N * W-
-		const SMatrix22 nextNW(matN * nextW); // N * W+
-		const SVector2 prevNd(matN * prevWd); // N * W- * d-
-		const SVector2 nextNd(matN * nextWd); // N * W+ * d+
+    if (nOffset < 0) { // need interpolation
+      SMatrix22 prevW, prevWJ, nextW, nextWJ, matN;
+      SVector2 prevWd, nextWd;
+      int ierr;
+      aPoint.getDerivatives(0, prevW, prevWJ, prevWd); // W-, W- * J-, W- * d-
+      aPoint.getDerivatives(1, nextW, nextWJ, nextWd); // W-, W- * J-, W- * d-
+      const SMatrix22 sumWJ(prevWJ + nextWJ);
+      matN = sumWJ.Inverse(ierr); // N = (W- * J- + W+ * J+)^-1
+      // derivatives for u_int
+      const SMatrix22 prevNW(matN * prevW); // N * W-
+      const SMatrix22 nextNW(matN * nextW); // N * W+
+      const SVector2 prevNd(matN * prevWd); // N * W- * d-
+      const SVector2 nextNd(matN * nextWd); // N * W+ * d+
 
-		unsigned int iOff = nDim * (-nOffset - 1) + nLocals + nCurv + 1; // first offset ('i' in u_i)
+      unsigned int iOff = nDim * (-nOffset - 1) + nLocals + nCurv + 1; // first offset ('i' in u_i)
 
-		// local offset
-		if (nCurv > 0) {
-			aJacobian.Place_in_col(-prevNd - nextNd, 3, 0); // from curvature
-			anIndex[0] = nLocals + 1;
-		}
-		aJacobian.Place_at(prevNW, 3, 1); // from 1st Offset
-		aJacobian.Place_at(nextNW, 3, 3); // from 2nd Offset
-		for (unsigned int i = 0; i < nDim; ++i) {
-			anIndex[1 + theDimension[i]] = iOff + i;
-			anIndex[3 + theDimension[i]] = iOff + nDim + i;
-		}
+      // local offset
+      if (nCurv > 0) {
+        aJacobian.Place_in_col(-prevNd - nextNd, 3, 0); // from curvature
+        anIndex[0] = nLocals + 1;
+      }
+      aJacobian.Place_at(prevNW, 3, 1); // from 1st Offset
+      aJacobian.Place_at(nextNW, 3, 3); // from 2nd Offset
+      for (unsigned int i = 0; i < nDim; ++i) {
+        anIndex[1 + theDimension[i]] = iOff + i;
+        anIndex[3 + theDimension[i]] = iOff + nDim + i;
+      }
 
-		// local slope and curvature
-		if (measDim > 2) {
-			// derivatives for u'_int
-			const SMatrix22 prevWPN(nextWJ * prevNW); // W+ * J+ * N * W-
-			const SMatrix22 nextWPN(prevWJ * nextNW); // W- * J- * N * W+
-			const SVector2 prevWNd(nextWJ * prevNd); // W+ * J+ * N * W- * d-
-			const SVector2 nextWNd(prevWJ * nextNd); // W- * J- * N * W+ * d+
-			if (nCurv > 0) {
-				aJacobian(0, 0) = 1.0;
-				aJacobian.Place_in_col(prevWNd - nextWNd, 1, 0); // from curvature
-			}
-			aJacobian.Place_at(-prevWPN, 1, 1); // from 1st Offset
-			aJacobian.Place_at(nextWPN, 1, 3); // from 2nd Offset
-		}
-	} else { // at point
-		// anIndex must be sorted
-		// forward : iOff2 = iOff1 + nDim, index1 = 1, index2 = 3
-		// backward: iOff2 = iOff1 - nDim, index1 = 3, index2 = 1
-		unsigned int iOff1 = nDim * nOffset + nCurv + nLocals + 1; // first offset ('i' in u_i)
-		unsigned int index1 = 3 - 2 * nJacobian; // index of first offset
-		unsigned int iOff2 = iOff1 + nDim * (nJacobian * 2 - 1); // second offset ('i' in u_i)
-		unsigned int index2 = 1 + 2 * nJacobian; // index of second offset
-		// local offset
-		aJacobian(3, index1) = 1.0; // from 1st Offset
-		aJacobian(4, index1 + 1) = 1.0;
-		for (unsigned int i = 0; i < nDim; ++i) {
-			anIndex[index1 + theDimension[i]] = iOff1 + i;
-		}
+      // local slope and curvature
+      if (measDim > 2) {
+        // derivatives for u'_int
+        const SMatrix22 prevWPN(nextWJ * prevNW); // W+ * J+ * N * W-
+        const SMatrix22 nextWPN(prevWJ * nextNW); // W- * J- * N * W+
+        const SVector2 prevWNd(nextWJ * prevNd); // W+ * J+ * N * W- * d-
+        const SVector2 nextWNd(prevWJ * nextNd); // W- * J- * N * W+ * d+
+        if (nCurv > 0) {
+          aJacobian(0, 0) = 1.0;
+          aJacobian.Place_in_col(prevWNd - nextWNd, 1, 0); // from curvature
+        }
+        aJacobian.Place_at(-prevWPN, 1, 1); // from 1st Offset
+        aJacobian.Place_at(nextWPN, 1, 3); // from 2nd Offset
+      }
+    } else { // at point
+      // anIndex must be sorted
+      // forward : iOff2 = iOff1 + nDim, index1 = 1, index2 = 3
+      // backward: iOff2 = iOff1 - nDim, index1 = 3, index2 = 1
+      unsigned int iOff1 = nDim * nOffset + nCurv + nLocals + 1; // first offset ('i' in u_i)
+      unsigned int index1 = 3 - 2 * nJacobian; // index of first offset
+      unsigned int iOff2 = iOff1 + nDim * (nJacobian * 2 - 1); // second offset ('i' in u_i)
+      unsigned int index2 = 1 + 2 * nJacobian; // index of second offset
+      // local offset
+      aJacobian(3, index1) = 1.0; // from 1st Offset
+      aJacobian(4, index1 + 1) = 1.0;
+      for (unsigned int i = 0; i < nDim; ++i) {
+        anIndex[index1 + theDimension[i]] = iOff1 + i;
+      }
 
-		// local slope and curvature
-		if (measDim > 2) {
-			SMatrix22 matW, matWJ;
-			SVector2 vecWd;
-			aPoint.getDerivatives(nJacobian, matW, matWJ, vecWd); // W, W * J, W * d
-			double sign = (nJacobian > 0) ? 1. : -1.;
-			if (nCurv > 0) {
-				aJacobian(0, 0) = 1.0;
-				aJacobian.Place_in_col(-sign * vecWd, 1, 0); // from curvature
-				anIndex[0] = nLocals + 1;
-			}
-			aJacobian.Place_at(-sign * matWJ, 1, index1); // from 1st Offset
-			aJacobian.Place_at(sign * matW, 1, index2); // from 2nd Offset
-			for (unsigned int i = 0; i < nDim; ++i) {
-				anIndex[index2 + theDimension[i]] = iOff2 + i;
-			}
-		}
-	}
-}
+      // local slope and curvature
+      if (measDim > 2) {
+        SMatrix22 matW, matWJ;
+        SVector2 vecWd;
+        aPoint.getDerivatives(nJacobian, matW, matWJ, vecWd); // W, W * J, W * d
+        double sign = (nJacobian > 0) ? 1. : -1.;
+        if (nCurv > 0) {
+          aJacobian(0, 0) = 1.0;
+          aJacobian.Place_in_col(-sign * vecWd, 1, 0); // from curvature
+          anIndex[0] = nLocals + 1;
+        }
+        aJacobian.Place_at(-sign * matWJ, 1, index1); // from 1st Offset
+        aJacobian.Place_at(sign * matW, 1, index2); // from 2nd Offset
+        for (unsigned int i = 0; i < nDim; ++i) {
+          anIndex[index2 + theDimension[i]] = iOff2 + i;
+        }
+      }
+    }
+  }
 
 /// Get jacobian for transformation from (trajectory) fit to kink parameters at point.
-/**
- * Jacobian broken lines (q/p,..,u_i-1,u_i,u_i+1..) to kink (du') parameters.
- * \param [out] anIndex List of fit parameters with non zero derivatives
- * \param [out] aJacobian Corresponding transformation matrix
- * \param [in] aPoint Point to use
- */
-void GblTrajectory::getFitToKinkJacobian(std::vector<unsigned int> &anIndex,
-		SMatrix27 &aJacobian, const GblPoint &aPoint) const {
+  /**
+   * Jacobian broken lines (q/p,..,u_i-1,u_i,u_i+1..) to kink (du') parameters.
+   * \param [out] anIndex List of fit parameters with non zero derivatives
+   * \param [out] aJacobian Corresponding transformation matrix
+   * \param [in] aPoint Point to use
+   */
+  void GblTrajectory::getFitToKinkJacobian(std::vector<unsigned int>& anIndex,
+                                           SMatrix27& aJacobian, const GblPoint& aPoint) const
+  {
 
-	unsigned int nDim = theDimension.size();
-	unsigned int nCurv = numCurvature;
-	unsigned int nLocals = numLocals;
+    unsigned int nDim = theDimension.size();
+    unsigned int nCurv = numCurvature;
+    unsigned int nLocals = numLocals;
 
-	int nOffset = aPoint.getOffset();
+    int nOffset = aPoint.getOffset();
 
-	SMatrix22 prevW, prevWJ, nextW, nextWJ;
-	SVector2 prevWd, nextWd;
-	aPoint.getDerivatives(0, prevW, prevWJ, prevWd); // W-, W- * J-, W- * d-
-	aPoint.getDerivatives(1, nextW, nextWJ, nextWd); // W-, W- * J-, W- * d-
-	const SMatrix22 sumWJ(prevWJ + nextWJ); // W- * J- + W+ * J+
-	const SVector2 sumWd(prevWd + nextWd); // W+ * d+ + W- * d-
+    SMatrix22 prevW, prevWJ, nextW, nextWJ;
+    SVector2 prevWd, nextWd;
+    aPoint.getDerivatives(0, prevW, prevWJ, prevWd); // W-, W- * J-, W- * d-
+    aPoint.getDerivatives(1, nextW, nextWJ, nextWd); // W-, W- * J-, W- * d-
+    const SMatrix22 sumWJ(prevWJ + nextWJ); // W- * J- + W+ * J+
+    const SVector2 sumWd(prevWd + nextWd); // W+ * d+ + W- * d-
 
-	unsigned int iOff = (nOffset - 1) * nDim + nCurv + nLocals + 1; // first offset ('i' in u_i)
+    unsigned int iOff = (nOffset - 1) * nDim + nCurv + nLocals + 1; // first offset ('i' in u_i)
 
-	// local offset
-	if (nCurv > 0) {
-		aJacobian.Place_in_col(-sumWd, 0, 0); // from curvature
-		anIndex[0] = nLocals + 1;
-	}
-	aJacobian.Place_at(prevW, 0, 1); // from 1st Offset
-	aJacobian.Place_at(-sumWJ, 0, 3); // from 2nd Offset
-	aJacobian.Place_at(nextW, 0, 5); // from 1st Offset
-	for (unsigned int i = 0; i < nDim; ++i) {
-		anIndex[1 + theDimension[i]] = iOff + i;
-		anIndex[3 + theDimension[i]] = iOff + nDim + i;
-		anIndex[5 + theDimension[i]] = iOff + nDim * 2 + i;
-	}
-}
+    // local offset
+    if (nCurv > 0) {
+      aJacobian.Place_in_col(-sumWd, 0, 0); // from curvature
+      anIndex[0] = nLocals + 1;
+    }
+    aJacobian.Place_at(prevW, 0, 1); // from 1st Offset
+    aJacobian.Place_at(-sumWJ, 0, 3); // from 2nd Offset
+    aJacobian.Place_at(nextW, 0, 5); // from 1st Offset
+    for (unsigned int i = 0; i < nDim; ++i) {
+      anIndex[1 + theDimension[i]] = iOff + i;
+      anIndex[3 + theDimension[i]] = iOff + nDim + i;
+      anIndex[5 + theDimension[i]] = iOff + nDim * 2 + i;
+    }
+  }
 
 /// Get fit results at point.
-/**
- * Get corrections and covariance matrix for local track and additional parameters
- * in forward or backward direction.
- *
- * The point is identified by its label (1..number(points)), the sign distinguishes the
- * backward (facing previous point) and forward 'side' (facing next point).
- * For scatterers the track direction may change in between.
- *
- * \param [in] aSignedLabel (Signed) label of point on trajectory
- * (<0: in front, >0: after point, slope changes at scatterer!)
- * \param [out] localPar Corrections for local parameters
- * \param [out] localCov Covariance for local parameters
- * \return error code (non-zero if trajectory not fitted successfully)
- */
-unsigned int GblTrajectory::getResults(int aSignedLabel, TVectorD &localPar,
-		TMatrixDSym &localCov) const {
-	if (not fitOK)
-		return 1;
-	std::pair<std::vector<unsigned int>, TMatrixD> indexAndJacobian =
-			getJacobian(aSignedLabel);
-	unsigned int nParBrl = indexAndJacobian.first.size();
-	TVectorD aVec(nParBrl); // compressed vector
-	for (unsigned int i = 0; i < nParBrl; ++i) {
-		aVec[i] = theVector(indexAndJacobian.first[i] - 1);
-	}
-	TMatrixDSym aMat = theMatrix.getBlockMatrix(indexAndJacobian.first); // compressed matrix
-	localPar = indexAndJacobian.second * aVec;
-	localCov = aMat.Similarity(indexAndJacobian.second);
-	return 0;
-}
+  /**
+   * Get corrections and covariance matrix for local track and additional parameters
+   * in forward or backward direction.
+   *
+   * The point is identified by its label (1..number(points)), the sign distinguishes the
+   * backward (facing previous point) and forward 'side' (facing next point).
+   * For scatterers the track direction may change in between.
+   *
+   * \param [in] aSignedLabel (Signed) label of point on trajectory
+   * (<0: in front, >0: after point, slope changes at scatterer!)
+   * \param [out] localPar Corrections for local parameters
+   * \param [out] localCov Covariance for local parameters
+   * \return error code (non-zero if trajectory not fitted successfully)
+   */
+  unsigned int GblTrajectory::getResults(int aSignedLabel, TVectorD& localPar,
+                                         TMatrixDSym& localCov) const
+  {
+    if (not fitOK)
+      return 1;
+    std::pair<std::vector<unsigned int>, TMatrixD> indexAndJacobian =
+      getJacobian(aSignedLabel);
+    unsigned int nParBrl = indexAndJacobian.first.size();
+    TVectorD aVec(nParBrl); // compressed vector
+    for (unsigned int i = 0; i < nParBrl; ++i) {
+      aVec[i] = theVector(indexAndJacobian.first[i] - 1);
+    }
+    TMatrixDSym aMat = theMatrix.getBlockMatrix(indexAndJacobian.first); // compressed matrix
+    localPar = indexAndJacobian.second * aVec;
+    localCov = aMat.Similarity(indexAndJacobian.second);
+    return 0;
+  }
 
 /// Get residuals from fit at point for measurement.
-/**
- * Get (diagonalized) residual, error of measurement and residual and down-weighting
- * factor for measurement at point
- *
- * \param [in]  aLabel Label of point on trajectory
- * \param [out] numData Number of data blocks from measurement at point
- * \param [out] aResiduals Measurements-Predictions
- * \param [out] aMeasErrors Errors of Measurements
- * \param [out] aResErrors Errors of Residuals (including correlations from track fit)
- * \param [out] aDownWeights Down-Weighting factors
- * \return error code (non-zero if trajectory not fitted successfully)
- */
-unsigned int GblTrajectory::getMeasResults(unsigned int aLabel,
-		unsigned int &numData, TVectorD &aResiduals, TVectorD &aMeasErrors,
-		TVectorD &aResErrors, TVectorD &aDownWeights) {
-	numData = 0;
-	if (not fitOK)
-		return 1;
+  /**
+   * Get (diagonalized) residual, error of measurement and residual and down-weighting
+   * factor for measurement at point
+   *
+   * \param [in]  aLabel Label of point on trajectory
+   * \param [out] numData Number of data blocks from measurement at point
+   * \param [out] aResiduals Measurements-Predictions
+   * \param [out] aMeasErrors Errors of Measurements
+   * \param [out] aResErrors Errors of Residuals (including correlations from track fit)
+   * \param [out] aDownWeights Down-Weighting factors
+   * \return error code (non-zero if trajectory not fitted successfully)
+   */
+  unsigned int GblTrajectory::getMeasResults(unsigned int aLabel,
+                                             unsigned int& numData, TVectorD& aResiduals, TVectorD& aMeasErrors,
+                                             TVectorD& aResErrors, TVectorD& aDownWeights)
+  {
+    numData = 0;
+    if (not fitOK)
+      return 1;
 
-	unsigned int firstData = measDataIndex[aLabel - 1]; // first data block with measurement
-	numData = measDataIndex[aLabel] - firstData; // number of data blocks
-	for (unsigned int i = 0; i < numData; ++i) {
-		getResAndErr(firstData + i, aResiduals[i], aMeasErrors[i],
-				aResErrors[i], aDownWeights[i]);
-	}
-	return 0;
-}
+    unsigned int firstData = measDataIndex[aLabel - 1]; // first data block with measurement
+    numData = measDataIndex[aLabel] - firstData; // number of data blocks
+    for (unsigned int i = 0; i < numData; ++i) {
+      getResAndErr(firstData + i, aResiduals[i], aMeasErrors[i],
+                   aResErrors[i], aDownWeights[i]);
+    }
+    return 0;
+  }
 
 /// Get (kink) residuals from fit at point for scatterer.
-/**
- * Get (diagonalized) residual, error of measurement and residual and down-weighting
- * factor for scatterering kinks at point
- *
- * \param [in]  aLabel Label of point on trajectory
- * \param [out] numData Number of data blocks from scatterer at point
- * \param [out] aResiduals (kink)Measurements-(kink)Predictions
- * \param [out] aMeasErrors Errors of (kink)Measurements
- * \param [out] aResErrors Errors of Residuals (including correlations from track fit)
- * \param [out] aDownWeights Down-Weighting factors
- * \return error code (non-zero if trajectory not fitted successfully)
- */
-unsigned int GblTrajectory::getScatResults(unsigned int aLabel,
-		unsigned int &numData, TVectorD &aResiduals, TVectorD &aMeasErrors,
-		TVectorD &aResErrors, TVectorD &aDownWeights) {
-	numData = 0;
-	if (not fitOK)
-		return 1;
+  /**
+   * Get (diagonalized) residual, error of measurement and residual and down-weighting
+   * factor for scatterering kinks at point
+   *
+   * \param [in]  aLabel Label of point on trajectory
+   * \param [out] numData Number of data blocks from scatterer at point
+   * \param [out] aResiduals (kink)Measurements-(kink)Predictions
+   * \param [out] aMeasErrors Errors of (kink)Measurements
+   * \param [out] aResErrors Errors of Residuals (including correlations from track fit)
+   * \param [out] aDownWeights Down-Weighting factors
+   * \return error code (non-zero if trajectory not fitted successfully)
+   */
+  unsigned int GblTrajectory::getScatResults(unsigned int aLabel,
+                                             unsigned int& numData, TVectorD& aResiduals, TVectorD& aMeasErrors,
+                                             TVectorD& aResErrors, TVectorD& aDownWeights)
+  {
+    numData = 0;
+    if (not fitOK)
+      return 1;
 
-	unsigned int firstData = scatDataIndex[aLabel - 1]; // first data block with scatterer
-	numData = scatDataIndex[aLabel] - firstData; // number of data blocks
-	for (unsigned int i = 0; i < numData; ++i) {
-		getResAndErr(firstData + i, aResiduals[i], aMeasErrors[i],
-				aResErrors[i], aDownWeights[i]);
-	}
-	return 0;
-}
+    unsigned int firstData = scatDataIndex[aLabel - 1]; // first data block with scatterer
+    numData = scatDataIndex[aLabel] - firstData; // number of data blocks
+    for (unsigned int i = 0; i < numData; ++i) {
+      getResAndErr(firstData + i, aResiduals[i], aMeasErrors[i],
+                   aResErrors[i], aDownWeights[i]);
+    }
+    return 0;
+  }
 
 /// Get (list of) labels of points on (simple) valid trajectory
-/**
- * \param [out] aLabelList List of labels (aLabelList[i] = i+1)
- * \return error code (non-zero if trajectory not valid (constructed successfully))
- */
-unsigned int GblTrajectory::getLabels(std::vector<unsigned int> &aLabelList) {
-	if (not constructOK)
-		return 1;
+  /**
+   * \param [out] aLabelList List of labels (aLabelList[i] = i+1)
+   * \return error code (non-zero if trajectory not valid (constructed successfully))
+   */
+  unsigned int GblTrajectory::getLabels(std::vector<unsigned int>& aLabelList)
+  {
+    if (not constructOK)
+      return 1;
 
-	unsigned int aLabel = 0;
-	unsigned int nPoint = thePoints[0].size();
-	aLabelList.resize(nPoint);
-	for (unsigned i = 0; i < nPoint; ++i) {
-		aLabelList[i] = ++aLabel;
-	}
-	return 0;
-}
+    unsigned int aLabel = 0;
+    unsigned int nPoint = thePoints[0].size();
+    aLabelList.resize(nPoint);
+    for (unsigned i = 0; i < nPoint; ++i) {
+      aLabelList[i] = ++aLabel;
+    }
+    return 0;
+  }
 
 /// Get (list of lists of) labels of points on (composed) valid trajectory
-/**
- * \param [out] aLabelList List of of lists of labels
- * \return error code (non-zero if trajectory not valid (constructed successfully))
- */
-unsigned int GblTrajectory::getLabels(
-		std::vector<std::vector<unsigned int> > &aLabelList) {
-	if (not constructOK)
-		return 1;
+  /**
+   * \param [out] aLabelList List of of lists of labels
+   * \return error code (non-zero if trajectory not valid (constructed successfully))
+   */
+  unsigned int GblTrajectory::getLabels(
+    std::vector<std::vector<unsigned int> >& aLabelList)
+  {
+    if (not constructOK)
+      return 1;
 
-	unsigned int aLabel = 0;
-	aLabelList.resize(numTrajectories);
-	for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
-		unsigned int nPoint = thePoints[iTraj].size();
-		aLabelList[iTraj].resize(nPoint);
-		for (unsigned i = 0; i < nPoint; ++i) {
-			aLabelList[iTraj][i] = ++aLabel;
-		}
-	}
-	return 0;
-}
+    unsigned int aLabel = 0;
+    aLabelList.resize(numTrajectories);
+    for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
+      unsigned int nPoint = thePoints[iTraj].size();
+      aLabelList[iTraj].resize(nPoint);
+      for (unsigned i = 0; i < nPoint; ++i) {
+        aLabelList[iTraj][i] = ++aLabel;
+      }
+    }
+    return 0;
+  }
 
 /// Get residual and errors from data block.
-/**
- * Get residual, error of measurement and residual and down-weighting
- * factor for (single) data block
- * \param [in]  aData Label of data block
- * \param [out] aResidual Measurement-Prediction
- * \param [out] aMeasError Error of Measurement
- * \param [out] aResError Error of Residual (including correlations from track fit)
- * \param [out] aDownWeight Down-Weighting factor
- */
-void GblTrajectory::getResAndErr(unsigned int aData, double &aResidual,
-		double &aMeasError, double &aResError, double &aDownWeight) {
+  /**
+   * Get residual, error of measurement and residual and down-weighting
+   * factor for (single) data block
+   * \param [in]  aData Label of data block
+   * \param [out] aResidual Measurement-Prediction
+   * \param [out] aMeasError Error of Measurement
+   * \param [out] aResError Error of Residual (including correlations from track fit)
+   * \param [out] aDownWeight Down-Weighting factor
+   */
+  void GblTrajectory::getResAndErr(unsigned int aData, double& aResidual,
+                                   double& aMeasError, double& aResError, double& aDownWeight)
+  {
 
-	double aMeasVar;
-	std::vector<unsigned int>* indLocal;
-	std::vector<double>* derLocal;
-	theData[aData].getResidual(aResidual, aMeasVar, aDownWeight, indLocal,
-			derLocal);
-	unsigned int nParBrl = (*indLocal).size();
-	TVectorD aVec(nParBrl); // compressed vector of derivatives
-	for (unsigned int j = 0; j < nParBrl; ++j) {
-		aVec[j] = (*derLocal)[j];
-	}
-	TMatrixDSym aMat = theMatrix.getBlockMatrix(*indLocal); // compressed (covariance) matrix
-	double aFitVar = aMat.Similarity(aVec); // variance from track fit
-	aMeasError = sqrt(aMeasVar); // error of measurement
-	aResError = (aFitVar < aMeasVar ? sqrt(aMeasVar - aFitVar) : 0.); // error of residual
-}
+    double aMeasVar;
+    std::vector<unsigned int>* indLocal;
+    std::vector<double>* derLocal;
+    theData[aData].getResidual(aResidual, aMeasVar, aDownWeight, indLocal,
+                               derLocal);
+    unsigned int nParBrl = (*indLocal).size();
+    TVectorD aVec(nParBrl); // compressed vector of derivatives
+    for (unsigned int j = 0; j < nParBrl; ++j) {
+      aVec[j] = (*derLocal)[j];
+    }
+    TMatrixDSym aMat = theMatrix.getBlockMatrix(*indLocal); // compressed (covariance) matrix
+    double aFitVar = aMat.Similarity(aVec); // variance from track fit
+    aMeasError = sqrt(aMeasVar); // error of measurement
+    aResError = (aFitVar < aMeasVar ? sqrt(aMeasVar - aFitVar) : 0.); // error of residual
+  }
 
 /// Build linear equation system from data (blocks).
-void GblTrajectory::buildLinearEquationSystem() {
-	unsigned int nBorder = numCurvature + numLocals;
-	theVector.resize(numParameters);
-	theMatrix.resize(numParameters, nBorder);
-	double aValue, aWeight;
-	std::vector<unsigned int>* indLocal;
-	std::vector<double>* derLocal;
-	std::vector<GblData>::iterator itData;
-	for (itData = theData.begin(); itData < theData.end(); ++itData) {
-		itData->getLocalData(aValue, aWeight, indLocal, derLocal);
-		for (unsigned int j = 0; j < indLocal->size(); ++j) {
-			theVector((*indLocal)[j] - 1) += (*derLocal)[j] * aWeight * aValue;
-		}
-		theMatrix.addBlockMatrix(aWeight, indLocal, derLocal);
-	}
-}
+  void GblTrajectory::buildLinearEquationSystem()
+  {
+    unsigned int nBorder = numCurvature + numLocals;
+    theVector.resize(numParameters);
+    theMatrix.resize(numParameters, nBorder);
+    double aValue, aWeight;
+    std::vector<unsigned int>* indLocal;
+    std::vector<double>* derLocal;
+    std::vector<GblData>::iterator itData;
+    for (itData = theData.begin(); itData < theData.end(); ++itData) {
+      itData->getLocalData(aValue, aWeight, indLocal, derLocal);
+      for (unsigned int j = 0; j < indLocal->size(); ++j) {
+        theVector((*indLocal)[j] - 1) += (*derLocal)[j] * aWeight * aValue;
+      }
+      theMatrix.addBlockMatrix(aWeight, indLocal, derLocal);
+    }
+  }
 
 /// Prepare fit for simple or composed trajectory
-/**
- * Generate data (blocks) from measurements, kinks, external seed and measurements.
- */
-void GblTrajectory::prepare() {
-	unsigned int nDim = theDimension.size();
-	// upper limit
-	unsigned int maxData = numMeasurements + nDim * (numOffsets - 2)
-			+ externalSeed.GetNrows();
-	theData.reserve(maxData);
-	measDataIndex.resize(numAllPoints + 3); // include external seed and measurements
-	scatDataIndex.resize(numAllPoints + 1);
-	unsigned int nData = 0;
-	std::vector<TMatrixD> innerTransDer;
-	std::vector<std::vector<unsigned int> > innerTransLab;
-	// composed trajectory ?
-	if (numInnerTrans > 0) {
-		//std::cout << "composed trajectory" << std::endl;
-		for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
-			// innermost point
-			GblPoint* innerPoint = &thePoints[iTraj].front();
-			// transformation fit to local track parameters
-			std::vector<unsigned int> firstLabels(5);
-			SMatrix55 matFitToLocal, matLocalToFit;
-			getFitToLocalJacobian(firstLabels, matFitToLocal, *innerPoint, 5);
-			// transformation local track to fit parameters
-			int ierr;
-			matLocalToFit = matFitToLocal.Inverse(ierr);
-			TMatrixD localToFit(5, 5);
-			for (unsigned int i = 0; i < 5; ++i) {
-				for (unsigned int j = 0; j < 5; ++j) {
-					localToFit(i, j) = matLocalToFit(i, j);
-				}
-			}
-			// transformation external to fit parameters at inner (first) point
-			innerTransDer.push_back(localToFit * innerTransformations[iTraj]);
-			innerTransLab.push_back(firstLabels);
-		}
-	}
-	// measurements
-	SMatrix55 matP;
-	// loop over trajectories
-	std::vector<GblPoint>::iterator itPoint;
-	for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
-		for (itPoint = thePoints[iTraj].begin();
-				itPoint < thePoints[iTraj].end(); ++itPoint) {
-			SVector5 aMeas, aPrec;
-			unsigned int nLabel = itPoint->getLabel();
-			unsigned int measDim = itPoint->hasMeasurement();
-			if (measDim) {
-				const TMatrixD localDer = itPoint->getLocalDerivatives();
-				const std::vector<int> globalLab = itPoint->getGlobalLabels();
-				const TMatrixD globalDer = itPoint->getGlobalDerivatives();
-				TMatrixD transDer;
-				itPoint->getMeasurement(matP, aMeas, aPrec);
-				unsigned int iOff = 5 - measDim; // first active component
-				std::vector<unsigned int> labDer(5);
-				SMatrix55 matDer, matPDer;
-				unsigned int nJacobian =
-						(itPoint < thePoints[iTraj].end() - 1) ? 1 : 0; // last point needs backward propagation
-				getFitToLocalJacobian(labDer, matDer, *itPoint, measDim,
-						nJacobian);
-				if (measDim > 2) {
-					matPDer = matP * matDer;
-				} else { // 'shortcut' for position measurements
-					matPDer.Place_at(
-							matP.Sub<SMatrix22>(3, 3)
-									* matDer.Sub<SMatrix25>(3, 0), 3, 0);
-				}
+  /**
+   * Generate data (blocks) from measurements, kinks, external seed and measurements.
+   */
+  void GblTrajectory::prepare()
+  {
+    unsigned int nDim = theDimension.size();
+    // upper limit
+    unsigned int maxData = numMeasurements + nDim * (numOffsets - 2)
+                           + externalSeed.GetNrows();
+    theData.reserve(maxData);
+    measDataIndex.resize(numAllPoints + 3); // include external seed and measurements
+    scatDataIndex.resize(numAllPoints + 1);
+    unsigned int nData = 0;
+    std::vector<TMatrixD> innerTransDer;
+    std::vector<std::vector<unsigned int> > innerTransLab;
+    // composed trajectory ?
+    if (numInnerTrans > 0) {
+      //std::cout << "composed trajectory" << std::endl;
+      for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
+        // innermost point
+        GblPoint* innerPoint = &thePoints[iTraj].front();
+        // transformation fit to local track parameters
+        std::vector<unsigned int> firstLabels(5);
+        SMatrix55 matFitToLocal, matLocalToFit;
+        getFitToLocalJacobian(firstLabels, matFitToLocal, *innerPoint, 5);
+        // transformation local track to fit parameters
+        int ierr;
+        matLocalToFit = matFitToLocal.Inverse(ierr);
+        TMatrixD localToFit(5, 5);
+        for (unsigned int i = 0; i < 5; ++i) {
+          for (unsigned int j = 0; j < 5; ++j) {
+            localToFit(i, j) = matLocalToFit(i, j);
+          }
+        }
+        // transformation external to fit parameters at inner (first) point
+        innerTransDer.push_back(localToFit * innerTransformations[iTraj]);
+        innerTransLab.push_back(firstLabels);
+      }
+    }
+    // measurements
+    SMatrix55 matP;
+    // loop over trajectories
+    std::vector<GblPoint>::iterator itPoint;
+    for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
+      for (itPoint = thePoints[iTraj].begin();
+           itPoint < thePoints[iTraj].end(); ++itPoint) {
+        SVector5 aMeas, aPrec;
+        unsigned int nLabel = itPoint->getLabel();
+        unsigned int measDim = itPoint->hasMeasurement();
+        if (measDim) {
+          const TMatrixD localDer = itPoint->getLocalDerivatives();
+          const std::vector<int> globalLab = itPoint->getGlobalLabels();
+          const TMatrixD globalDer = itPoint->getGlobalDerivatives();
+          TMatrixD transDer;
+          itPoint->getMeasurement(matP, aMeas, aPrec);
+          unsigned int iOff = 5 - measDim; // first active component
+          std::vector<unsigned int> labDer(5);
+          SMatrix55 matDer, matPDer;
+          unsigned int nJacobian =
+            (itPoint < thePoints[iTraj].end() - 1) ? 1 : 0; // last point needs backward propagation
+          getFitToLocalJacobian(labDer, matDer, *itPoint, measDim,
+                                nJacobian);
+          if (measDim > 2) {
+            matPDer = matP * matDer;
+          } else { // 'shortcut' for position measurements
+            matPDer.Place_at(
+              matP.Sub<SMatrix22>(3, 3)
+              * matDer.Sub<SMatrix25>(3, 0), 3, 0);
+          }
 
-				if (numInnerTrans > 0) {
-					// transform for external parameters
-					TMatrixD proDer(measDim, 5);
-					// match parameters
-					unsigned int ifirst = 0;
-					unsigned int ilabel = 0;
-					while (ilabel < 5) {
-						if (labDer[ilabel] > 0) {
-							while (innerTransLab[iTraj][ifirst]
-									!= labDer[ilabel] and ifirst < 5) {
-								++ifirst;
-							}
-							if (ifirst >= 5) {
-								labDer[ilabel] -= 2 * nDim * (iTraj + 1); // adjust label
-							} else {
-								// match
-								labDer[ilabel] = 0; // mark as related to external parameters
-								for (unsigned int k = iOff; k < 5; ++k) {
-									proDer(k - iOff, ifirst) = matPDer(k,
-											ilabel);
-								}
-							}
-						}
-						++ilabel;
-					}
-					transDer.ResizeTo(measDim, numCurvature);
-					transDer = proDer * innerTransDer[iTraj];
-				}
-				for (unsigned int i = iOff; i < 5; ++i) {
-					if (aPrec(i) > 0.) {
-						GblData aData(nLabel, aMeas(i), aPrec(i));
-						aData.addDerivatives(i, labDer, matPDer, iOff, localDer,
-								globalLab, globalDer, numLocals, transDer);
-						theData.push_back(aData);
-						nData++;
-					}
-				}
+          if (numInnerTrans > 0) {
+            // transform for external parameters
+            TMatrixD proDer(measDim, 5);
+            // match parameters
+            unsigned int ifirst = 0;
+            unsigned int ilabel = 0;
+            while (ilabel < 5) {
+              if (labDer[ilabel] > 0) {
+                while (innerTransLab[iTraj][ifirst]
+                       != labDer[ilabel] and ifirst < 5) {
+                  ++ifirst;
+                }
+                if (ifirst >= 5) {
+                  labDer[ilabel] -= 2 * nDim * (iTraj + 1); // adjust label
+                } else {
+                  // match
+                  labDer[ilabel] = 0; // mark as related to external parameters
+                  for (unsigned int k = iOff; k < 5; ++k) {
+                    proDer(k - iOff, ifirst) = matPDer(k,
+                                                       ilabel);
+                  }
+                }
+              }
+              ++ilabel;
+            }
+            transDer.ResizeTo(measDim, numCurvature);
+            transDer = proDer * innerTransDer[iTraj];
+          }
+          for (unsigned int i = iOff; i < 5; ++i) {
+            if (aPrec(i) > 0.) {
+              GblData aData(nLabel, aMeas(i), aPrec(i));
+              aData.addDerivatives(i, labDer, matPDer, iOff, localDer,
+                                   globalLab, globalDer, numLocals, transDer);
+              theData.push_back(aData);
+              nData++;
+            }
+          }
 
-			}
-			measDataIndex[nLabel] = nData;
-		}
-	}
+        }
+        measDataIndex[nLabel] = nData;
+      }
+    }
 
-	// pseudo measurements from kinks
-	SMatrix22 matT;
-	scatDataIndex[0] = nData;
-	scatDataIndex[1] = nData;
-	// loop over trajectories
-	for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
-		for (itPoint = thePoints[iTraj].begin() + 1;
-				itPoint < thePoints[iTraj].end() - 1; ++itPoint) {
-			SVector2 aMeas, aPrec;
-			unsigned int nLabel = itPoint->getLabel();
-			if (itPoint->hasScatterer()) {
-				itPoint->getScatterer(matT, aMeas, aPrec);
-				TMatrixD transDer;
-				std::vector<unsigned int> labDer(7);
-				SMatrix27 matDer, matTDer;
-				getFitToKinkJacobian(labDer, matDer, *itPoint);
-				matTDer = matT * matDer;
-				if (numInnerTrans > 0) {
-					// transform for external parameters
-					TMatrixD proDer(nDim, 5);
-					// match parameters
-					unsigned int ifirst = 0;
-					unsigned int ilabel = 0;
-					while (ilabel < 7) {
-						if (labDer[ilabel] > 0) {
-							while (innerTransLab[iTraj][ifirst]
-									!= labDer[ilabel] and ifirst < 5) {
-								++ifirst;
-							}
-							if (ifirst >= 5) {
-								labDer[ilabel] -= 2 * nDim * (iTraj + 1); // adjust label
-							} else {
-								// match
-								labDer[ilabel] = 0; // mark as related to external parameters
-								for (unsigned int k = 0; k < nDim; ++k) {
-									proDer(k, ifirst) = matTDer(k, ilabel);
-								}
-							}
-						}
-						++ilabel;
-					}
-					transDer.ResizeTo(nDim, numCurvature);
-					transDer = proDer * innerTransDer[iTraj];
-				}
-				for (unsigned int i = 0; i < nDim; ++i) {
-					unsigned int iDim = theDimension[i];
-					if (aPrec(iDim) > 0.) {
-						GblData aData(nLabel, aMeas(iDim), aPrec(iDim));
-						aData.addDerivatives(iDim, labDer, matTDer, numLocals,
-								transDer);
-						theData.push_back(aData);
-						nData++;
-					}
-				}
-			}
-			scatDataIndex[nLabel] = nData;
-		}
-		scatDataIndex[thePoints[iTraj].back().getLabel()] = nData;
-	}
+    // pseudo measurements from kinks
+    SMatrix22 matT;
+    scatDataIndex[0] = nData;
+    scatDataIndex[1] = nData;
+    // loop over trajectories
+    for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
+      for (itPoint = thePoints[iTraj].begin() + 1;
+           itPoint < thePoints[iTraj].end() - 1; ++itPoint) {
+        SVector2 aMeas, aPrec;
+        unsigned int nLabel = itPoint->getLabel();
+        if (itPoint->hasScatterer()) {
+          itPoint->getScatterer(matT, aMeas, aPrec);
+          TMatrixD transDer;
+          std::vector<unsigned int> labDer(7);
+          SMatrix27 matDer, matTDer;
+          getFitToKinkJacobian(labDer, matDer, *itPoint);
+          matTDer = matT * matDer;
+          if (numInnerTrans > 0) {
+            // transform for external parameters
+            TMatrixD proDer(nDim, 5);
+            // match parameters
+            unsigned int ifirst = 0;
+            unsigned int ilabel = 0;
+            while (ilabel < 7) {
+              if (labDer[ilabel] > 0) {
+                while (innerTransLab[iTraj][ifirst]
+                       != labDer[ilabel] and ifirst < 5) {
+                  ++ifirst;
+                }
+                if (ifirst >= 5) {
+                  labDer[ilabel] -= 2 * nDim * (iTraj + 1); // adjust label
+                } else {
+                  // match
+                  labDer[ilabel] = 0; // mark as related to external parameters
+                  for (unsigned int k = 0; k < nDim; ++k) {
+                    proDer(k, ifirst) = matTDer(k, ilabel);
+                  }
+                }
+              }
+              ++ilabel;
+            }
+            transDer.ResizeTo(nDim, numCurvature);
+            transDer = proDer * innerTransDer[iTraj];
+          }
+          for (unsigned int i = 0; i < nDim; ++i) {
+            unsigned int iDim = theDimension[i];
+            if (aPrec(iDim) > 0.) {
+              GblData aData(nLabel, aMeas(iDim), aPrec(iDim));
+              aData.addDerivatives(iDim, labDer, matTDer, numLocals,
+                                   transDer);
+              theData.push_back(aData);
+              nData++;
+            }
+          }
+        }
+        scatDataIndex[nLabel] = nData;
+      }
+      scatDataIndex[thePoints[iTraj].back().getLabel()] = nData;
+    }
 
-	// external seed
-	if (externalPoint > 0) {
-		std::pair<std::vector<unsigned int>, TMatrixD> indexAndJacobian =
-				getJacobian(externalPoint);
-		std::vector<unsigned int> externalSeedIndex = indexAndJacobian.first;
-		std::vector<double> externalSeedDerivatives(externalSeedIndex.size());
-		const TMatrixDSymEigen externalSeedEigen(externalSeed);
-		const TVectorD valEigen = externalSeedEigen.GetEigenValues();
-		TMatrixD vecEigen = externalSeedEigen.GetEigenVectors();
-		vecEigen = vecEigen.T() * indexAndJacobian.second;
-		for (int i = 0; i < externalSeed.GetNrows(); ++i) {
-			if (valEigen(i) > 0.) {
-				for (int j = 0; j < externalSeed.GetNcols(); ++j) {
-					externalSeedDerivatives[j] = vecEigen(i, j);
-				}
-				GblData aData(externalPoint, 0., valEigen(i));
-				aData.addDerivatives(externalSeedIndex,
-						externalSeedDerivatives);
-				theData.push_back(aData);
-				nData++;
-			}
-		}
-	}
-	measDataIndex[numAllPoints + 1] = nData;
-	// external measurements
-	unsigned int nExt = externalMeasurements.GetNrows();
-	if (nExt > 0) {
-		std::vector<unsigned int> index(numCurvature);
-		std::vector<double> derivatives(numCurvature);
-		for (unsigned int iExt = 0; iExt < nExt; ++iExt) {
-			for (unsigned int iCol = 0; iCol < numCurvature; ++iCol) {
-				index[iCol] = numLocals + iCol + 1;
-				derivatives[iCol] = externalDerivatives(iExt, iCol);
-			}
-			GblData aData(1U, externalMeasurements(iExt),
-					externalPrecisions(iExt));
-			aData.addDerivatives(index, derivatives);
-			theData.push_back(aData);
-			nData++;
-		}
-	}
-	measDataIndex[numAllPoints + 2] = nData;
-}
+    // external seed
+    if (externalPoint > 0) {
+      std::pair<std::vector<unsigned int>, TMatrixD> indexAndJacobian =
+        getJacobian(externalPoint);
+      std::vector<unsigned int> externalSeedIndex = indexAndJacobian.first;
+      std::vector<double> externalSeedDerivatives(externalSeedIndex.size());
+      const TMatrixDSymEigen externalSeedEigen(externalSeed);
+      const TVectorD valEigen = externalSeedEigen.GetEigenValues();
+      TMatrixD vecEigen = externalSeedEigen.GetEigenVectors();
+      vecEigen = vecEigen.T() * indexAndJacobian.second;
+      for (int i = 0; i < externalSeed.GetNrows(); ++i) {
+        if (valEigen(i) > 0.) {
+          for (int j = 0; j < externalSeed.GetNcols(); ++j) {
+            externalSeedDerivatives[j] = vecEigen(i, j);
+          }
+          GblData aData(externalPoint, 0., valEigen(i));
+          aData.addDerivatives(externalSeedIndex,
+                               externalSeedDerivatives);
+          theData.push_back(aData);
+          nData++;
+        }
+      }
+    }
+    measDataIndex[numAllPoints + 1] = nData;
+    // external measurements
+    unsigned int nExt = externalMeasurements.GetNrows();
+    if (nExt > 0) {
+      std::vector<unsigned int> index(numCurvature);
+      std::vector<double> derivatives(numCurvature);
+      for (unsigned int iExt = 0; iExt < nExt; ++iExt) {
+        for (unsigned int iCol = 0; iCol < numCurvature; ++iCol) {
+          index[iCol] = numLocals + iCol + 1;
+          derivatives[iCol] = externalDerivatives(iExt, iCol);
+        }
+        GblData aData(1U, externalMeasurements(iExt),
+                      externalPrecisions(iExt));
+        aData.addDerivatives(index, derivatives);
+        theData.push_back(aData);
+        nData++;
+      }
+    }
+    measDataIndex[numAllPoints + 2] = nData;
+  }
 
 /// Calculate predictions for all points.
-void GblTrajectory::predict() {
-	std::vector<GblData>::iterator itData;
-	for (itData = theData.begin(); itData < theData.end(); ++itData) {
-		itData->setPrediction(theVector);
-	}
-}
+  void GblTrajectory::predict()
+  {
+    std::vector<GblData>::iterator itData;
+    for (itData = theData.begin(); itData < theData.end(); ++itData) {
+      itData->setPrediction(theVector);
+    }
+  }
 
 /// Down-weight all points.
-/**
- * \param [in] aMethod M-estimator (1: Tukey, 2:Huber, 3:Cauchy)
- */
-double GblTrajectory::downWeight(unsigned int aMethod) {
-	double aLoss = 0.;
-	std::vector<GblData>::iterator itData;
-	for (itData = theData.begin(); itData < theData.end(); ++itData) {
-		aLoss += (1. - itData->setDownWeighting(aMethod));
-	}
-	return aLoss;
-}
+  /**
+   * \param [in] aMethod M-estimator (1: Tukey, 2:Huber, 3:Cauchy)
+   */
+  double GblTrajectory::downWeight(unsigned int aMethod)
+  {
+    double aLoss = 0.;
+    std::vector<GblData>::iterator itData;
+    for (itData = theData.begin(); itData < theData.end(); ++itData) {
+      aLoss += (1. - itData->setDownWeighting(aMethod));
+    }
+    return aLoss;
+  }
 
 /// Perform fit of (valid) trajectory.
-/**
- * Optionally iterate for outlier down-weighting.
- * Fit may fail due to singular or not positive definite matrices (internal exceptions 1-3).
- *
- * \param [out] Chi2 Chi2 sum (corrected for down-weighting)
- * \param [out] Ndf  Number of degrees of freedom
- * \param [out] lostWeight Sum of weights lost due to down-weighting
- * \param [in] optionList Iterations for down-weighting
- * (One character per iteration: t,h,c (or T,H,C) for Tukey, Huber or Cauchy function)
- * \return Error code (non zero value indicates failure of fit)
- */
-unsigned int GblTrajectory::fit(double &Chi2, int &Ndf, double &lostWeight,
-		std::string optionList) {
-	const double normChi2[4] = { 1.0, 0.8737, 0.9326, 0.8228 };
-	const std::string methodList = "TtHhCc";
+  /**
+   * Optionally iterate for outlier down-weighting.
+   * Fit may fail due to singular or not positive definite matrices (internal exceptions 1-3).
+   *
+   * \param [out] Chi2 Chi2 sum (corrected for down-weighting)
+   * \param [out] Ndf  Number of degrees of freedom
+   * \param [out] lostWeight Sum of weights lost due to down-weighting
+   * \param [in] optionList Iterations for down-weighting
+   * (One character per iteration: t,h,c (or T,H,C) for Tukey, Huber or Cauchy function)
+   * \return Error code (non zero value indicates failure of fit)
+   */
+  unsigned int GblTrajectory::fit(double& Chi2, int& Ndf, double& lostWeight,
+                                  std::string optionList)
+  {
+    const double normChi2[4] = { 1.0, 0.8737, 0.9326, 0.8228 };
+    const std::string methodList = "TtHhCc";
 
-	Chi2 = 0.;
-	Ndf = -1;
-	lostWeight = 0.;
-	if (not constructOK)
-		return 10;
+    Chi2 = 0.;
+    Ndf = -1;
+    lostWeight = 0.;
+    if (not constructOK)
+      return 10;
 
-	unsigned int aMethod = 0;
+    unsigned int aMethod = 0;
 
-	buildLinearEquationSystem();
-	lostWeight = 0.;
-	unsigned int ierr = 0;
-	try {
+    buildLinearEquationSystem();
+    lostWeight = 0.;
+    unsigned int ierr = 0;
+    try {
 
-		theMatrix.solveAndInvertBorderedBand(theVector, theVector);
-		predict();
+      theMatrix.solveAndInvertBorderedBand(theVector, theVector);
+      predict();
 
-		for (unsigned int i = 0; i < optionList.size(); ++i) // down weighting iterations
-				{
-			size_t aPosition = methodList.find(optionList[i]);
-			if (aPosition != std::string::npos) {
-				aMethod = aPosition / 2 + 1;
-				lostWeight = downWeight(aMethod);
-				buildLinearEquationSystem();
-				theMatrix.solveAndInvertBorderedBand(theVector, theVector);
-				predict();
-			}
-		}
-		Ndf = theData.size() - numParameters;
-		Chi2 = 0.;
-		for (unsigned int i = 0; i < theData.size(); ++i) {
-			Chi2 += theData[i].getChi2();
-		}
-		Chi2 /= normChi2[aMethod];
-		fitOK = true;
+      for (unsigned int i = 0; i < optionList.size(); ++i) { // down weighting iterations
+        size_t aPosition = methodList.find(optionList[i]);
+        if (aPosition != std::string::npos) {
+          aMethod = aPosition / 2 + 1;
+          lostWeight = downWeight(aMethod);
+          buildLinearEquationSystem();
+          theMatrix.solveAndInvertBorderedBand(theVector, theVector);
+          predict();
+        }
+      }
+      Ndf = theData.size() - numParameters;
+      Chi2 = 0.;
+      for (unsigned int i = 0; i < theData.size(); ++i) {
+        Chi2 += theData[i].getChi2();
+      }
+      Chi2 /= normChi2[aMethod];
+      fitOK = true;
 
-	} catch (int e) {
-		std::cout << " GblTrajectory::fit exception " << e << std::endl;
-		ierr = e;
-	}
-	return ierr;
-}
+    } catch (int e) {
+      std::cout << " GblTrajectory::fit exception " << e << std::endl;
+      ierr = e;
+    }
+    return ierr;
+  }
 
 /// Write valid trajectory to Millepede-II binary file.
-void GblTrajectory::milleOut(MilleBinary &aMille) {
-	double aValue;
-	double aErr;
-	std::vector<unsigned int>* indLocal;
-	std::vector<double>* derLocal;
-	std::vector<int>* labGlobal;
-	std::vector<double>* derGlobal;
+  void GblTrajectory::milleOut(MilleBinary& aMille)
+  {
+    double aValue;
+    double aErr;
+    std::vector<unsigned int>* indLocal;
+    std::vector<double>* derLocal;
+    std::vector<int>* labGlobal;
+    std::vector<double>* derGlobal;
 
-	if (not constructOK)
-		return;
+    if (not constructOK)
+      return;
 
 //   data: measurements, kinks and external seed
-	std::vector<GblData>::iterator itData;
-	for (itData = theData.begin(); itData != theData.end(); ++itData) {
-		itData->getAllData(aValue, aErr, indLocal, derLocal, labGlobal,
-				derGlobal);
-		aMille.addData(aValue, aErr, *indLocal, *derLocal, *labGlobal,
-				*derGlobal);
-	}
-	aMille.writeRecord();
-}
+    std::vector<GblData>::iterator itData;
+    for (itData = theData.begin(); itData != theData.end(); ++itData) {
+      itData->getAllData(aValue, aErr, indLocal, derLocal, labGlobal,
+                         derGlobal);
+      aMille.addData(aValue, aErr, *indLocal, *derLocal, *labGlobal,
+                     *derGlobal);
+    }
+    aMille.writeRecord();
+  }
 
 /// Print GblTrajectory
-/**
- * \param [in] level print level (0: minimum, >0: more)
- */
-void GblTrajectory::printTrajectory(unsigned int level) {
-	if (numInnerTrans) {
-		std::cout << "Composed GblTrajectory, " << numInnerTrans
-				<< " subtrajectories" << std::endl;
-	} else {
-		std::cout << "Simple GblTrajectory" << std::endl;
-	}
-	if (theDimension.size() < 2) {
-		std::cout << " 2D-trajectory" << std::endl;
-	}
-	std::cout << " Number of GblPoints          : " << numAllPoints
-			<< std::endl;
-	std::cout << " Number of points with offsets: " << numOffsets << std::endl;
-	std::cout << " Number of fit parameters     : " << numParameters
-			<< std::endl;
-	std::cout << " Number of measurements       : " << numMeasurements
-			<< std::endl;
-	if (externalMeasurements.GetNrows()) {
-		std::cout << " Number of ext. measurements  : "
-				<< externalMeasurements.GetNrows() << std::endl;
-	}
-	if (externalPoint) {
-		std::cout << " Label of point with ext. seed: " << externalPoint
-				<< std::endl;
-	}
-	if (constructOK) {
-		std::cout << " Constructed OK " << std::endl;
-	}
-	if (fitOK) {
-		std::cout << " Fitted OK " << std::endl;
-	}
-	if (level > 0) {
-		if (numInnerTrans) {
-			std::cout << " Inner transformations" << std::endl;
-			for (unsigned int i = 0; i < numInnerTrans; ++i) {
-				innerTransformations[i].Print();
-			}
-		}
-		if (externalMeasurements.GetNrows()) {
-			std::cout << " External measurements" << std::endl;
-			std::cout << "  Measurements:" << std::endl;
-			externalMeasurements.Print();
-			std::cout << "  Precisions:" << std::endl;
-			externalPrecisions.Print();
-			std::cout << "  Derivatives:" << std::endl;
-			externalDerivatives.Print();
-		}
-		if (externalPoint) {
-			std::cout << " External seed:" << std::endl;
-			externalSeed.Print();
-		}
-		if (fitOK) {
-			std::cout << " Fit results" << std::endl;
-			std::cout << "  Parameters:" << std::endl;
-			theVector.print();
-			std::cout << "  Covariance matrix (bordered band part):"
-					<< std::endl;
-			theMatrix.printMatrix();
-		}
-	}
-}
+  /**
+   * \param [in] level print level (0: minimum, >0: more)
+   */
+  void GblTrajectory::printTrajectory(unsigned int level)
+  {
+    if (numInnerTrans) {
+      std::cout << "Composed GblTrajectory, " << numInnerTrans
+                << " subtrajectories" << std::endl;
+    } else {
+      std::cout << "Simple GblTrajectory" << std::endl;
+    }
+    if (theDimension.size() < 2) {
+      std::cout << " 2D-trajectory" << std::endl;
+    }
+    std::cout << " Number of GblPoints          : " << numAllPoints
+              << std::endl;
+    std::cout << " Number of points with offsets: " << numOffsets << std::endl;
+    std::cout << " Number of fit parameters     : " << numParameters
+              << std::endl;
+    std::cout << " Number of measurements       : " << numMeasurements
+              << std::endl;
+    if (externalMeasurements.GetNrows()) {
+      std::cout << " Number of ext. measurements  : "
+                << externalMeasurements.GetNrows() << std::endl;
+    }
+    if (externalPoint) {
+      std::cout << " Label of point with ext. seed: " << externalPoint
+                << std::endl;
+    }
+    if (constructOK) {
+      std::cout << " Constructed OK " << std::endl;
+    }
+    if (fitOK) {
+      std::cout << " Fitted OK " << std::endl;
+    }
+    if (level > 0) {
+      if (numInnerTrans) {
+        std::cout << " Inner transformations" << std::endl;
+        for (unsigned int i = 0; i < numInnerTrans; ++i) {
+          innerTransformations[i].Print();
+        }
+      }
+      if (externalMeasurements.GetNrows()) {
+        std::cout << " External measurements" << std::endl;
+        std::cout << "  Measurements:" << std::endl;
+        externalMeasurements.Print();
+        std::cout << "  Precisions:" << std::endl;
+        externalPrecisions.Print();
+        std::cout << "  Derivatives:" << std::endl;
+        externalDerivatives.Print();
+      }
+      if (externalPoint) {
+        std::cout << " External seed:" << std::endl;
+        externalSeed.Print();
+      }
+      if (fitOK) {
+        std::cout << " Fit results" << std::endl;
+        std::cout << "  Parameters:" << std::endl;
+        theVector.print();
+        std::cout << "  Covariance matrix (bordered band part):"
+                  << std::endl;
+        theMatrix.printMatrix();
+      }
+    }
+  }
 
 /// Print \link GblPoint GblPoints \endlink on trajectory
-/**
- * \param [in] level print level (0: minimum, >0: more)
- */
-void GblTrajectory::printPoints(unsigned int level) {
-	std::cout << "GblPoints " << std::endl;
-	for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
-		std::vector<GblPoint>::iterator itPoint;
-		for (itPoint = thePoints[iTraj].begin();
-				itPoint < thePoints[iTraj].end(); ++itPoint) {
-			itPoint->printPoint(level);
-		}
-	}
-}
+  /**
+   * \param [in] level print level (0: minimum, >0: more)
+   */
+  void GblTrajectory::printPoints(unsigned int level)
+  {
+    std::cout << "GblPoints " << std::endl;
+    for (unsigned int iTraj = 0; iTraj < numTrajectories; ++iTraj) {
+      std::vector<GblPoint>::iterator itPoint;
+      for (itPoint = thePoints[iTraj].begin();
+           itPoint < thePoints[iTraj].end(); ++itPoint) {
+        itPoint->printPoint(level);
+      }
+    }
+  }
 
 /// Print GblData blocks for trajectory
-void GblTrajectory::printData() {
-	std::cout << "GblData blocks " << std::endl;
-	std::vector<GblData>::iterator itData;
-	for (itData = theData.begin(); itData < theData.end(); ++itData) {
-		itData->printData();
-	}
-}
+  void GblTrajectory::printData()
+  {
+    std::cout << "GblData blocks " << std::endl;
+    std::vector<GblData>::iterator itData;
+    for (itData = theData.begin(); itData < theData.end(); ++itData) {
+      itData->printData();
+    }
+  }
 
 }

--- a/GBL/src/MilleBinary.cc
+++ b/GBL/src/MilleBinary.cc
@@ -33,100 +33,104 @@
 namespace gbl {
 
 /// Create binary file.
-/**
- * \param [in] fileName File name
- * \param [in] doublePrec Flag for storage as double values
- * \param [in] aSize Buffer size
- */
-MilleBinary::MilleBinary(const std::string &fileName, bool doublePrec,
-		unsigned int aSize) :
-		binaryFile(fileName.c_str(), std::ios::binary | std::ios::out), intBuffer(), floatBuffer(), doubleBuffer(), doublePrecision(
-				doublePrec) {
-	intBuffer.reserve(aSize);
-	intBuffer.push_back(0); // first word is error counter
-	if (doublePrecision) {
-		doubleBuffer.reserve(aSize);
-		doubleBuffer.push_back(0.);
+  /**
+   * \param [in] fileName File name
+   * \param [in] doublePrec Flag for storage as double values
+   * \param [in] aSize Buffer size
+   */
+  MilleBinary::MilleBinary(const std::string& fileName, bool doublePrec,
+                           unsigned int aSize) :
+    binaryFile(fileName.c_str(), std::ios::binary | std::ios::out), intBuffer(), floatBuffer(), doubleBuffer(), doublePrecision(
+      doublePrec)
+  {
+    intBuffer.reserve(aSize);
+    intBuffer.push_back(0); // first word is error counter
+    if (doublePrecision) {
+      doubleBuffer.reserve(aSize);
+      doubleBuffer.push_back(0.);
 
-	} else {
-		floatBuffer.reserve(aSize);
-		floatBuffer.push_back(0.);
-	}
-}
+    } else {
+      floatBuffer.reserve(aSize);
+      floatBuffer.push_back(0.);
+    }
+  }
 
-MilleBinary::~MilleBinary() {
-	binaryFile.close();
-}
+  MilleBinary::~MilleBinary()
+  {
+    binaryFile.close();
+  }
 
 /// Add data block to (end of) record.
-/**
- * \param [in] aMeas Value
- * \param [in] aErr Error
- * \param [in] indLocal List of labels of local parameters
- * \param [in] derLocal List of derivatives for local parameters
- * \param [in] labGlobal List of labels of global parameters
- * \param [in] derGlobal List of derivatives for global parameters
- */
-void MilleBinary::addData(double aMeas, double aErr,
-		const std::vector<unsigned int> &indLocal,
-		const std::vector<double> &derLocal, const std::vector<int> &labGlobal,
-		const std::vector<double> &derGlobal) {
+  /**
+   * \param [in] aMeas Value
+   * \param [in] aErr Error
+   * \param [in] indLocal List of labels of local parameters
+   * \param [in] derLocal List of derivatives for local parameters
+   * \param [in] labGlobal List of labels of global parameters
+   * \param [in] derGlobal List of derivatives for global parameters
+   */
+  void MilleBinary::addData(double aMeas, double aErr,
+                            const std::vector<unsigned int>& indLocal,
+                            const std::vector<double>& derLocal, const std::vector<int>& labGlobal,
+                            const std::vector<double>& derGlobal)
+  {
 
-	if (doublePrecision) {
-		// double values
-		intBuffer.push_back(0);
-		doubleBuffer.push_back(aMeas);
-		for (unsigned int i = 0; i < indLocal.size(); ++i) {
-			intBuffer.push_back(indLocal[i]);
-			doubleBuffer.push_back(derLocal[i]);
-		}
-		intBuffer.push_back(0);
-		doubleBuffer.push_back(aErr);
-		for (unsigned int i = 0; i < labGlobal.size(); ++i) {
-			if (derGlobal[i]) {
-				intBuffer.push_back(labGlobal[i]);
-				doubleBuffer.push_back(derGlobal[i]);
-			}
-		}
-	} else {
-		// float values
-		intBuffer.push_back(0);
-		floatBuffer.push_back(aMeas);
-		for (unsigned int i = 0; i < indLocal.size(); ++i) {
-			intBuffer.push_back(indLocal[i]);
-			floatBuffer.push_back(derLocal[i]);
-		}
-		intBuffer.push_back(0);
-		floatBuffer.push_back(aErr);
-		for (unsigned int i = 0; i < labGlobal.size(); ++i) {
-			if (derGlobal[i]) {
-				intBuffer.push_back(labGlobal[i]);
-				floatBuffer.push_back(derGlobal[i]);
-			}
-		}
-	}
-}
+    if (doublePrecision) {
+      // double values
+      intBuffer.push_back(0);
+      doubleBuffer.push_back(aMeas);
+      for (unsigned int i = 0; i < indLocal.size(); ++i) {
+        intBuffer.push_back(indLocal[i]);
+        doubleBuffer.push_back(derLocal[i]);
+      }
+      intBuffer.push_back(0);
+      doubleBuffer.push_back(aErr);
+      for (unsigned int i = 0; i < labGlobal.size(); ++i) {
+        if (derGlobal[i]) {
+          intBuffer.push_back(labGlobal[i]);
+          doubleBuffer.push_back(derGlobal[i]);
+        }
+      }
+    } else {
+      // float values
+      intBuffer.push_back(0);
+      floatBuffer.push_back(aMeas);
+      for (unsigned int i = 0; i < indLocal.size(); ++i) {
+        intBuffer.push_back(indLocal[i]);
+        floatBuffer.push_back(derLocal[i]);
+      }
+      intBuffer.push_back(0);
+      floatBuffer.push_back(aErr);
+      for (unsigned int i = 0; i < labGlobal.size(); ++i) {
+        if (derGlobal[i]) {
+          intBuffer.push_back(labGlobal[i]);
+          floatBuffer.push_back(derGlobal[i]);
+        }
+      }
+    }
+  }
 
 /// Write record to file.
-void MilleBinary::writeRecord() {
+  void MilleBinary::writeRecord()
+  {
 
-	const int recordLength =
-			(doublePrecision) ? -intBuffer.size() * 2 : intBuffer.size() * 2;
-	binaryFile.write(reinterpret_cast<const char*>(&recordLength),
-			sizeof(recordLength));
-	if (doublePrecision)
-		binaryFile.write(reinterpret_cast<char*>(&doubleBuffer[0]),
-				doubleBuffer.size() * sizeof(doubleBuffer[0]));
-	else
-		binaryFile.write(reinterpret_cast<char*>(&floatBuffer[0]),
-				floatBuffer.size() * sizeof(floatBuffer[0]));
-	binaryFile.write(reinterpret_cast<char*>(&intBuffer[0]),
-			intBuffer.size() * sizeof(intBuffer[0]));
+    const int recordLength =
+      (doublePrecision) ? -intBuffer.size() * 2 : intBuffer.size() * 2;
+    binaryFile.write(reinterpret_cast<const char*>(&recordLength),
+                     sizeof(recordLength));
+    if (doublePrecision)
+      binaryFile.write(reinterpret_cast<char*>(&doubleBuffer[0]),
+                       doubleBuffer.size() * sizeof(doubleBuffer[0]));
+    else
+      binaryFile.write(reinterpret_cast<char*>(&floatBuffer[0]),
+                       floatBuffer.size() * sizeof(floatBuffer[0]));
+    binaryFile.write(reinterpret_cast<char*>(&intBuffer[0]),
+                     intBuffer.size() * sizeof(intBuffer[0]));
 // start with new record
-	intBuffer.resize(1);
-	if (doublePrecision)
-		doubleBuffer.resize(1);
-	else
-		floatBuffer.resize(1);
-}
+    intBuffer.resize(1);
+    if (doublePrecision)
+      doubleBuffer.resize(1);
+    else
+      floatBuffer.resize(1);
+  }
 }

--- a/GBL/src/VMatrix.cc
+++ b/GBL/src/VMatrix.cc
@@ -32,421 +32,452 @@
 //! Namespace for the general broken lines package
 namespace gbl {
 
-/*********** simple Matrix based on std::vector<double> **********/
+  /*********** simple Matrix based on std::vector<double> **********/
 
-VMatrix::VMatrix(const unsigned int nRows, const unsigned int nCols) :
-		numRows(nRows), numCols(nCols), theVec(nRows * nCols) {
-}
+  VMatrix::VMatrix(const unsigned int nRows, const unsigned int nCols) :
+    numRows(nRows), numCols(nCols), theVec(nRows * nCols)
+  {
+  }
 
-VMatrix::VMatrix(const VMatrix &aMatrix) :
-		numRows(aMatrix.numRows), numCols(aMatrix.numCols), theVec(
-				aMatrix.theVec) {
+  VMatrix::VMatrix(const VMatrix& aMatrix) :
+    numRows(aMatrix.numRows), numCols(aMatrix.numCols), theVec(
+      aMatrix.theVec)
+  {
 
-}
+  }
 
-VMatrix::~VMatrix() {
-}
+  VMatrix::~VMatrix()
+  {
+  }
 
 /// Resize Matrix.
-/**
- * \param [in] nRows Number of rows.
- * \param [in] nCols Number of columns.
- */
-void VMatrix::resize(const unsigned int nRows, const unsigned int nCols) {
-	numRows = nRows;
-	numCols = nCols;
-	theVec.resize(nRows * nCols);
-}
+  /**
+   * \param [in] nRows Number of rows.
+   * \param [in] nCols Number of columns.
+   */
+  void VMatrix::resize(const unsigned int nRows, const unsigned int nCols)
+  {
+    numRows = nRows;
+    numCols = nCols;
+    theVec.resize(nRows * nCols);
+  }
 
 /// Get transposed matrix.
-/**
- * \return Transposed matrix.
- */
-VMatrix VMatrix::transpose() const {
-	VMatrix aResult(numCols, numRows);
-	for (unsigned int i = 0; i < numRows; ++i) {
-		for (unsigned int j = 0; j < numCols; ++j) {
-			aResult(j, i) = theVec[numCols * i + j];
-		}
-	}
-	return aResult;
-}
+  /**
+   * \return Transposed matrix.
+   */
+  VMatrix VMatrix::transpose() const
+  {
+    VMatrix aResult(numCols, numRows);
+    for (unsigned int i = 0; i < numRows; ++i) {
+      for (unsigned int j = 0; j < numCols; ++j) {
+        aResult(j, i) = theVec[numCols * i + j];
+      }
+    }
+    return aResult;
+  }
 
 /// Get number of rows.
-/**
- * \return Number of rows.
- */
-unsigned int VMatrix::getNumRows() const {
-	return numRows;
-}
+  /**
+   * \return Number of rows.
+   */
+  unsigned int VMatrix::getNumRows() const
+  {
+    return numRows;
+  }
 
 /// Get number of columns.
-/**
- * \return Number of columns.
- */
-unsigned int VMatrix::getNumCols() const {
-	return numCols;
-}
+  /**
+   * \return Number of columns.
+   */
+  unsigned int VMatrix::getNumCols() const
+  {
+    return numCols;
+  }
 
 /// Print matrix.
-void VMatrix::print() const {
-	std::cout << " VMatrix: " << numRows << "*" << numCols << std::endl;
-	for (unsigned int i = 0; i < numRows; ++i) {
-		for (unsigned int j = 0; j < numCols; ++j) {
-			if (j % 5 == 0) {
-				std::cout << std::endl << std::setw(4) << i << ","
-						<< std::setw(4) << j << "-" << std::setw(4)
-						<< std::min(j + 4, numCols) << ":";
-			}
-			std::cout << std::setw(13) << theVec[numCols * i + j];
-		}
-	}
-	std::cout << std::endl << std::endl;
-}
+  void VMatrix::print() const
+  {
+    std::cout << " VMatrix: " << numRows << "*" << numCols << std::endl;
+    for (unsigned int i = 0; i < numRows; ++i) {
+      for (unsigned int j = 0; j < numCols; ++j) {
+        if (j % 5 == 0) {
+          std::cout << std::endl << std::setw(4) << i << ","
+                    << std::setw(4) << j << "-" << std::setw(4)
+                    << std::min(j + 4, numCols) << ":";
+        }
+        std::cout << std::setw(13) << theVec[numCols * i + j];
+      }
+    }
+    std::cout << std::endl << std::endl;
+  }
 
 /// Multiplication Matrix*Vector.
-VVector VMatrix::operator*(const VVector &aVector) const {
-	VVector aResult(numRows);
-	for (unsigned int i = 0; i < this->numRows; ++i) {
-		double sum = 0.0;
-		for (unsigned int j = 0; j < this->numCols; ++j) {
-			sum += theVec[numCols * i + j] * aVector(j);
-		}
-		aResult(i) = sum;
-	}
-	return aResult;
-}
+  VVector VMatrix::operator*(const VVector& aVector) const
+  {
+    VVector aResult(numRows);
+    for (unsigned int i = 0; i < this->numRows; ++i) {
+      double sum = 0.0;
+      for (unsigned int j = 0; j < this->numCols; ++j) {
+        sum += theVec[numCols * i + j] * aVector(j);
+      }
+      aResult(i) = sum;
+    }
+    return aResult;
+  }
 
 /// Multiplication Matrix*Matrix.
-VMatrix VMatrix::operator*(const VMatrix &aMatrix) const {
+  VMatrix VMatrix::operator*(const VMatrix& aMatrix) const
+  {
 
-	VMatrix aResult(numRows, aMatrix.numCols);
-	for (unsigned int i = 0; i < numRows; ++i) {
-		for (unsigned int j = 0; j < aMatrix.numCols; ++j) {
-			double sum = 0.0;
-			for (unsigned int k = 0; k < numCols; ++k) {
-				sum += theVec[numCols * i + k] * aMatrix(k, j);
-			}
-			aResult(i, j) = sum;
-		}
-	}
-	return aResult;
-}
+    VMatrix aResult(numRows, aMatrix.numCols);
+    for (unsigned int i = 0; i < numRows; ++i) {
+      for (unsigned int j = 0; j < aMatrix.numCols; ++j) {
+        double sum = 0.0;
+        for (unsigned int k = 0; k < numCols; ++k) {
+          sum += theVec[numCols * i + k] * aMatrix(k, j);
+        }
+        aResult(i, j) = sum;
+      }
+    }
+    return aResult;
+  }
 
 /// Addition Matrix+Matrix.
-VMatrix VMatrix::operator+(const VMatrix &aMatrix) const {
-	VMatrix aResult(numRows, numCols);
-	for (unsigned int i = 0; i < numRows; ++i) {
-		for (unsigned int j = 0; j < numCols; ++j) {
-			aResult(i, j) = theVec[numCols * i + j] + aMatrix(i, j);
-		}
-	}
-	return aResult;
-}
+  VMatrix VMatrix::operator+(const VMatrix& aMatrix) const
+  {
+    VMatrix aResult(numRows, numCols);
+    for (unsigned int i = 0; i < numRows; ++i) {
+      for (unsigned int j = 0; j < numCols; ++j) {
+        aResult(i, j) = theVec[numCols * i + j] + aMatrix(i, j);
+      }
+    }
+    return aResult;
+  }
 
 /// Assignment Matrix=Matrix.
-VMatrix &VMatrix::operator=(const VMatrix &aMatrix) {
-	if (this != &aMatrix) {   // Gracefully handle self assignment
-		numRows = aMatrix.getNumRows();
-		numCols = aMatrix.getNumCols();
-		theVec.resize(numRows * numCols);
-		for (unsigned int i = 0; i < numRows; ++i) {
-			for (unsigned int j = 0; j < numCols; ++j) {
-				theVec[numCols * i + j] = aMatrix(i, j);
-			}
-		}
-	}
-	return *this;
-}
+  VMatrix& VMatrix::operator=(const VMatrix& aMatrix)
+  {
+    if (this != &aMatrix) {   // Gracefully handle self assignment
+      numRows = aMatrix.getNumRows();
+      numCols = aMatrix.getNumCols();
+      theVec.resize(numRows * numCols);
+      for (unsigned int i = 0; i < numRows; ++i) {
+        for (unsigned int j = 0; j < numCols; ++j) {
+          theVec[numCols * i + j] = aMatrix(i, j);
+        }
+      }
+    }
+    return *this;
+  }
 
-/*********** simple symmetric Matrix based on std::vector<double> **********/
+  /*********** simple symmetric Matrix based on std::vector<double> **********/
 
-VSymMatrix::VSymMatrix(const unsigned int nRows) :
-		numRows(nRows), theVec((nRows * nRows + nRows) / 2) {
-}
+  VSymMatrix::VSymMatrix(const unsigned int nRows) :
+    numRows(nRows), theVec((nRows * nRows + nRows) / 2)
+  {
+  }
 
-VSymMatrix::~VSymMatrix() {
-}
+  VSymMatrix::~VSymMatrix()
+  {
+  }
 
 /// Resize symmetric matrix.
-/**
- * \param [in] nRows Number of rows.
- */
-void VSymMatrix::resize(const unsigned int nRows) {
-	numRows = nRows;
-	theVec.resize((nRows * nRows + nRows) / 2);
-}
+  /**
+   * \param [in] nRows Number of rows.
+   */
+  void VSymMatrix::resize(const unsigned int nRows)
+  {
+    numRows = nRows;
+    theVec.resize((nRows * nRows + nRows) / 2);
+  }
 
 /// Get number of rows (= number of colums).
-/**
- * \return Number of rows.
- */
-unsigned int VSymMatrix::getNumRows() const {
-	return numRows;
-}
+  /**
+   * \return Number of rows.
+   */
+  unsigned int VSymMatrix::getNumRows() const
+  {
+    return numRows;
+  }
 
 /// Print matrix.
-void VSymMatrix::print() const {
-	std::cout << " VSymMatrix: " << numRows << "*" << numRows << std::endl;
-	for (unsigned int i = 0; i < numRows; ++i) {
-		for (unsigned int j = 0; j <= i; ++j) {
-			if (j % 5 == 0) {
-				std::cout << std::endl << std::setw(4) << i << ","
-						<< std::setw(4) << j << "-" << std::setw(4)
-						<< std::min(j + 4, i) << ":";
-			}
-			std::cout << std::setw(13) << theVec[(i * i + i) / 2 + j];
-		}
-	}
-	std::cout << std::endl << std::endl;
-}
+  void VSymMatrix::print() const
+  {
+    std::cout << " VSymMatrix: " << numRows << "*" << numRows << std::endl;
+    for (unsigned int i = 0; i < numRows; ++i) {
+      for (unsigned int j = 0; j <= i; ++j) {
+        if (j % 5 == 0) {
+          std::cout << std::endl << std::setw(4) << i << ","
+                    << std::setw(4) << j << "-" << std::setw(4)
+                    << std::min(j + 4, i) << ":";
+        }
+        std::cout << std::setw(13) << theVec[(i * i + i) / 2 + j];
+      }
+    }
+    std::cout << std::endl << std::endl;
+  }
 
 /// Subtraction SymMatrix-(sym)Matrix.
-VSymMatrix VSymMatrix::operator-(const VMatrix &aMatrix) const {
-	VSymMatrix aResult(numRows);
-	for (unsigned int i = 0; i < numRows; ++i) {
-		for (unsigned int j = 0; j <= i; ++j) {
-			aResult(i, j) = theVec[(i * i + i) / 2 + j] - aMatrix(i, j);
-		}
-	}
-	return aResult;
-}
+  VSymMatrix VSymMatrix::operator-(const VMatrix& aMatrix) const
+  {
+    VSymMatrix aResult(numRows);
+    for (unsigned int i = 0; i < numRows; ++i) {
+      for (unsigned int j = 0; j <= i; ++j) {
+        aResult(i, j) = theVec[(i * i + i) / 2 + j] - aMatrix(i, j);
+      }
+    }
+    return aResult;
+  }
 
 /// Multiplication SymMatrix*Vector.
-VVector VSymMatrix::operator*(const VVector &aVector) const {
-	VVector aResult(numRows);
-	for (unsigned int i = 0; i < numRows; ++i) {
-		aResult(i) = theVec[(i * i + i) / 2 + i] * aVector(i);
-		for (unsigned int j = 0; j < i; ++j) {
-			aResult(j) += theVec[(i * i + i) / 2 + j] * aVector(i);
-			aResult(i) += theVec[(i * i + i) / 2 + j] * aVector(j);
-		}
-	}
-	return aResult;
-}
+  VVector VSymMatrix::operator*(const VVector& aVector) const
+  {
+    VVector aResult(numRows);
+    for (unsigned int i = 0; i < numRows; ++i) {
+      aResult(i) = theVec[(i * i + i) / 2 + i] * aVector(i);
+      for (unsigned int j = 0; j < i; ++j) {
+        aResult(j) += theVec[(i * i + i) / 2 + j] * aVector(i);
+        aResult(i) += theVec[(i * i + i) / 2 + j] * aVector(j);
+      }
+    }
+    return aResult;
+  }
 
 /// Multiplication SymMatrix*Matrix.
-VMatrix VSymMatrix::operator*(const VMatrix &aMatrix) const {
-	unsigned int nCol = aMatrix.getNumCols();
-	VMatrix aResult(numRows, nCol);
-	for (unsigned int l = 0; l < nCol; ++l) {
-		for (unsigned int i = 0; i < numRows; ++i) {
-			aResult(i, l) = theVec[(i * i + i) / 2 + i] * aMatrix(i, l);
-			for (unsigned int j = 0; j < i; ++j) {
-				aResult(j, l) += theVec[(i * i + i) / 2 + j] * aMatrix(i, l);
-				aResult(i, l) += theVec[(i * i + i) / 2 + j] * aMatrix(j, l);
-			}
-		}
-	}
-	return aResult;
-}
+  VMatrix VSymMatrix::operator*(const VMatrix& aMatrix) const
+  {
+    unsigned int nCol = aMatrix.getNumCols();
+    VMatrix aResult(numRows, nCol);
+    for (unsigned int l = 0; l < nCol; ++l) {
+      for (unsigned int i = 0; i < numRows; ++i) {
+        aResult(i, l) = theVec[(i * i + i) / 2 + i] * aMatrix(i, l);
+        for (unsigned int j = 0; j < i; ++j) {
+          aResult(j, l) += theVec[(i * i + i) / 2 + j] * aMatrix(i, l);
+          aResult(i, l) += theVec[(i * i + i) / 2 + j] * aMatrix(j, l);
+        }
+      }
+    }
+    return aResult;
+  }
 
-/*********** simple Vector based on std::vector<double> **********/
+  /*********** simple Vector based on std::vector<double> **********/
 
-VVector::VVector(const unsigned int nRows) :
-		numRows(nRows), theVec(nRows) {
-}
+  VVector::VVector(const unsigned int nRows) :
+    numRows(nRows), theVec(nRows)
+  {
+  }
 
-VVector::VVector(const VVector &aVector) :
-		numRows(aVector.numRows), theVec(aVector.theVec) {
+  VVector::VVector(const VVector& aVector) :
+    numRows(aVector.numRows), theVec(aVector.theVec)
+  {
 
-}
+  }
 
-VVector::~VVector() {
-}
+  VVector::~VVector()
+  {
+  }
 
 /// Resize vector.
-/**
- * \param [in] nRows Number of rows.
- */
-void VVector::resize(const unsigned int nRows) {
-	numRows = nRows;
-	theVec.resize(nRows);
-}
+  /**
+   * \param [in] nRows Number of rows.
+   */
+  void VVector::resize(const unsigned int nRows)
+  {
+    numRows = nRows;
+    theVec.resize(nRows);
+  }
 
 /// Get part of vector.
-/**
- * \param [in] len Length of part.
- * \param [in] start Offset of part.
- * \return Part of vector.
- */
-VVector VVector::getVec(unsigned int len, unsigned int start) const {
-	VVector aResult(len);
-	std::memcpy(&aResult.theVec[0], &theVec[start], sizeof(double) * len);
-	return aResult;
-}
+  /**
+   * \param [in] len Length of part.
+   * \param [in] start Offset of part.
+   * \return Part of vector.
+   */
+  VVector VVector::getVec(unsigned int len, unsigned int start) const
+  {
+    VVector aResult(len);
+    std::memcpy(&aResult.theVec[0], &theVec[start], sizeof(double) * len);
+    return aResult;
+  }
 
 /// Put part of vector.
-/**
- * \param [in] aVector Vector with part.
- * \param [in] start Offset of part.
- */
-void VVector::putVec(const VVector &aVector, unsigned int start) {
-	std::memcpy(&theVec[start], &aVector.theVec[0],
-			sizeof(double) * aVector.numRows);
-}
+  /**
+   * \param [in] aVector Vector with part.
+   * \param [in] start Offset of part.
+   */
+  void VVector::putVec(const VVector& aVector, unsigned int start)
+  {
+    std::memcpy(&theVec[start], &aVector.theVec[0],
+                sizeof(double) * aVector.numRows);
+  }
 
 /// Get number of rows.
-/**
- * \return Number of rows.
- */
-unsigned int VVector::getNumRows() const {
-	return numRows;
-}
+  /**
+   * \return Number of rows.
+   */
+  unsigned int VVector::getNumRows() const
+  {
+    return numRows;
+  }
 
 /// Print vector.
-void VVector::print() const {
-	std::cout << " VVector: " << numRows << std::endl;
-	for (unsigned int i = 0; i < numRows; ++i) {
+  void VVector::print() const
+  {
+    std::cout << " VVector: " << numRows << std::endl;
+    for (unsigned int i = 0; i < numRows; ++i) {
 
-		if (i % 5 == 0) {
-			std::cout << std::endl << std::setw(4) << i << "-" << std::setw(4)
-					<< std::min(i + 4, numRows) << ":";
-		}
-		std::cout << std::setw(13) << theVec[i];
-	}
-	std::cout << std::endl << std::endl;
-}
+      if (i % 5 == 0) {
+        std::cout << std::endl << std::setw(4) << i << "-" << std::setw(4)
+                  << std::min(i + 4, numRows) << ":";
+      }
+      std::cout << std::setw(13) << theVec[i];
+    }
+    std::cout << std::endl << std::endl;
+  }
 
 /// Subtraction Vector-Vector.
-VVector VVector::operator-(const VVector &aVector) const {
-	VVector aResult(numRows);
-	for (unsigned int i = 0; i < numRows; ++i) {
-		aResult(i) = theVec[i] - aVector(i);
-	}
-	return aResult;
-}
+  VVector VVector::operator-(const VVector& aVector) const
+  {
+    VVector aResult(numRows);
+    for (unsigned int i = 0; i < numRows; ++i) {
+      aResult(i) = theVec[i] - aVector(i);
+    }
+    return aResult;
+  }
 
 /// Assignment Vector=Vector.
-VVector &VVector::operator=(const VVector &aVector) {
-	if (this != &aVector) {   // Gracefully handle self assignment
-		numRows = aVector.getNumRows();
-		theVec.resize(numRows);
-		for (unsigned int i = 0; i < numRows; ++i) {
-			theVec[i] = aVector(i);
-		}
-	}
-	return *this;
-}
+  VVector& VVector::operator=(const VVector& aVector)
+  {
+    if (this != &aVector) {   // Gracefully handle self assignment
+      numRows = aVector.getNumRows();
+      theVec.resize(numRows);
+      for (unsigned int i = 0; i < numRows; ++i) {
+        theVec[i] = aVector(i);
+      }
+    }
+    return *this;
+  }
 
-/*============================================================================
- from mpnum.F (MillePede-II by V. Blobel, Univ. Hamburg)
- ============================================================================*/
+  /*============================================================================
+   from mpnum.F (MillePede-II by V. Blobel, Univ. Hamburg)
+   ============================================================================*/
 /// Matrix inversion.
-/**
- *     Invert symmetric N-by-N matrix V in symmetric storage mode
- *               V(1) = V11, V(2) = V12, V(3) = V22, V(4) = V13, . . .
- *               replaced by inverse matrix
- *
- *     Method of solution is by elimination selecting the  pivot  on  the
- *     diagonal each stage. The rank of the matrix is returned in  NRANK.
- *     For NRANK ne N, all remaining  rows  and  cols  of  the  resulting
- *     matrix V are  set  to  zero.
- *  \exception 1 : matrix is singular.
- *  \return Rank of matrix.
- */
-unsigned int VSymMatrix::invert() {
+  /**
+   *     Invert symmetric N-by-N matrix V in symmetric storage mode
+   *               V(1) = V11, V(2) = V12, V(3) = V22, V(4) = V13, . . .
+   *               replaced by inverse matrix
+   *
+   *     Method of solution is by elimination selecting the  pivot  on  the
+   *     diagonal each stage. The rank of the matrix is returned in  NRANK.
+   *     For NRANK ne N, all remaining  rows  and  cols  of  the  resulting
+   *     matrix V are  set  to  zero.
+   *  \exception 1 : matrix is singular.
+   *  \return Rank of matrix.
+   */
+  unsigned int VSymMatrix::invert()
+  {
 
-	const double eps = 1.0E-10;
-	unsigned int aSize = numRows;
-	std::vector<int> next(aSize);
-	std::vector<double> diag(aSize);
-	int nSize = aSize;
+    const double eps = 1.0E-10;
+    unsigned int aSize = numRows;
+    std::vector<int> next(aSize);
+    std::vector<double> diag(aSize);
+    int nSize = aSize;
 
-	int first = 1;
-	for (int i = 1; i <= nSize; ++i) {
-		next[i - 1] = i + 1; // set "next" pointer
-		diag[i - 1] = fabs(theVec[(i * i + i) / 2 - 1]); // save abs of diagonal elements
-	}
-	next[aSize - 1] = -1; // end flag
+    int first = 1;
+    for (int i = 1; i <= nSize; ++i) {
+      next[i - 1] = i + 1; // set "next" pointer
+      diag[i - 1] = fabs(theVec[(i * i + i) / 2 - 1]); // save abs of diagonal elements
+    }
+    next[aSize - 1] = -1; // end flag
 
-	unsigned int nrank = 0;
-	for (int i = 1; i <= nSize; ++i) { // start of loop
-		int k = 0;
-		double vkk = 0.0;
+    unsigned int nrank = 0;
+    for (int i = 1; i <= nSize; ++i) { // start of loop
+      int k = 0;
+      double vkk = 0.0;
 
-		int j = first;
-		int previous = 0;
-		int last = previous;
-		// look for pivot
-		while (j > 0) {
-			int jj = (j * j + j) / 2 - 1;
-			if (fabs(theVec[jj]) > std::max(fabs(vkk), eps * diag[j - 1])) {
-				vkk = theVec[jj];
-				k = j;
-				last = previous;
-			}
-			previous = j;
-			j = next[j - 1];
-		}
-		// pivot found
-		if (k > 0) {
-			int kk = (k * k + k) / 2 - 1;
-			if (last <= 0) {
-				first = next[k - 1];
-			} else {
-				next[last - 1] = next[k - 1];
-			}
-			next[k - 1] = 0; // index is used, reset
-			nrank++; // increase rank and ...
+      int j = first;
+      int previous = 0;
+      int last = previous;
+      // look for pivot
+      while (j > 0) {
+        int jj = (j * j + j) / 2 - 1;
+        if (fabs(theVec[jj]) > std::max(fabs(vkk), eps * diag[j - 1])) {
+          vkk = theVec[jj];
+          k = j;
+          last = previous;
+        }
+        previous = j;
+        j = next[j - 1];
+      }
+      // pivot found
+      if (k > 0) {
+        int kk = (k * k + k) / 2 - 1;
+        if (last <= 0) {
+          first = next[k - 1];
+        } else {
+          next[last - 1] = next[k - 1];
+        }
+        next[k - 1] = 0; // index is used, reset
+        nrank++; // increase rank and ...
 
-			vkk = 1.0 / vkk;
-			theVec[kk] = -vkk;
-			int jk = kk - k;
-			int jl = -1;
-			for (int m = 1; m <= nSize; ++m) { // elimination
-				if (m == k) {
-					jk = kk;
-					jl += m;
-				} else {
-					if (m < k) {
-						++jk;
-					} else {
-						jk += m - 1;
-					}
+        vkk = 1.0 / vkk;
+        theVec[kk] = -vkk;
+        int jk = kk - k;
+        int jl = -1;
+        for (int m = 1; m <= nSize; ++m) { // elimination
+          if (m == k) {
+            jk = kk;
+            jl += m;
+          } else {
+            if (m < k) {
+              ++jk;
+            } else {
+              jk += m - 1;
+            }
 
-					double vjk = theVec[jk];
-					theVec[jk] = vkk * vjk;
-					int lk = kk - k;
-					if (m >= k) {
-						for (int l = 1; l <= k - 1; ++l) {
-							++jl;
-							++lk;
-							theVec[jl] -= theVec[lk] * vjk;
-						}
-						++jl;
-						lk = kk;
-						for (int l = k + 1; l <= m; ++l) {
-							++jl;
-							lk += l - 1;
-							theVec[jl] -= theVec[lk] * vjk;
-						}
-					} else {
-						for (int l = 1; l <= m; ++l) {
-							++jl;
-							++lk;
-							theVec[jl] -= theVec[lk] * vjk;
-						}
-					}
-				}
-			}
-		} else {
-			for (int m = 1; m <= nSize; ++m) {
-				if (next[m - 1] >= 0) {
-					int kk = (m * m - m) / 2 - 1;
-					for (int n = 1; n <= nSize; ++n) {
-						if (next[n - 1] >= 0) {
-							theVec[kk + n] = 0.0; // clear matrix row/col
-						}
-					}
-				}
-			}
-			throw 1; // singular
-		}
-	}
-	for (int ij = 0; ij < (nSize * nSize + nSize) / 2; ++ij) {
-		theVec[ij] = -theVec[ij]; // finally reverse sign of all matrix elements
-	}
-	return nrank;
-}
+            double vjk = theVec[jk];
+            theVec[jk] = vkk * vjk;
+            int lk = kk - k;
+            if (m >= k) {
+              for (int l = 1; l <= k - 1; ++l) {
+                ++jl;
+                ++lk;
+                theVec[jl] -= theVec[lk] * vjk;
+              }
+              ++jl;
+              lk = kk;
+              for (int l = k + 1; l <= m; ++l) {
+                ++jl;
+                lk += l - 1;
+                theVec[jl] -= theVec[lk] * vjk;
+              }
+            } else {
+              for (int l = 1; l <= m; ++l) {
+                ++jl;
+                ++lk;
+                theVec[jl] -= theVec[lk] * vjk;
+              }
+            }
+          }
+        }
+      } else {
+        for (int m = 1; m <= nSize; ++m) {
+          if (next[m - 1] >= 0) {
+            int kk = (m * m - m) / 2 - 1;
+            for (int n = 1; n <= nSize; ++n) {
+              if (next[n - 1] >= 0) {
+                theVec[kk + n] = 0.0; // clear matrix row/col
+              }
+            }
+          }
+        }
+        throw 1; // singular
+      }
+    }
+    for (int ij = 0; ij < (nSize * nSize + nSize) / 2; ++ij) {
+      theVec[ij] = -theVec[ij]; // finally reverse sign of all matrix elements
+    }
+    return nrank;
+  }
 }

--- a/GFRave/include/GFRaveConverters.h
+++ b/GFRave/include/GFRaveConverters.h
@@ -61,22 +61,23 @@ namespace genfit {
    * If a vector of MeasuredStateOnPlane is provided, they will be used (instead of the tracks fitted states) to calculate the rave::Track parameters.
    * Ownership over MeasuredStateOnPlane will be taken.
    */
-  std::vector < rave::Track > GFTracksToTracks(const std::vector < genfit::Track* > & GFTracks,
-                                               std::vector < genfit::MeasuredStateOnPlane* > * GFStates, // = nullptr
+  std::vector < rave::Track > GFTracksToTracks(const std::vector < genfit::Track* >& GFTracks,
+                                               std::vector < genfit::MeasuredStateOnPlane* >* GFStates,  // = nullptr
                                                std::map<int, genfit::trackAndState>& IdGFTrackStateMap,
                                                int startID = 0);
 
-  rave::Track GFTrackToTrack(trackAndState, int id = -1, std::string tag="");
+  rave::Track GFTrackToTrack(trackAndState, int id = -1, std::string tag = "");
   //rave::Track MeasuredStateOnPlaneToTrack(const MeasuredStateOnPlane* state, const rave::Track& orig);
   //rave::Track MeasuredStateOnPlaneToTrack(const MeasuredStateOnPlane* state, int id = -1, Track* originaltrack = nullptr, std::string tag="");
 
   // RAVE to GENFIT
   /** set state and cov of a MeasuredStateOnPlane according to rave track
    */
-  void setData(const rave::Track & orig, MeasuredStateOnPlane* state);
+  void setData(const rave::Track& orig, MeasuredStateOnPlane* state);
 
-  GFRaveVertex* RaveToGFVertex(const rave::Vertex &, const std::map<int, genfit::trackAndState>& IdGFTrackStateMap);
-  void RaveToGFVertices(std::vector<GFRaveVertex*> *, const std::vector<rave::Vertex> &, const std::map<int, genfit::trackAndState>& IdGFTrackStateMap);
+  GFRaveVertex* RaveToGFVertex(const rave::Vertex&, const std::map<int, genfit::trackAndState>& IdGFTrackStateMap);
+  void RaveToGFVertices(std::vector<GFRaveVertex*>*, const std::vector<rave::Vertex>&,
+                        const std::map<int, genfit::trackAndState>& IdGFTrackStateMap);
 
   SharedPlanePtr PlaneToGFDetPlane(const ravesurf::Plane& rplane);
 
@@ -89,7 +90,7 @@ namespace genfit {
   TMatrixDSym Covariance6DToTMatrixDSym(const rave::Covariance6D&);
 
   // ROOT to RAVE
-  rave::Point3D TVector3ToPoint3D(const TVector3 &);
+  rave::Point3D TVector3ToPoint3D(const TVector3&);
   rave::Covariance3D TMatrixDSymToCovariance3D(const TMatrixDSym&);
 
 

--- a/GFRave/include/GFRaveMagneticField.h
+++ b/GFRave/include/GFRaveMagneticField.h
@@ -33,21 +33,21 @@
 
 namespace genfit {
 
-/**
- * @brief GFRaveMagneticField class
- * Uses the FieldManager to provide a magnetic field to rave.
- */
-class GFRaveMagneticField : public rave::MagneticField {
+  /**
+   * @brief GFRaveMagneticField class
+   * Uses the FieldManager to provide a magnetic field to rave.
+   */
+  class GFRaveMagneticField : public rave::MagneticField {
   public:
-    GFRaveMagneticField(){};
-    virtual GFRaveMagneticField * copy() const;
-    virtual ~GFRaveMagneticField(){};
+    GFRaveMagneticField() {};
+    virtual GFRaveMagneticField* copy() const;
+    virtual ~GFRaveMagneticField() {};
 
-    virtual rave::Vector3D inTesla ( const rave::Point3D & ) const;
+    virtual rave::Vector3D inTesla(const rave::Point3D&) const;
 
   private:
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/GFRave/include/GFRavePropagator.h
+++ b/GFRave/include/GFRavePropagator.h
@@ -42,37 +42,37 @@
 
 namespace genfit {
 
-/**
- * @brief GFRavePropagator class
- *
- * Inherits from rave::Propagator. A map has to be provided,
- * containing pointers the genfit::Tracks, as well as pointers to clones of fitted states.
- * The GFRavePropagator uses the information of the rave::track to set
- * the state and covariance of the corresponding MeasuredStateOnPlane,
- * extrapolates and then returns a new rave::track with the
- * extrapolated state and covariance.
- */
-class GFRavePropagator : public rave::Propagator
-{
+  /**
+   * @brief GFRavePropagator class
+   *
+   * Inherits from rave::Propagator. A map has to be provided,
+   * containing pointers the genfit::Tracks, as well as pointers to clones of fitted states.
+   * The GFRavePropagator uses the information of the rave::track to set
+   * the state and covariance of the corresponding MeasuredStateOnPlane,
+   * extrapolates and then returns a new rave::track with the
+   * extrapolated state and covariance.
+   */
+  class GFRavePropagator : public rave::Propagator {
   public:
     GFRavePropagator();
     virtual GFRavePropagator* copy() const;
-    virtual rave::Track closestTo ( const rave::Track &,
-                                    const rave::Point3D &, bool transverse ) const;
-    virtual std::pair < rave::Track, double > to ( const rave::Track & orig,
-                                                   const ravesurf::Plane & ) const;
-    virtual std::pair < rave::Track, double > to ( const rave::Track & orig,
-                                                   const ravesurf::Cylinder & ) const;
+    virtual rave::Track closestTo(const rave::Track&,
+                                  const rave::Point3D&, bool transverse) const;
+    virtual std::pair < rave::Track, double > to(const rave::Track& orig,
+                                                 const ravesurf::Plane&) const;
+    virtual std::pair < rave::Track, double > to(const rave::Track& orig,
+                                                 const ravesurf::Cylinder&) const;
 
     virtual ~GFRavePropagator();
 
-    void setIdGFTrackStateMap(std::map < int, genfit::trackAndState > * map);
+    void setIdGFTrackStateMap(std::map < int, genfit::trackAndState >* map);
 
   private:
 
     // data members
-    std::map < int, genfit::trackAndState > * IdGFTrackStateMap_; // pointers to genfit::tracks and measuredStateOnPlanes via rave track ID
-};
+    std::map < int, genfit::trackAndState >*
+    IdGFTrackStateMap_;  // pointers to genfit::tracks and measuredStateOnPlanes via rave track ID
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/GFRave/include/GFRaveTrackParameters.h
+++ b/GFRave/include/GFRaveTrackParameters.h
@@ -43,17 +43,17 @@
 
 namespace genfit {
 
-/**
- * @brief GFRaveTrackParameters class
- * Contains a pointer to the original genfit::Track, the weight of the track in the vertex,
- * and smoothed (with the vertex information) state and covariance of the track.
- */
-class GFRaveTrackParameters : public TObject
-{
+  /**
+   * @brief GFRaveTrackParameters class
+   * Contains a pointer to the original genfit::Track, the weight of the track in the vertex,
+   * and smoothed (with the vertex information) state and covariance of the track.
+   */
+  class GFRaveTrackParameters : public TObject {
   public:
     // constructors, destructors
     GFRaveTrackParameters();
-    GFRaveTrackParameters(const Track* track, MeasuredStateOnPlane* originalState, double weight, const TVectorD & state6, const TMatrixDSym & cov6x6, bool isSmoothed);
+    GFRaveTrackParameters(const Track* track, MeasuredStateOnPlane* originalState, double weight, const TVectorD& state6,
+                          const TMatrixDSym& cov6x6, bool isSmoothed);
     GFRaveTrackParameters(const Track* track, MeasuredStateOnPlane* originalState, double weight);
 
     // Accessors
@@ -68,7 +68,7 @@ class GFRaveTrackParameters : public TObject
     TVectorD getState() const {return state_;}
     TVector3 getPos() const;
     TVector3 getMom() const;
-    const TMatrixDSym & getCov() const {return cov_;}
+    const TMatrixDSym& getCov() const {return cov_;}
 
     double getCharge() const;
     double getPdg() const;
@@ -86,7 +86,7 @@ class GFRaveTrackParameters : public TObject
 
   private:
     ClassDef(GFRaveTrackParameters, 1)
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/GFRave/include/GFRaveVertex.h
+++ b/GFRave/include/GFRaveVertex.h
@@ -36,25 +36,25 @@
 
 namespace genfit {
 
-/**
- * @brief GFRaveVertex class
- *
- * A Vertex contains information about its position and covariance.
- * The tracks the vertex is consisting of are stored in smoothedTracks_.
- * These GFRaveTrackParameters contain the weight of the corresponding track
- * in the vertex, smoothed track parameters and a pointer to the original
- * unaltered genfit::Track.
- */
-class GFRaveVertex : public TObject {
+  /**
+   * @brief GFRaveVertex class
+   *
+   * A Vertex contains information about its position and covariance.
+   * The tracks the vertex is consisting of are stored in smoothedTracks_.
+   * These GFRaveTrackParameters contain the weight of the corresponding track
+   * in the vertex, smoothed track parameters and a pointer to the original
+   * unaltered genfit::Track.
+   */
+  class GFRaveVertex : public TObject {
 
   public:
     // constructors, destructors
     GFRaveVertex();
-    GFRaveVertex(const TVector3 & pos, const TMatrixDSym & cov,
-                 const std::vector < genfit::GFRaveTrackParameters* > & smoothedTracks,
+    GFRaveVertex(const TVector3& pos, const TMatrixDSym& cov,
+                 const std::vector < genfit::GFRaveTrackParameters* >& smoothedTracks,
                  double ndf, double chi2, int id = -1);
 
-    GFRaveVertex(const GFRaveVertex &);
+    GFRaveVertex(const GFRaveVertex&);
 
     GFRaveVertex& operator=(GFRaveVertex);
     void swap(GFRaveVertex&);
@@ -89,12 +89,13 @@ class GFRaveVertex : public TObject {
     double chi2_;
     int id_; // id of the rave::vertex the GFVertex is created from
 
-    std::vector < genfit::GFRaveTrackParameters* > smoothedTracks_; //-> track parameters of smoothed (with the vertex information) tracks, weights and original tracks; Vertex has ownership!
+    std::vector < genfit::GFRaveTrackParameters* >
+    smoothedTracks_; //-> track parameters of smoothed (with the vertex information) tracks, weights and original tracks; Vertex has ownership!
 
   public:
     ClassDef(GFRaveVertex, 1)
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/GFRave/include/GFRaveVertexFactory.h
+++ b/GFRave/include/GFRaveVertexFactory.h
@@ -45,52 +45,54 @@ namespace rave {
 
 namespace genfit {
 
-/**
- * @brief Simple struct containing a Track pointer and a MeasuredStateOnPlane. Used in GFRave.
- */
-struct trackAndState {
-  const Track* track_; // pointer to original track
-  MeasuredStateOnPlane* state_; // pointer to copy of fitted state; can be altered (extrapolated) during vertexing
-};
+  /**
+   * @brief Simple struct containing a Track pointer and a MeasuredStateOnPlane. Used in GFRave.
+   */
+  struct trackAndState {
+    const Track* track_; // pointer to original track
+    MeasuredStateOnPlane* state_; // pointer to copy of fitted state; can be altered (extrapolated) during vertexing
+  };
 
-
-/**
- * @brief Vertex factory for producing GFRaveVertex objects from Track objects.
- *
- * The GFRaveVertexFactory is basically a wrapper around the rave::VertexFactory.
- * It takes care of initializing the rave::VertexFactory, building the necessary maps,
- * convert GENFIT to rave objects and vice versa.
- **/
-class GFRaveVertexFactory {
- public:
-  // constructors, destructors
-  GFRaveVertexFactory(int verbosity = 0, bool useVacuumPropagator = false);
-  ~GFRaveVertexFactory();
-
-  // functions
-  void findVertices ( std::vector <  genfit::GFRaveVertex* > *, const std::vector < genfit::Track* > &, bool use_beamspot=false );
-  //! MeasuredStateOnPlanes will be used (instead of the tracks fitted states) to calculate the rave::Track parameters. takes ownership of MeasuredStateOnPlanes.
-  void findVertices ( std::vector <  genfit::GFRaveVertex* > *, const std::vector < genfit::Track* > &, std::vector < genfit::MeasuredStateOnPlane* > &, bool use_beamspot=false );
-
-  void setBeamspot(const TVector3 & pos, const TMatrixDSym & cov);
 
   /**
-   * Set the reconstruction method. See http://projects.hepforge.org/rave/trac/wiki/RaveMethods
-   * Smoothing has to be turned on! e.g. kalman-smoothing:1
-   */
-  void setMethod(const std::string & method);
+   * @brief Vertex factory for producing GFRaveVertex objects from Track objects.
+   *
+   * The GFRaveVertexFactory is basically a wrapper around the rave::VertexFactory.
+   * It takes care of initializing the rave::VertexFactory, building the necessary maps,
+   * convert GENFIT to rave objects and vice versa.
+   **/
+  class GFRaveVertexFactory {
+  public:
+    // constructors, destructors
+    GFRaveVertexFactory(int verbosity = 0, bool useVacuumPropagator = false);
+    ~GFRaveVertexFactory();
 
- private:
+    // functions
+    void findVertices(std::vector <  genfit::GFRaveVertex* >*, const std::vector < genfit::Track* >&, bool use_beamspot = false);
+    //! MeasuredStateOnPlanes will be used (instead of the tracks fitted states) to calculate the rave::Track parameters. takes ownership of MeasuredStateOnPlanes.
+    void findVertices(std::vector <  genfit::GFRaveVertex* >*, const std::vector < genfit::Track* >&,
+                      std::vector < genfit::MeasuredStateOnPlane* >&, bool use_beamspot = false);
 
-  void clearMap();
+    void setBeamspot(const TVector3& pos, const TMatrixDSym& cov);
 
-  // data members
-  std::map<int, genfit::trackAndState> IdGFTrackStateMap_; // map of copies of the cardinal MeasuredStateOnPlanes for the GFRavePropagator; ownership of MeasuredStateOnPlanes is HERE!!!
-  rave::VertexFactory* factory_; // Ownership
-  rave::MagneticField* magneticField_; // Ownership
-  rave::Propagator* propagator_; // Ownership
+    /**
+     * Set the reconstruction method. See http://projects.hepforge.org/rave/trac/wiki/RaveMethods
+     * Smoothing has to be turned on! e.g. kalman-smoothing:1
+     */
+    void setMethod(const std::string& method);
 
-};
+  private:
+
+    void clearMap();
+
+    // data members
+    std::map<int, genfit::trackAndState>
+    IdGFTrackStateMap_; // map of copies of the cardinal MeasuredStateOnPlanes for the GFRavePropagator; ownership of MeasuredStateOnPlanes is HERE!!!
+    rave::VertexFactory* factory_; // Ownership
+    rave::MagneticField* magneticField_; // Ownership
+    rave::Propagator* propagator_; // Ownership
+
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/GFRave/src/GFRaveConverters.cc
+++ b/GFRave/src/GFRaveConverters.cc
@@ -32,316 +32,329 @@
 namespace genfit {
 
 
-std::vector < rave::Track >
-GFTracksToTracks(const std::vector < genfit::Track* >  & GFTracks,
-    std::vector < genfit::MeasuredStateOnPlane* > * GFStates,
-    std::map<int, genfit::trackAndState>& IdGFTrackStateMap,
-    int startID){
+  std::vector < rave::Track >
+  GFTracksToTracks(const std::vector < genfit::Track* >&   GFTracks,
+                   std::vector < genfit::MeasuredStateOnPlane* >* GFStates,
+                   std::map<int, genfit::trackAndState>& IdGFTrackStateMap,
+                   int startID)
+  {
 
-  unsigned int ntracks(GFTracks.size());
+    unsigned int ntracks(GFTracks.size());
 
-  if (GFStates != nullptr)
-    if (GFTracks.size() != GFStates->size()) {
-      Exception exc("GFTracksToTracks ==> GFStates has not the same size as GFTracks!",__LINE__,__FILE__);
+    if (GFStates != nullptr)
+      if (GFTracks.size() != GFStates->size()) {
+        Exception exc("GFTracksToTracks ==> GFStates has not the same size as GFTracks!", __LINE__, __FILE__);
+        throw exc;
+      }
+
+    std::vector < rave::Track > ravetracks;
+    ravetracks.reserve(ntracks);
+
+    for (unsigned int i = 0; i < ntracks; ++i) {
+
+      if (GFTracks[i] == nullptr) {
+        Exception exc("GFTracksToTracks ==> genfit::Track is nullptr", __LINE__, __FILE__);
+        throw exc;
+      }
+
+      // only convert successfully fitted tracks!
+      if (!GFTracks[i]->getFitStatus(GFTracks[i]->getCardinalRep())->isFitConverged()) continue;
+
+      if (IdGFTrackStateMap.count(startID) > 0) {
+        Exception exc("GFTracksToTracks ==> IdGFTrackStateMap has already an entry for this id", __LINE__, __FILE__);
+        throw exc;
+      }
+      IdGFTrackStateMap[startID].track_ = GFTracks[i];
+      if (GFStates == nullptr)
+        IdGFTrackStateMap[startID].state_ = new MeasuredStateOnPlane(
+          GFTracks[i]->getFittedState()); // here clones are made so that the state of the original GFTracks and their TrackReps will not be altered by the vertexing process
+      else
+        IdGFTrackStateMap[startID].state_ = (*GFStates)[i];
+
+      ravetracks.push_back(GFTrackToTrack(IdGFTrackStateMap[startID], startID));
+
+      ++startID;
+    }
+
+    //std::cout << "IdGFTrackStateMap size " << IdGFTrackStateMap.size() << std::endl;
+    return ravetracks;
+  }
+
+
+  rave::Track
+  GFTrackToTrack(trackAndState trackAndState, int id, std::string tag)
+  {
+
+    if (trackAndState.track_ == nullptr) {
+      Exception exc("GFTrackToTrack ==> originaltrack is nullptr", __LINE__, __FILE__);
       throw exc;
     }
 
-  std::vector < rave::Track > ravetracks;
-  ravetracks.reserve(ntracks);
-
-  for (unsigned int i=0; i<ntracks; ++i){
-
-    if (GFTracks[i] == nullptr) {
-      Exception exc("GFTracksToTracks ==> genfit::Track is nullptr",__LINE__,__FILE__);
+    if (! trackAndState.track_->getFitStatus()->isFitConverged()) {
+      Exception exc("GFTrackToTrack ==> Trackfit is not converged", __LINE__, __FILE__);
       throw exc;
     }
 
-    // only convert successfully fitted tracks!
-    if (!GFTracks[i]->getFitStatus(GFTracks[i]->getCardinalRep())->isFitConverged()) continue;
+    TVector3 pos, mom;
+    TMatrixDSym cov;
 
-    if (IdGFTrackStateMap.count(startID) > 0){
-      Exception exc("GFTracksToTracks ==> IdGFTrackStateMap has already an entry for this id",__LINE__,__FILE__);
-      throw exc;
-    }
-    IdGFTrackStateMap[startID].track_ = GFTracks[i];
-    if (GFStates == nullptr)
-      IdGFTrackStateMap[startID].state_ = new MeasuredStateOnPlane(GFTracks[i]->getFittedState()); // here clones are made so that the state of the original GFTracks and their TrackReps will not be altered by the vertexing process
-    else
-      IdGFTrackStateMap[startID].state_ = (*GFStates)[i];
+    trackAndState.track_->getFittedState().getPosMomCov(pos, mom, cov);
 
-    ravetracks.push_back(GFTrackToTrack(IdGFTrackStateMap[startID], startID) );
+    // state
+    rave::Vector6D ravestate(pos.X(), pos.Y(), pos.Z(),
+                             mom.X(), mom.Y(), mom.Z());
 
-    ++startID;
+    // covariance
+    rave::Covariance6D ravecov(cov(0, 0), cov(1, 0), cov(2, 0),
+                               cov(1, 1), cov(2, 1), cov(2, 2),
+                               cov(3, 0), cov(4, 0), cov(5, 0),
+                               cov(3, 1), cov(4, 1), cov(5, 1),
+                               cov(3, 2), cov(4, 2), cov(5, 2),
+                               cov(3, 3), cov(4, 3), cov(5, 3),
+                               cov(4, 4), cov(5, 4), cov(5, 5));
+
+    //std::cerr<<"create rave track with id " << id << std::endl;
+    //std::cerr<<"  pos: "; Point3DToTVector3(ravestate.position()).Print();
+    //std::cerr<<"  mom: "; Vector3DToTVector3(ravestate.momentum()).Print();
+
+    rave::Track ret(id, ravestate, ravecov,
+                    trackAndState.track_->getFitStatus()->getCharge(),
+                    trackAndState.track_->getFitStatus()->getChi2(),
+                    trackAndState.track_->getFitStatus()->getNdf(),
+                    static_cast<void*>(const_cast<Track*>(trackAndState.track_)), tag);
+
+    //std::cout << "ret.originalObject() " << ret.originalObject() << "\n";
+    //std::cout << "ret.id() " << ret.id() << "\n";
+
+    return ret;
   }
 
-  //std::cout << "IdGFTrackStateMap size " << IdGFTrackStateMap.size() << std::endl;
-  return ravetracks;
-}
 
+  void
+  setData(const rave::Track& orig, MeasuredStateOnPlane* state)
+  {
 
-rave::Track
-GFTrackToTrack(trackAndState trackAndState, int id, std::string tag){
+    state->setPosMomCov(TVector3(orig.state().x(), orig.state().y(), orig.state().z()),
+                        TVector3(orig.state().px(), orig.state().py(), orig.state().pz()),
+                        Covariance6DToTMatrixDSym(orig.error()));
 
-  if (trackAndState.track_ == nullptr) {
-    Exception exc("GFTrackToTrack ==> originaltrack is nullptr",__LINE__,__FILE__);
-    throw exc;
   }
 
-  if (! trackAndState.track_->getFitStatus()->isFitConverged()) {
-    Exception exc("GFTrackToTrack ==> Trackfit is not converged",__LINE__,__FILE__);
-    throw exc;
-  }
 
-  TVector3 pos, mom;
-  TMatrixDSym cov;
+  GFRaveVertex*
+  RaveToGFVertex(const rave::Vertex& raveVertex,
+                 const std::map<int, genfit::trackAndState>& IdGFTrackStateMap)
+  {
 
-  trackAndState.track_->getFittedState().getPosMomCov(pos, mom, cov);
-
-  // state
-  rave::Vector6D ravestate(pos.X(), pos.Y(), pos.Z(),
-                           mom.X(), mom.Y(), mom.Z());
-
-  // covariance
-  rave::Covariance6D ravecov(cov(0,0), cov(1,0), cov(2,0),
-                             cov(1,1), cov(2,1), cov(2,2),
-                             cov(3,0), cov(4,0), cov(5,0),
-                             cov(3,1), cov(4,1), cov(5,1),
-                             cov(3,2), cov(4,2), cov(5,2),
-                             cov(3,3), cov(4,3), cov(5,3),
-                             cov(4,4), cov(5,4), cov(5,5));
-
-  //std::cerr<<"create rave track with id " << id << std::endl;
-  //std::cerr<<"  pos: "; Point3DToTVector3(ravestate.position()).Print();
-  //std::cerr<<"  mom: "; Vector3DToTVector3(ravestate.momentum()).Print();
-
-  rave::Track ret(id, ravestate, ravecov,
-      trackAndState.track_->getFitStatus()->getCharge(),
-      trackAndState.track_->getFitStatus()->getChi2(),
-      trackAndState.track_->getFitStatus()->getNdf(),
-      static_cast<void*>(const_cast<Track*>(trackAndState.track_)), tag);
-
-  //std::cout << "ret.originalObject() " << ret.originalObject() << "\n";
-  //std::cout << "ret.id() " << ret.id() << "\n";
-
-  return ret;
-}
-
-
-void
-setData(const rave::Track& orig, MeasuredStateOnPlane* state){
-
-  state->setPosMomCov(TVector3(orig.state().x(), orig.state().y(), orig.state().z()),
-                      TVector3(orig.state().px(), orig.state().py(), orig.state().pz()),
-                      Covariance6DToTMatrixDSym(orig.error()));
-
-}
-
-
-GFRaveVertex*
-RaveToGFVertex(const rave::Vertex & raveVertex,
-    const std::map<int, genfit::trackAndState>& IdGFTrackStateMap){
-
-  if (!(raveVertex.isValid())) {
-    Exception exc("RaveToGFVertex ==> rave Vertex is not valid!",__LINE__,__FILE__);
-    throw exc;
-  }
-
-  std::vector < std::pair < float, rave::Track > > raveWeightedTracks(raveVertex.weightedTracks());
-  std::vector < std::pair < float, rave::Track > > raveSmoothedTracks(raveVertex.weightedRefittedTracks());
-
-  int id;
-  unsigned int nTrks(raveWeightedTracks.size());
-
-  // check if rave vertex has  refitted tracks
-  bool smoothing(true);
-  if (! (raveVertex.hasRefittedTracks()) ) {
-    smoothing = false;
-  }
-
-  // check numbers of tracks and smoothed tracks
-  if (smoothing && nTrks != raveSmoothedTracks.size()){
-    Exception exc("RaveToGFVertex ==> number of smoothed tracks != number of tracks",__LINE__,__FILE__);
-    throw exc;
-  }
-
-  // (smoothed) track parameters
-  std::vector < GFRaveTrackParameters* > trackParameters;
-  trackParameters.reserve(nTrks);
-
-  // convert tracks
-  for (unsigned int i=0; i<nTrks; ++i){
-    id = raveWeightedTracks[i].second.id();
-
-    if (IdGFTrackStateMap.count(id) == 0){
-      Exception exc("RaveToGFVertex ==> rave track id is not present in IdGFTrackStateMap",__LINE__,__FILE__);
+    if (!(raveVertex.isValid())) {
+      Exception exc("RaveToGFVertex ==> rave Vertex is not valid!", __LINE__, __FILE__);
       throw exc;
     }
 
-    GFRaveTrackParameters* trackparams;
+    std::vector < std::pair < float, rave::Track > > raveWeightedTracks(raveVertex.weightedTracks());
+    std::vector < std::pair < float, rave::Track > > raveSmoothedTracks(raveVertex.weightedRefittedTracks());
 
-    if(smoothing) {
-      // convert smoothed track parameters
-      trackparams = new GFRaveTrackParameters(IdGFTrackStateMap.at(id).track_, //track
-          IdGFTrackStateMap.at(id).state_, //state
-          raveWeightedTracks[i].first, //weight
-          Vector6DToTVectorD(raveSmoothedTracks[i].second.state()), //smoothed state
-          Covariance6DToTMatrixDSym(raveSmoothedTracks[i].second.error()), //smoothed cov
-          true);
+    int id;
+    unsigned int nTrks(raveWeightedTracks.size());
+
+    // check if rave vertex has  refitted tracks
+    bool smoothing(true);
+    if (!(raveVertex.hasRefittedTracks())) {
+      smoothing = false;
     }
-    else {
-      // convert track parameters, no smoothed tracks available
-      trackparams = new GFRaveTrackParameters(IdGFTrackStateMap.at(id).track_, //track
-          IdGFTrackStateMap.at(id).state_, //state
-          raveWeightedTracks[i].first, //weight
-          Vector6DToTVectorD(raveWeightedTracks[i].second.state()), //state
-          Covariance6DToTMatrixDSym(raveWeightedTracks[i].second.error()), //cov
-          false);
+
+    // check numbers of tracks and smoothed tracks
+    if (smoothing && nTrks != raveSmoothedTracks.size()) {
+      Exception exc("RaveToGFVertex ==> number of smoothed tracks != number of tracks", __LINE__, __FILE__);
+      throw exc;
     }
-    trackParameters.push_back(trackparams);
+
+    // (smoothed) track parameters
+    std::vector < GFRaveTrackParameters* > trackParameters;
+    trackParameters.reserve(nTrks);
+
+    // convert tracks
+    for (unsigned int i = 0; i < nTrks; ++i) {
+      id = raveWeightedTracks[i].second.id();
+
+      if (IdGFTrackStateMap.count(id) == 0) {
+        Exception exc("RaveToGFVertex ==> rave track id is not present in IdGFTrackStateMap", __LINE__, __FILE__);
+        throw exc;
+      }
+
+      GFRaveTrackParameters* trackparams;
+
+      if (smoothing) {
+        // convert smoothed track parameters
+        trackparams = new GFRaveTrackParameters(IdGFTrackStateMap.at(id).track_, //track
+                                                IdGFTrackStateMap.at(id).state_, //state
+                                                raveWeightedTracks[i].first, //weight
+                                                Vector6DToTVectorD(raveSmoothedTracks[i].second.state()), //smoothed state
+                                                Covariance6DToTMatrixDSym(raveSmoothedTracks[i].second.error()), //smoothed cov
+                                                true);
+      } else {
+        // convert track parameters, no smoothed tracks available
+        trackparams = new GFRaveTrackParameters(IdGFTrackStateMap.at(id).track_, //track
+                                                IdGFTrackStateMap.at(id).state_, //state
+                                                raveWeightedTracks[i].first, //weight
+                                                Vector6DToTVectorD(raveWeightedTracks[i].second.state()), //state
+                                                Covariance6DToTMatrixDSym(raveWeightedTracks[i].second.error()), //cov
+                                                false);
+      }
+      trackParameters.push_back(trackparams);
+    }
+
+    return new GFRaveVertex(Point3DToTVector3(raveVertex.position()),
+                            Covariance3DToTMatrixDSym(raveVertex.error()),
+                            trackParameters,
+                            raveVertex.ndf(), raveVertex.chiSquared(), raveVertex.id());
   }
 
-  return new GFRaveVertex(Point3DToTVector3(raveVertex.position()),
-                          Covariance3DToTMatrixDSym(raveVertex.error()),
-                          trackParameters,
-                          raveVertex.ndf(), raveVertex.chiSquared(), raveVertex.id());
-}
+  void
+  RaveToGFVertices(std::vector<GFRaveVertex*>* GFVertices,
+                   const std::vector<rave::Vertex>& raveVertices,
+                   const std::map<int, genfit::trackAndState>& IdGFTrackStateMap)
+  {
 
-void
-RaveToGFVertices(std::vector<GFRaveVertex*> * GFVertices,
-    const std::vector<rave::Vertex> & raveVertices,
-    const std::map<int, genfit::trackAndState>& IdGFTrackStateMap){
+    unsigned int nVert(raveVertices.size());
 
-  unsigned int nVert(raveVertices.size());
+    GFVertices->reserve(nVert);
 
-  GFVertices->reserve(nVert);
-
-  for (unsigned int i=0; i<nVert; ++i){
-    GFVertices->push_back(RaveToGFVertex(raveVertices[i], IdGFTrackStateMap));
-  }
-}
-
-
-SharedPlanePtr
-PlaneToGFDetPlane(const ravesurf::Plane& rplane) {
-  return SharedPlanePtr(new DetPlane(Point3DToTVector3(rplane.position()),
-                    Vector3DToTVector3(rplane.normalVector()) ));
-}
-
-
-TVector3
-Point3DToTVector3(const rave::Point3D& v) {
-  return TVector3(v.x(), v.y(), v.z());
-}
-
-TVector3
-Vector3DToTVector3(const rave::Vector3D& v) {
-  return TVector3(v.x(), v.y(), v.z());
-}
-
-
-TMatrixDSym
-Covariance3DToTMatrixDSym(const rave::Covariance3D& ravecov){
-  TMatrixDSym cov(3);
-
-  cov(0,0) = ravecov.dxx();
-  cov(0,1) = ravecov.dxy();
-  cov(0,2) = ravecov.dxz();
-
-  cov(1,0) = ravecov.dxy();
-  cov(1,1) = ravecov.dyy();
-  cov(1,2) = ravecov.dyz();
-
-  cov(2,0) = ravecov.dxz();
-  cov(2,1) = ravecov.dyz();
-  cov(2,2) = ravecov.dzz();
-
-  return cov;
-}
-
-
-TVectorD
-Vector6DToTVectorD(const rave::Vector6D& ravevec){
-  TVectorD vec(6);
-
-  vec[0] = ravevec.x();
-  vec[1] = ravevec.y();
-  vec[2] = ravevec.z();
-
-  vec[3] = ravevec.px();
-  vec[4] = ravevec.py();
-  vec[5] = ravevec.pz();
-
-  return vec;
-}
-
-
-TMatrixDSym
-Covariance6DToTMatrixDSym(const rave::Covariance6D& ravecov){
-  TMatrixDSym cov(6);
-
-  cov(0,0) = ravecov.dxx();
-  cov(0,1) = ravecov.dxy();
-  cov(0,2) = ravecov.dxz();
-  cov(0,3) = ravecov.dxpx();
-  cov(0,4) = ravecov.dxpy();
-  cov(0,5) = ravecov.dxpz();
-
-  cov(1,0) = ravecov.dxy();
-  cov(1,1) = ravecov.dyy();
-  cov(1,2) = ravecov.dyz();
-  cov(1,3) = ravecov.dypx();
-  cov(1,4) = ravecov.dypy();
-  cov(1,5) = ravecov.dypz();
-
-  cov(2,0) = ravecov.dxz();
-  cov(2,1) = ravecov.dyz();
-  cov(2,2) = ravecov.dzz();
-  cov(2,3) = ravecov.dzpx();
-  cov(2,4) = ravecov.dzpy();
-  cov(2,5) = ravecov.dzpz();
-
-  cov(3,0) = ravecov.dxpx();
-  cov(3,1) = ravecov.dypx();
-  cov(3,2) = ravecov.dzpx();
-  cov(3,3) = ravecov.dpxpx();
-  cov(3,4) = ravecov.dpxpy();
-  cov(3,5) = ravecov.dpxpz();
-
-  cov(4,0) = ravecov.dxpy();
-  cov(4,1) = ravecov.dypy();
-  cov(4,2) = ravecov.dzpy();
-  cov(4,3) = ravecov.dpxpy();
-  cov(4,4) = ravecov.dpypy();
-  cov(4,5) = ravecov.dpypz();
-
-  cov(5,0) = ravecov.dxpz();
-  cov(5,1) = ravecov.dypz();
-  cov(5,2) = ravecov.dzpz();
-  cov(5,3) = ravecov.dpxpz();
-  cov(5,4) = ravecov.dpypz();
-  cov(5,5) = ravecov.dpzpz();
-
-  return cov;
-}
-
-
-rave::Point3D
-TVector3ToPoint3D(const TVector3 & vec){
-  return rave::Point3D(vec.X(), vec.Y(), vec.Z());
-}
-
-
-rave::Covariance3D
-TMatrixDSymToCovariance3D(const TMatrixDSym & matrix){
-  if (matrix.GetNrows()!=3) {
-    Exception exc("TMatrixDSymToCovariance3D ==> TMatrixDSym is not 3x3!",__LINE__,__FILE__);
-    throw exc;
+    for (unsigned int i = 0; i < nVert; ++i) {
+      GFVertices->push_back(RaveToGFVertex(raveVertices[i], IdGFTrackStateMap));
+    }
   }
 
-  return rave::Covariance3D(matrix(0,0), matrix(0,1), matrix(0,2),
-                            matrix(1,1), matrix(1,2), matrix(2,2));
 
-}
+  SharedPlanePtr
+  PlaneToGFDetPlane(const ravesurf::Plane& rplane)
+  {
+    return SharedPlanePtr(new DetPlane(Point3DToTVector3(rplane.position()),
+                                       Vector3DToTVector3(rplane.normalVector())));
+  }
+
+
+  TVector3
+  Point3DToTVector3(const rave::Point3D& v)
+  {
+    return TVector3(v.x(), v.y(), v.z());
+  }
+
+  TVector3
+  Vector3DToTVector3(const rave::Vector3D& v)
+  {
+    return TVector3(v.x(), v.y(), v.z());
+  }
+
+
+  TMatrixDSym
+  Covariance3DToTMatrixDSym(const rave::Covariance3D& ravecov)
+  {
+    TMatrixDSym cov(3);
+
+    cov(0, 0) = ravecov.dxx();
+    cov(0, 1) = ravecov.dxy();
+    cov(0, 2) = ravecov.dxz();
+
+    cov(1, 0) = ravecov.dxy();
+    cov(1, 1) = ravecov.dyy();
+    cov(1, 2) = ravecov.dyz();
+
+    cov(2, 0) = ravecov.dxz();
+    cov(2, 1) = ravecov.dyz();
+    cov(2, 2) = ravecov.dzz();
+
+    return cov;
+  }
+
+
+  TVectorD
+  Vector6DToTVectorD(const rave::Vector6D& ravevec)
+  {
+    TVectorD vec(6);
+
+    vec[0] = ravevec.x();
+    vec[1] = ravevec.y();
+    vec[2] = ravevec.z();
+
+    vec[3] = ravevec.px();
+    vec[4] = ravevec.py();
+    vec[5] = ravevec.pz();
+
+    return vec;
+  }
+
+
+  TMatrixDSym
+  Covariance6DToTMatrixDSym(const rave::Covariance6D& ravecov)
+  {
+    TMatrixDSym cov(6);
+
+    cov(0, 0) = ravecov.dxx();
+    cov(0, 1) = ravecov.dxy();
+    cov(0, 2) = ravecov.dxz();
+    cov(0, 3) = ravecov.dxpx();
+    cov(0, 4) = ravecov.dxpy();
+    cov(0, 5) = ravecov.dxpz();
+
+    cov(1, 0) = ravecov.dxy();
+    cov(1, 1) = ravecov.dyy();
+    cov(1, 2) = ravecov.dyz();
+    cov(1, 3) = ravecov.dypx();
+    cov(1, 4) = ravecov.dypy();
+    cov(1, 5) = ravecov.dypz();
+
+    cov(2, 0) = ravecov.dxz();
+    cov(2, 1) = ravecov.dyz();
+    cov(2, 2) = ravecov.dzz();
+    cov(2, 3) = ravecov.dzpx();
+    cov(2, 4) = ravecov.dzpy();
+    cov(2, 5) = ravecov.dzpz();
+
+    cov(3, 0) = ravecov.dxpx();
+    cov(3, 1) = ravecov.dypx();
+    cov(3, 2) = ravecov.dzpx();
+    cov(3, 3) = ravecov.dpxpx();
+    cov(3, 4) = ravecov.dpxpy();
+    cov(3, 5) = ravecov.dpxpz();
+
+    cov(4, 0) = ravecov.dxpy();
+    cov(4, 1) = ravecov.dypy();
+    cov(4, 2) = ravecov.dzpy();
+    cov(4, 3) = ravecov.dpxpy();
+    cov(4, 4) = ravecov.dpypy();
+    cov(4, 5) = ravecov.dpypz();
+
+    cov(5, 0) = ravecov.dxpz();
+    cov(5, 1) = ravecov.dypz();
+    cov(5, 2) = ravecov.dzpz();
+    cov(5, 3) = ravecov.dpxpz();
+    cov(5, 4) = ravecov.dpypz();
+    cov(5, 5) = ravecov.dpzpz();
+
+    return cov;
+  }
+
+
+  rave::Point3D
+  TVector3ToPoint3D(const TVector3& vec)
+  {
+    return rave::Point3D(vec.X(), vec.Y(), vec.Z());
+  }
+
+
+  rave::Covariance3D
+  TMatrixDSymToCovariance3D(const TMatrixDSym& matrix)
+  {
+    if (matrix.GetNrows() != 3) {
+      Exception exc("TMatrixDSymToCovariance3D ==> TMatrixDSym is not 3x3!", __LINE__, __FILE__);
+      throw exc;
+    }
+
+    return rave::Covariance3D(matrix(0, 0), matrix(0, 1), matrix(0, 2),
+                              matrix(1, 1), matrix(1, 2), matrix(2, 2));
+
+  }
 
 
 } // end of namespace genfit

--- a/GFRave/src/GFRaveMagneticField.cc
+++ b/GFRave/src/GFRaveMagneticField.cc
@@ -26,22 +26,23 @@
 
 namespace genfit {
 
-GFRaveMagneticField *
-GFRaveMagneticField::copy() const{
-  return new GFRaveMagneticField(*this);
-}
+  GFRaveMagneticField*
+  GFRaveMagneticField::copy() const
+  {
+    return new GFRaveMagneticField(*this);
+  }
 
 
-rave::Vector3D
-GFRaveMagneticField::inTesla ( const rave::Point3D & position) const
-{
-  TVector3 pos(position.x(), position.y(), position.z());
+  rave::Vector3D
+  GFRaveMagneticField::inTesla(const rave::Point3D& position) const
+  {
+    TVector3 pos(position.x(), position.y(), position.z());
 
-  TVector3 B = FieldManager::getInstance()->getFieldVal(pos); // magnetic field in kGauss
-  B *= 1.E-1;
+    TVector3 B = FieldManager::getInstance()->getFieldVal(pos); // magnetic field in kGauss
+    B *= 1.E-1;
 
-  return rave::Vector3D (B.X(), B.Y(), B.Z());
-}
+    return rave::Vector3D(B.X(), B.Y(), B.Z());
+  }
 
 
 } /* End of namespace genfit */

--- a/GFRave/src/GFRavePropagator.cc
+++ b/GFRave/src/GFRavePropagator.cc
@@ -27,76 +27,77 @@
 
 namespace genfit {
 
-GFRavePropagator::GFRavePropagator() :
+  GFRavePropagator::GFRavePropagator() :
     IdGFTrackStateMap_(nullptr)
-{
-  //std::cout << "GFRavePropagator::GFRavePropagator() \n";
-}
-  
-GFRavePropagator*
-GFRavePropagator::copy() const
-{
-  //std::cout << "GFRavePropagator::copy() \n";
-  return new GFRavePropagator(*this);
-}
+  {
+    //std::cout << "GFRavePropagator::GFRavePropagator() \n";
+  }
+
+  GFRavePropagator*
+  GFRavePropagator::copy() const
+  {
+    //std::cout << "GFRavePropagator::copy() \n";
+    return new GFRavePropagator(*this);
+  }
 
 
-GFRavePropagator::~GFRavePropagator()
-{
-  //std::cout << "GFRavePropagator::~GFRavePropagator() \n";
-}
-    
-    
-std::pair < rave::Track, double >
-GFRavePropagator::to ( const rave::Track & /*orig*/,
-                       const ravesurf::Cylinder & /*rcyl*/ ) const
-{
-  // todo to be implemented!!
-  Exception exc("GFRavePropagator::to (cylinder) ==> not yet implemented!",__LINE__,__FILE__);
-  throw exc;
-}
+  GFRavePropagator::~GFRavePropagator()
+  {
+    //std::cout << "GFRavePropagator::~GFRavePropagator() \n";
+  }
 
 
-std::pair < rave::Track, double >
-GFRavePropagator::to ( const rave::Track & orig,
-                       const ravesurf::Plane & rplane ) const
-{
-  // will throw Exception if extrapolation does not work
-  double path = IdGFTrackStateMap_->at(orig.id()).state_->extrapolateToPlane(PlaneToGFDetPlane(rplane));
-
-  std::pair < rave::Track, double > ret(GFTrackToTrack(IdGFTrackStateMap_->at(orig.id()), orig.id(), orig.tag()), path);
-  return ret;
-}
-
-
-rave::Track
-GFRavePropagator::closestTo ( const rave::Track & orig,
-                              const rave::Point3D & pt, bool transverse ) const
-{
-
-  if (transverse){
-    Exception exc("GFRavePropagator::closestTo ==> transverse is true, not implemented!",__LINE__,__FILE__);
+  std::pair < rave::Track, double >
+  GFRavePropagator::to(const rave::Track& /*orig*/,
+                       const ravesurf::Cylinder& /*rcyl*/) const
+  {
+    // todo to be implemented!!
+    Exception exc("GFRavePropagator::to (cylinder) ==> not yet implemented!", __LINE__, __FILE__);
     throw exc;
   }
 
-  TVector3 point(Point3DToTVector3(pt));
-  IdGFTrackStateMap_->at(orig.id()).state_->extrapolateToPoint(point);
 
-  return GFTrackToTrack(IdGFTrackStateMap_->at(orig.id()), orig.id(), orig.tag());
-}
+  std::pair < rave::Track, double >
+  GFRavePropagator::to(const rave::Track& orig,
+                       const ravesurf::Plane& rplane) const
+  {
+    // will throw Exception if extrapolation does not work
+    double path = IdGFTrackStateMap_->at(orig.id()).state_->extrapolateToPlane(PlaneToGFDetPlane(rplane));
 
-
-void
-GFRavePropagator::setIdGFTrackStateMap(std::map < int, genfit::trackAndState > * map){
-  //std::cout << "GFRavePropagator::setIdGFMeasuredStateOnPlaneMap() \n";
-
-  IdGFTrackStateMap_ = map;
-
-  if (IdGFTrackStateMap_==nullptr) {
-    Exception exc("GFRavePropagator::setIdGFMeasuredStateOnPlaneMap ==> map is nullptr!",__LINE__,__FILE__);
-    throw exc;
+    std::pair < rave::Track, double > ret(GFTrackToTrack(IdGFTrackStateMap_->at(orig.id()), orig.id(), orig.tag()), path);
+    return ret;
   }
-  //std::cout<<"IdGFTrackStateMap_: " << (int)IdGFTrackStateMap_ << std::endl;
-}
+
+
+  rave::Track
+  GFRavePropagator::closestTo(const rave::Track& orig,
+                              const rave::Point3D& pt, bool transverse) const
+  {
+
+    if (transverse) {
+      Exception exc("GFRavePropagator::closestTo ==> transverse is true, not implemented!", __LINE__, __FILE__);
+      throw exc;
+    }
+
+    TVector3 point(Point3DToTVector3(pt));
+    IdGFTrackStateMap_->at(orig.id()).state_->extrapolateToPoint(point);
+
+    return GFTrackToTrack(IdGFTrackStateMap_->at(orig.id()), orig.id(), orig.tag());
+  }
+
+
+  void
+  GFRavePropagator::setIdGFTrackStateMap(std::map < int, genfit::trackAndState >* map)
+  {
+    //std::cout << "GFRavePropagator::setIdGFMeasuredStateOnPlaneMap() \n";
+
+    IdGFTrackStateMap_ = map;
+
+    if (IdGFTrackStateMap_ == nullptr) {
+      Exception exc("GFRavePropagator::setIdGFMeasuredStateOnPlaneMap ==> map is nullptr!", __LINE__, __FILE__);
+      throw exc;
+    }
+    //std::cout<<"IdGFTrackStateMap_: " << (int)IdGFTrackStateMap_ << std::endl;
+  }
 
 } /* End of namespace genfit */

--- a/GFRave/src/GFRaveTrackParameters.cc
+++ b/GFRave/src/GFRaveTrackParameters.cc
@@ -28,85 +28,91 @@
 namespace genfit {
 
 
-GFRaveTrackParameters::GFRaveTrackParameters() :
-  originalTrack_(nullptr),
-  weight_(0),
-  state_(6),
-  cov_(6,6),
-  hasSmoothedData_(false)
-{
-  ;
-}
-
-
-GFRaveTrackParameters::GFRaveTrackParameters(const Track* track, MeasuredStateOnPlane* /*originalState*/, double weight, const TVectorD & state6, const TMatrixDSym & cov6x6, bool isSmoothed) :
-  originalTrack_(const_cast<Track*>(track)),
-  weight_(weight),
-  state_(state6),
-  cov_(cov6x6),
-  hasSmoothedData_(isSmoothed)
-{
-  if (state_.GetNrows() != 6) {
-    Exception exc("GFRaveTrackParameters ==> State is not 6D!",__LINE__,__FILE__);
-    throw exc;
-  }
-  if (cov_.GetNrows()!=6) {
-    Exception exc("GFRaveTrackParameters ==> Covariance is not 6D!",__LINE__,__FILE__);
-    throw exc;
+  GFRaveTrackParameters::GFRaveTrackParameters() :
+    originalTrack_(nullptr),
+    weight_(0),
+    state_(6),
+    cov_(6, 6),
+    hasSmoothedData_(false)
+  {
+    ;
   }
 
-}
 
+  GFRaveTrackParameters::GFRaveTrackParameters(const Track* track, MeasuredStateOnPlane* /*originalState*/, double weight,
+                                               const TVectorD& state6, const TMatrixDSym& cov6x6, bool isSmoothed) :
+    originalTrack_(const_cast<Track*>(track)),
+    weight_(weight),
+    state_(state6),
+    cov_(cov6x6),
+    hasSmoothedData_(isSmoothed)
+  {
+    if (state_.GetNrows() != 6) {
+      Exception exc("GFRaveTrackParameters ==> State is not 6D!", __LINE__, __FILE__);
+      throw exc;
+    }
+    if (cov_.GetNrows() != 6) {
+      Exception exc("GFRaveTrackParameters ==> Covariance is not 6D!", __LINE__, __FILE__);
+      throw exc;
+    }
 
-GFRaveTrackParameters::GFRaveTrackParameters(const Track* track, MeasuredStateOnPlane* /*originalState*/, double weight) :
-  originalTrack_(const_cast<Track*>(track)),
-  weight_(weight),
-  state_(1,6),
-  cov_(6,6),
-  hasSmoothedData_(false)
-{
-  ;
-}
-
-
-TVector3
-GFRaveTrackParameters::getPos() const {
-  return TVector3(state_[0], state_[1], state_[2]);
-}
-
-
-TVector3
-GFRaveTrackParameters::getMom() const {
-  return TVector3(state_[3], state_[4], state_[5]);
-}
-
-
-double
-GFRaveTrackParameters::getCharge() const {
-  return getTrack()->getFitStatus()->getCharge();
-}
-
-
-double
-GFRaveTrackParameters::getPdg() const{
-  if (hasTrack())
-    return getTrack()->getCardinalRep()->getPDG();
-  else {
-    Exception exc("GFRaveTrackParameters::getPdg() ==> no genfit::Track available!",__LINE__,__FILE__);
-    throw exc;
   }
-}
 
 
-void
-GFRaveTrackParameters::Print(const Option_t*) const {
-  std::cout << "weight: " << getWeight() << "\n";
-  if (!hasSmoothedData_) std::cout << "state and cov are NOT smoothed! \n";
-  std::cout << "state: "; getState().Print();
-  std::cout << "cov: "; getCov().Print();
-  if (hasTrack()) {std::cout << "genfit::Track: "; getTrack()->Print();}
-  else std::cout << "NO genfit::Track pointer \n";
-}
+  GFRaveTrackParameters::GFRaveTrackParameters(const Track* track, MeasuredStateOnPlane* /*originalState*/, double weight) :
+    originalTrack_(const_cast<Track*>(track)),
+    weight_(weight),
+    state_(1, 6),
+    cov_(6, 6),
+    hasSmoothedData_(false)
+  {
+    ;
+  }
+
+
+  TVector3
+  GFRaveTrackParameters::getPos() const
+  {
+    return TVector3(state_[0], state_[1], state_[2]);
+  }
+
+
+  TVector3
+  GFRaveTrackParameters::getMom() const
+  {
+    return TVector3(state_[3], state_[4], state_[5]);
+  }
+
+
+  double
+  GFRaveTrackParameters::getCharge() const
+  {
+    return getTrack()->getFitStatus()->getCharge();
+  }
+
+
+  double
+  GFRaveTrackParameters::getPdg() const
+  {
+    if (hasTrack())
+      return getTrack()->getCardinalRep()->getPDG();
+    else {
+      Exception exc("GFRaveTrackParameters::getPdg() ==> no genfit::Track available!", __LINE__, __FILE__);
+      throw exc;
+    }
+  }
+
+
+  void
+  GFRaveTrackParameters::Print(const Option_t*) const
+  {
+    std::cout << "weight: " << getWeight() << "\n";
+    if (!hasSmoothedData_) std::cout << "state and cov are NOT smoothed! \n";
+    std::cout << "state: "; getState().Print();
+    std::cout << "cov: "; getCov().Print();
+    if (hasTrack()) {std::cout << "genfit::Track: "; getTrack()->Print();}
+    else std::cout << "NO genfit::Track pointer \n";
+  }
 
 
 } /* End of namespace genfit */

--- a/GFRave/src/GFRaveVertex.cc
+++ b/GFRave/src/GFRaveVertex.cc
@@ -29,102 +29,106 @@ namespace genfit {
 //#define COUNT
 
 #ifdef COUNT
-static int instCount(0);
+  static int instCount(0);
 #endif
 
-GFRaveVertex::GFRaveVertex() :
-  cov_(3,3),
-  ndf_(0),
-  chi2_(0),
-  id_(-1)
-{
+  GFRaveVertex::GFRaveVertex() :
+    cov_(3, 3),
+    ndf_(0),
+    chi2_(0),
+    id_(-1)
+  {
 #ifdef COUNT
-  std::cerr << "GFRaveVertex::GFRaveVertex() - Number of objects: " << ++instCount << std::endl;
+    std::cerr << "GFRaveVertex::GFRaveVertex() - Number of objects: " << ++instCount << std::endl;
 #endif
-}
-
-
-GFRaveVertex::GFRaveVertex(const TVector3 & pos, const TMatrixDSym& cov,
-                           const std::vector < GFRaveTrackParameters* > & smoothedTracks,
-                           double ndf, double chi2, int id) :
-  pos_(pos),
-  cov_(cov),
-  ndf_(ndf),
-  chi2_(chi2),
-  id_(id),
-  smoothedTracks_(smoothedTracks)
-{
-  if (cov_.GetNrows()!=3 || cov_.GetNcols()!=3) {
-    Exception exc("GFRaveVertex ==> Covariance is not 3x3!",__LINE__,__FILE__);
-    throw exc;
   }
 
-#ifdef COUNT
-  std::cerr << "GFRaveVertex::GFRaveVertex(...) - Number of objects: " << ++instCount << std::endl;
-#endif
-}
 
-
-GFRaveVertex::GFRaveVertex(const GFRaveVertex & vertex) :
-  TObject(vertex),
-  pos_(vertex.pos_),
-  cov_(vertex.cov_),
-  ndf_(vertex.ndf_),
-  chi2_(vertex.chi2_),
-  id_(vertex.id_)
-{
-  unsigned int nPar =  vertex.smoothedTracks_.size();
-  smoothedTracks_.reserve(nPar);
-  for (unsigned int i=0; i<nPar; ++i) {
-    smoothedTracks_.push_back(new GFRaveTrackParameters(*(vertex.smoothedTracks_[i])));
-  }
+  GFRaveVertex::GFRaveVertex(const TVector3& pos, const TMatrixDSym& cov,
+                             const std::vector < GFRaveTrackParameters* >& smoothedTracks,
+                             double ndf, double chi2, int id) :
+    pos_(pos),
+    cov_(cov),
+    ndf_(ndf),
+    chi2_(chi2),
+    id_(id),
+    smoothedTracks_(smoothedTracks)
+  {
+    if (cov_.GetNrows() != 3 || cov_.GetNcols() != 3) {
+      Exception exc("GFRaveVertex ==> Covariance is not 3x3!", __LINE__, __FILE__);
+      throw exc;
+    }
 
 #ifdef COUNT
-  std::cerr << "GFRaveVertex::GFRaveVertex(GFRaveVertex) - Number of objects: " << ++instCount << std::endl;
+    std::cerr << "GFRaveVertex::GFRaveVertex(...) - Number of objects: " << ++instCount << std::endl;
 #endif
-}
-
-
-GFRaveVertex& GFRaveVertex::operator=(GFRaveVertex other) {
-  swap(other);
-  return *this;
-}
-
-
-void GFRaveVertex::swap(GFRaveVertex& other) {
-  std::swap(this->pos_, other.pos_);
-  this->cov_.ResizeTo(other.cov_);
-  std::swap(this->cov_, other.cov_);
-  std::swap(this->ndf_, other.ndf_);
-  std::swap(this->chi2_, other.chi2_);
-  std::swap(this->id_, other.id_);
-  std::swap(this->smoothedTracks_, other.smoothedTracks_);
-}
-
-
-GFRaveVertex::~GFRaveVertex(){
-  unsigned int nPar =  smoothedTracks_.size();
-  for (unsigned int i=0; i<nPar; ++i) {
-    delete smoothedTracks_[i];
   }
+
+
+  GFRaveVertex::GFRaveVertex(const GFRaveVertex& vertex) :
+    TObject(vertex),
+    pos_(vertex.pos_),
+    cov_(vertex.cov_),
+    ndf_(vertex.ndf_),
+    chi2_(vertex.chi2_),
+    id_(vertex.id_)
+  {
+    unsigned int nPar =  vertex.smoothedTracks_.size();
+    smoothedTracks_.reserve(nPar);
+    for (unsigned int i = 0; i < nPar; ++i) {
+      smoothedTracks_.push_back(new GFRaveTrackParameters(*(vertex.smoothedTracks_[i])));
+    }
 
 #ifdef COUNT
-  std::cerr << "GFRaveVertex::~GFRaveVertex() - Number of objects: " << --instCount << std::endl;
+    std::cerr << "GFRaveVertex::GFRaveVertex(GFRaveVertex) - Number of objects: " << ++instCount << std::endl;
 #endif
-}
-
-
-void
-GFRaveVertex::Print(const Option_t*) const {
-  std::cout << "GFRaveVertex\n";
-  std::cout << "Position: "; getPos().Print();
-  std::cout << "Covariance: "; getCov().Print();
-  std::cout << "Ndf: " << getNdf() << ", Chi2: " << getChi2() << ", Id: " << getId() << "\n";
-  std::cout << "Number of tracks: " << getNTracks() << "\n";
-  for (unsigned int i=0;  i<getNTracks(); ++i) {
-    std::cout << " track " << i << ":\n"; getParameters(i)->Print();
   }
-}
+
+
+  GFRaveVertex& GFRaveVertex::operator=(GFRaveVertex other)
+  {
+    swap(other);
+    return *this;
+  }
+
+
+  void GFRaveVertex::swap(GFRaveVertex& other)
+  {
+    std::swap(this->pos_, other.pos_);
+    this->cov_.ResizeTo(other.cov_);
+    std::swap(this->cov_, other.cov_);
+    std::swap(this->ndf_, other.ndf_);
+    std::swap(this->chi2_, other.chi2_);
+    std::swap(this->id_, other.id_);
+    std::swap(this->smoothedTracks_, other.smoothedTracks_);
+  }
+
+
+  GFRaveVertex::~GFRaveVertex()
+  {
+    unsigned int nPar =  smoothedTracks_.size();
+    for (unsigned int i = 0; i < nPar; ++i) {
+      delete smoothedTracks_[i];
+    }
+
+#ifdef COUNT
+    std::cerr << "GFRaveVertex::~GFRaveVertex() - Number of objects: " << --instCount << std::endl;
+#endif
+  }
+
+
+  void
+  GFRaveVertex::Print(const Option_t*) const
+  {
+    std::cout << "GFRaveVertex\n";
+    std::cout << "Position: "; getPos().Print();
+    std::cout << "Covariance: "; getCov().Print();
+    std::cout << "Ndf: " << getNdf() << ", Chi2: " << getChi2() << ", Id: " << getId() << "\n";
+    std::cout << "Number of tracks: " << getNTracks() << "\n";
+    for (unsigned int i = 0;  i < getNTracks(); ++i) {
+      std::cout << " track " << i << ":\n"; getParameters(i)->Print();
+    }
+  }
 
 } /* End of namespace genfit */
 

--- a/core/include/AbsBField.h
+++ b/core/include/AbsBField.h
@@ -28,34 +28,34 @@
 
 namespace genfit {
 
-/** @brief Abstract Interface to magnetic fields in GENFIT
- *
- *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
- *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
- */
-class AbsBField {
-public:
-
-  AbsBField(){;}
-  virtual ~AbsBField(){;}
-
-  /**
-   * @brief Get the magneticField [kGauss] at position.
+  /** @brief Abstract Interface to magnetic fields in GENFIT
    *
-   * Override this in your concrete implementation.
-   * Provided for compatibility with old genfit.  Use the other interface to avoid
-   * unnecessary TVector3 instantiations.
+   *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
+   *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
    */
-  virtual TVector3 get(const TVector3& position) const = 0;
+  class AbsBField {
+  public:
 
-  /**
-   * @brief Get the magneticField [kGauss] at position.
-   *
-   * Override this in your concrete implementation.
-   */
-  virtual void get(const double& posX, const double& posY, const double& posZ, double& Bx, double& By, double& Bz) const { const TVector3& B(this->get(TVector3(posX, posY, posZ))); Bx = B.X(); By = B.Y(); Bz = B.Z(); }
- 
-};
+    AbsBField() {;}
+    virtual ~AbsBField() {;}
+
+    /**
+     * @brief Get the magneticField [kGauss] at position.
+     *
+     * Override this in your concrete implementation.
+     * Provided for compatibility with old genfit.  Use the other interface to avoid
+     * unnecessary TVector3 instantiations.
+     */
+    virtual TVector3 get(const TVector3& position) const = 0;
+
+    /**
+     * @brief Get the magneticField [kGauss] at position.
+     *
+     * Override this in your concrete implementation.
+     */
+    virtual void get(const double& posX, const double& posY, const double& posZ, double& Bx, double& By, double& Bz) const { const TVector3& B(this->get(TVector3(posX, posY, posZ))); Bx = B.X(); By = B.Y(); Bz = B.Z(); }
+
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/core/include/AbsFinitePlane.h
+++ b/core/include/AbsFinitePlane.h
@@ -34,37 +34,37 @@
 
 namespace genfit {
 
-/**
- * @brief Abstract base class for finite detector planes.
- *
- * This is most important for avoiding fake intersection points in fitting of curlers.
- * This should be implemented for silicon detectors most importantly.
- */
-class AbsFinitePlane {
+  /**
+   * @brief Abstract base class for finite detector planes.
+   *
+   * This is most important for avoiding fake intersection points in fitting of curlers.
+   * This should be implemented for silicon detectors most importantly.
+   */
+  class AbsFinitePlane {
 
- public:
+  public:
 
-  AbsFinitePlane() {};
-  virtual ~AbsFinitePlane() {};
+    AbsFinitePlane() {};
+    virtual ~AbsFinitePlane() {};
 
-  //! Returns whether a u,v point is in the active plane or not. Needs to be implemented
-  //! in child class.
-  virtual bool isInActive(double u, double v) const = 0;
+    //! Returns whether a u,v point is in the active plane or not. Needs to be implemented
+    //! in child class.
+    virtual bool isInActive(double u, double v) const = 0;
 
-  //! Deep copy ctor for polymorphic class.
-  virtual AbsFinitePlane* clone() const = 0;
+    //! Deep copy ctor for polymorphic class.
+    virtual AbsFinitePlane* clone() const = 0;
 
-  virtual void Print(const Option_t* = "") const = 0;
+    virtual void Print(const Option_t* = "") const = 0;
 
 
- protected:
+  protected:
 
-  // protect from calling copy c'tor or assignment operator from outside the class. Use #clone() if you want a copy!
-  AbsFinitePlane(const AbsFinitePlane&) {;}
-  AbsFinitePlane& operator=(const AbsFinitePlane&);
+    // protect from calling copy c'tor or assignment operator from outside the class. Use #clone() if you want a copy!
+    AbsFinitePlane(const AbsFinitePlane&) {;}
+    AbsFinitePlane& operator=(const AbsFinitePlane&);
 
-  ClassDef(AbsFinitePlane, 1);
-};
+    ClassDef(AbsFinitePlane, 1);
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/core/include/AbsFitter.h
+++ b/core/include/AbsFitter.h
@@ -26,35 +26,35 @@
 
 namespace genfit {
 
-class Track;
-class AbsTrackRep;
-
-/**
- * @brief Abstract base class for fitters.
- */
-class AbsFitter {
- public:
-  AbsFitter() : debugLvl_(0) {}
-  virtual ~AbsFitter() {}
+  class Track;
+  class AbsTrackRep;
 
   /**
-   * Process Track with one AbsTrackRep of the Track. Optionally resort the hits if necessary (and supported by the fitter)
+   * @brief Abstract base class for fitters.
    */
-  virtual void processTrackWithRep(Track*, const AbsTrackRep*, bool resortHits = false) = 0;
+  class AbsFitter {
+  public:
+    AbsFitter() : debugLvl_(0) {}
+    virtual ~AbsFitter() {}
 
-  /**
-   * Process all reps. Start with the cardinalRep and resort the hits if necessary (and supported by the fitter)
-   */
-  void processTrack(Track*, bool resortHits = false);
+    /**
+     * Process Track with one AbsTrackRep of the Track. Optionally resort the hits if necessary (and supported by the fitter)
+     */
+    virtual void processTrackWithRep(Track*, const AbsTrackRep*, bool resortHits = false) = 0;
 
-  virtual void setDebugLvl(unsigned int lvl = 1) {debugLvl_ = lvl;}
+    /**
+     * Process all reps. Start with the cardinalRep and resort the hits if necessary (and supported by the fitter)
+     */
+    void processTrack(Track*, bool resortHits = false);
+
+    virtual void setDebugLvl(unsigned int lvl = 1) {debugLvl_ = lvl;}
 
 
- protected:
+  protected:
 
-  unsigned int debugLvl_;
+    unsigned int debugLvl_;
 
-};
+  };
 
 }  /* End of namespace genfit */
 /** @} */

--- a/core/include/AbsFitterInfo.h
+++ b/core/include/AbsFitterInfo.h
@@ -33,82 +33,83 @@
 
 namespace genfit {
 
-class AbsTrackRep;
-class TrackPoint;
+  class AbsTrackRep;
+  class TrackPoint;
 
-/**
- *  @brief This class collects all information needed and produced by a specific  AbsFitter and is specific to one AbsTrackRep of the Track.
- */
-class AbsFitterInfo : public TObject {
-
- public:
-
-  AbsFitterInfo();
-  AbsFitterInfo(const TrackPoint* trackPoint, const AbsTrackRep* rep);
-
-  virtual ~AbsFitterInfo() {};
-
-  //! Deep copy ctor for polymorphic class.
-  virtual AbsFitterInfo* clone() const = 0;
-
-  const TrackPoint* getTrackPoint() const {return trackPoint_;}
-  const AbsTrackRep* getRep() const {return rep_;}
-
-  void setTrackPoint(const TrackPoint *tp) {trackPoint_ = tp;}
-  virtual void setRep(const AbsTrackRep* rep) {rep_ = rep;}
-
-  virtual bool hasMeasurements() const = 0;
-  virtual bool hasReferenceState() const = 0;
-  virtual bool hasForwardPrediction() const = 0;
-  virtual bool hasBackwardPrediction() const = 0;
-  virtual bool hasPrediction(int direction) const {if (direction >=0) return hasForwardPrediction(); return hasBackwardPrediction();}
-  virtual bool hasForwardUpdate() const = 0;
-  virtual bool hasBackwardUpdate() const = 0;
-  virtual bool hasUpdate(int direction) const {if (direction >=0) return hasForwardUpdate(); return hasBackwardUpdate();}
-
-  virtual void deleteForwardInfo() = 0;
-  virtual void deleteBackwardInfo() = 0;
-  virtual void deleteReferenceInfo() = 0;
-  virtual void deleteMeasurementInfo() = 0;
-
-  const SharedPlanePtr& getPlane() const {return sharedPlane_;}
-  virtual const MeasuredStateOnPlane& getFittedState(bool biased = true) const = 0;
-  virtual MeasurementOnPlane getResidual(unsigned int iMeasurement = 0, bool biased = true, bool onlyMeasurementErrors = false) const = 0;
-
-  void setPlane(const SharedPlanePtr& plane) {sharedPlane_ = plane;}
-
-  virtual void Print(const Option_t* = "") const {;}
-
-  virtual bool checkConsistency(const PruneFlags* = nullptr) const = 0;
-
- protected:
-
-  /** Pointer to TrackPoint where the FitterInfo belongs to
+  /**
+   *  @brief This class collects all information needed and produced by a specific  AbsFitter and is specific to one AbsTrackRep of the Track.
    */
-  const TrackPoint* trackPoint_; //! No ownership
+  class AbsFitterInfo : public TObject {
 
-  /** Pointer to AbsTrackRep with respect to which the FitterInfo is defined
-   */
-  const AbsTrackRep* rep_; //! No ownership
+  public:
 
-  SharedPlanePtr sharedPlane_; //! Shared ownership.  '!' shuts up ROOT.
+    AbsFitterInfo();
+    AbsFitterInfo(const TrackPoint* trackPoint, const AbsTrackRep* rep);
+
+    virtual ~AbsFitterInfo() {};
+
+    //! Deep copy ctor for polymorphic class.
+    virtual AbsFitterInfo* clone() const = 0;
+
+    const TrackPoint* getTrackPoint() const {return trackPoint_;}
+    const AbsTrackRep* getRep() const {return rep_;}
+
+    void setTrackPoint(const TrackPoint* tp) {trackPoint_ = tp;}
+    virtual void setRep(const AbsTrackRep* rep) {rep_ = rep;}
+
+    virtual bool hasMeasurements() const = 0;
+    virtual bool hasReferenceState() const = 0;
+    virtual bool hasForwardPrediction() const = 0;
+    virtual bool hasBackwardPrediction() const = 0;
+    virtual bool hasPrediction(int direction) const {if (direction >= 0) return hasForwardPrediction(); return hasBackwardPrediction();}
+    virtual bool hasForwardUpdate() const = 0;
+    virtual bool hasBackwardUpdate() const = 0;
+    virtual bool hasUpdate(int direction) const {if (direction >= 0) return hasForwardUpdate(); return hasBackwardUpdate();}
+
+    virtual void deleteForwardInfo() = 0;
+    virtual void deleteBackwardInfo() = 0;
+    virtual void deleteReferenceInfo() = 0;
+    virtual void deleteMeasurementInfo() = 0;
+
+    const SharedPlanePtr& getPlane() const {return sharedPlane_;}
+    virtual const MeasuredStateOnPlane& getFittedState(bool biased = true) const = 0;
+    virtual MeasurementOnPlane getResidual(unsigned int iMeasurement = 0, bool biased = true,
+                                           bool onlyMeasurementErrors = false) const = 0;
+
+    void setPlane(const SharedPlanePtr& plane) {sharedPlane_ = plane;}
+
+    virtual void Print(const Option_t* = "") const {;}
+
+    virtual bool checkConsistency(const PruneFlags* = nullptr) const = 0;
+
+  protected:
+
+    /** Pointer to TrackPoint where the FitterInfo belongs to
+     */
+    const TrackPoint* trackPoint_; //! No ownership
+
+    /** Pointer to AbsTrackRep with respect to which the FitterInfo is defined
+     */
+    const AbsTrackRep* rep_; //! No ownership
+
+    SharedPlanePtr sharedPlane_; //! Shared ownership.  '!' shuts up ROOT.
 
 
- private:
-  AbsFitterInfo(const AbsFitterInfo&); // copy constructor
-  AbsFitterInfo& operator=(const AbsFitterInfo&); // assignment operator
+  private:
+    AbsFitterInfo(const AbsFitterInfo&); // copy constructor
+    AbsFitterInfo& operator=(const AbsFitterInfo&); // assignment operator
 
 
- public:
-  ClassDef(AbsFitterInfo,1)
+  public:
+    ClassDef(AbsFitterInfo, 1)
 
-};
+  };
 
 //! Needed for boost cloneability:
-inline AbsFitterInfo* new_clone( const AbsFitterInfo & a)
-{
-  return a.clone();
-}
+  inline AbsFitterInfo* new_clone(const AbsFitterInfo& a)
+  {
+    return a.clone();
+  }
 
 } /* End of namespace genfit */
 /** @} */

--- a/core/include/AbsHMatrix.h
+++ b/core/include/AbsHMatrix.h
@@ -30,48 +30,48 @@
 
 namespace genfit {
 
-/**
- * @brief HMatrix for projecting from AbsTrackRep parameters to measured parameters in a DetPlane.
- *
- */
-class AbsHMatrix : public TObject {
+  /**
+   * @brief HMatrix for projecting from AbsTrackRep parameters to measured parameters in a DetPlane.
+   *
+   */
+  class AbsHMatrix : public TObject {
 
- public:
+  public:
 
-  AbsHMatrix() {;}
+    AbsHMatrix() {;}
 
-  virtual ~AbsHMatrix() {;}
+    virtual ~AbsHMatrix() {;}
 
-  //! Get the actual matrix representation
-  virtual const TMatrixD& getMatrix() const = 0;
+    //! Get the actual matrix representation
+    virtual const TMatrixD& getMatrix() const = 0;
 
-  //! H*v
-  virtual TVectorD Hv(const TVectorD& v) const {return getMatrix()*v;}
+    //! H*v
+    virtual TVectorD Hv(const TVectorD& v) const {return getMatrix() * v;}
 
-  //! M*H^t
-  virtual TMatrixD MHt(const TMatrixDSym& M) const {return TMatrixD(M, TMatrixD::kMultTranspose, getMatrix());}
-  virtual TMatrixD MHt(const TMatrixD& M) const {return TMatrixD(M, TMatrixD::kMultTranspose, getMatrix());}
+    //! M*H^t
+    virtual TMatrixD MHt(const TMatrixDSym& M) const {return TMatrixD(M, TMatrixD::kMultTranspose, getMatrix());}
+    virtual TMatrixD MHt(const TMatrixD& M) const {return TMatrixD(M, TMatrixD::kMultTranspose, getMatrix());}
 
-  //! similarity: H*M*H^t
-  virtual void HMHt(TMatrixDSym& M) const {M.Similarity(getMatrix());}
+    //! similarity: H*M*H^t
+    virtual void HMHt(TMatrixDSym& M) const {M.Similarity(getMatrix());}
 
-  virtual AbsHMatrix* clone() const = 0;
+    virtual AbsHMatrix* clone() const = 0;
 
-  bool operator==(const AbsHMatrix& other) const {return this->isEqual(other);}
-  bool operator!=(const AbsHMatrix& other) const {return !(this->isEqual(other));}
-  virtual bool isEqual(const AbsHMatrix& other) const = 0;
+    bool operator==(const AbsHMatrix& other) const {return this->isEqual(other);}
+    bool operator!=(const AbsHMatrix& other) const {return !(this->isEqual(other));}
+    virtual bool isEqual(const AbsHMatrix& other) const = 0;
 
-  virtual void Print(const Option_t* = "") const {;}
+    virtual void Print(const Option_t* = "") const {;}
 
- protected:
-  // protect from calling copy c'tor or assignment operator from outside the class. Use #clone() if you want a copy!
-  AbsHMatrix(const AbsHMatrix& o) : TObject(o) {;}
-  AbsHMatrix& operator=(const AbsHMatrix&);
+  protected:
+    // protect from calling copy c'tor or assignment operator from outside the class. Use #clone() if you want a copy!
+    AbsHMatrix(const AbsHMatrix& o) : TObject(o) {;}
+    AbsHMatrix& operator=(const AbsHMatrix&);
 
- public:
-  ClassDef(AbsHMatrix,1)
+  public:
+    ClassDef(AbsHMatrix, 1)
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/core/include/AbsMeasurement.h
+++ b/core/include/AbsMeasurement.h
@@ -31,96 +31,96 @@
 
 namespace genfit {
 
-class AbsTrackRep;
-class TrackPoint;
-
-/**
- *  @brief Contains the measurement and covariance in raw detector coordinates.
- *
- *  Detector and hit ids can be used to point back to the original detector hits (clusters etc.).
- */
-class AbsMeasurement : public TObject {
-
- public:
-
-  AbsMeasurement() : rawHitCoords_(), rawHitCov_(), detId_(-1), hitId_(-1), trackPoint_(nullptr) {;}
-  AbsMeasurement(int nDims) : rawHitCoords_(nDims), rawHitCov_(nDims), detId_(-1), hitId_(-1), trackPoint_(nullptr) {;}
-  AbsMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId, TrackPoint* trackPoint);
-
-  virtual ~AbsMeasurement();
-
-  //! Deep copy ctor for polymorphic class.
-  virtual AbsMeasurement* clone() const = 0;
-
-  TrackPoint* getTrackPoint() const {return trackPoint_;}
-  void setTrackPoint(TrackPoint* tp) {trackPoint_ = tp;}
-
-  const TVectorD& getRawHitCoords() const {return rawHitCoords_;}
-  const TMatrixDSym& getRawHitCov() const {return rawHitCov_;}
-  TVectorD& getRawHitCoords() {return rawHitCoords_;}
-  TMatrixDSym& getRawHitCov() {return rawHitCov_;}
-  int getDetId() const {return detId_;}
-  int getHitId() const {return hitId_;}
-
-  //! If the AbsMeasurement is a wire hit, the left/right resolution will be used.
-  virtual bool isLeftRightMeasurement() const {return false;}
-  virtual int getLeftRightResolution() const {return 0;}
-
-  unsigned int getDim() const {return rawHitCoords_.GetNrows();}
-
-  void setRawHitCoords(const TVectorD& coords) {rawHitCoords_ = coords;}
-  void setRawHitCov(const TMatrixDSym& cov) {rawHitCov_ = cov;}
-  void setDetId(int detId) {detId_ = detId;}
-  void setHitId(int hitId) {hitId_ = hitId;}
-
+  class AbsTrackRep;
+  class TrackPoint;
 
   /**
-   * Construct (virtual) detector plane (use state's AbsTrackRep).
-   * It's possible to make corrections to the plane here.
-   * The state should be defined somewhere near the measurement.
-   * For virtual planes, the state will be extrapolated to the POCA to point (SpacepointMeasurement)
-   * or line (WireMeasurement), and from this info the plane will be constructed.
+   *  @brief Contains the measurement and covariance in raw detector coordinates.
+   *
+   *  Detector and hit ids can be used to point back to the original detector hits (clusters etc.).
    */
-  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const = 0;
+  class AbsMeasurement : public TObject {
 
-  /**
-   * Construct MeasurementOnPlane on plane of the state
-   * and wrt the states TrackRep.
-   * The state will usually be the prediction or reference state,
-   * and has to be defined AT the measurement.
-   * The AbsMeasurement will be projected onto the plane.
-   * It's possible to make corrections to the coordinates here (e.g. by using the state coordinates).
-   * Usually the vector will contain only one element. But in the case of e.g. a WireMeasurement, it will be 2 (left and right).
-   */
-  virtual std::vector<genfit::MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const = 0;
+  public:
 
-  /**
-   * Returns a new AbsHMatrix object. Caller must take ownership.
-   */
-  virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const = 0;
+    AbsMeasurement() : rawHitCoords_(), rawHitCov_(), detId_(-1), hitId_(-1), trackPoint_(nullptr) {;}
+    AbsMeasurement(int nDims) : rawHitCoords_(nDims), rawHitCov_(nDims), detId_(-1), hitId_(-1), trackPoint_(nullptr) {;}
+    AbsMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId, TrackPoint* trackPoint);
 
-  virtual void Print(const Option_t* = "") const;
+    virtual ~AbsMeasurement();
+
+    //! Deep copy ctor for polymorphic class.
+    virtual AbsMeasurement* clone() const = 0;
+
+    TrackPoint* getTrackPoint() const {return trackPoint_;}
+    void setTrackPoint(TrackPoint* tp) {trackPoint_ = tp;}
+
+    const TVectorD& getRawHitCoords() const {return rawHitCoords_;}
+    const TMatrixDSym& getRawHitCov() const {return rawHitCov_;}
+    TVectorD& getRawHitCoords() {return rawHitCoords_;}
+    TMatrixDSym& getRawHitCov() {return rawHitCov_;}
+    int getDetId() const {return detId_;}
+    int getHitId() const {return hitId_;}
+
+    //! If the AbsMeasurement is a wire hit, the left/right resolution will be used.
+    virtual bool isLeftRightMeasurement() const {return false;}
+    virtual int getLeftRightResolution() const {return 0;}
+
+    unsigned int getDim() const {return rawHitCoords_.GetNrows();}
+
+    void setRawHitCoords(const TVectorD& coords) {rawHitCoords_ = coords;}
+    void setRawHitCov(const TMatrixDSym& cov) {rawHitCov_ = cov;}
+    void setDetId(int detId) {detId_ = detId;}
+    void setHitId(int hitId) {hitId_ = hitId;}
 
 
- private:
-  //! protect from calling assignment operator from outside the class. Use #clone() if you want a copy!
-  AbsMeasurement& operator=(const AbsMeasurement&); // default cannot work because TVector and TMatrix = operators don't do resizing
+    /**
+     * Construct (virtual) detector plane (use state's AbsTrackRep).
+     * It's possible to make corrections to the plane here.
+     * The state should be defined somewhere near the measurement.
+     * For virtual planes, the state will be extrapolated to the POCA to point (SpacepointMeasurement)
+     * or line (WireMeasurement), and from this info the plane will be constructed.
+     */
+    virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const = 0;
 
- protected:
-  //! protect from calling copy c'tor from outside the class. Use #clone() if you want a copy!
-  AbsMeasurement(const AbsMeasurement&);
+    /**
+     * Construct MeasurementOnPlane on plane of the state
+     * and wrt the states TrackRep.
+     * The state will usually be the prediction or reference state,
+     * and has to be defined AT the measurement.
+     * The AbsMeasurement will be projected onto the plane.
+     * It's possible to make corrections to the coordinates here (e.g. by using the state coordinates).
+     * Usually the vector will contain only one element. But in the case of e.g. a WireMeasurement, it will be 2 (left and right).
+     */
+    virtual std::vector<genfit::MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const = 0;
 
-  TVectorD rawHitCoords_;
-  TMatrixDSym rawHitCov_;
-  int detId_; // detId id is -1 per default
-  int hitId_; // hitId id is -1 per default
+    /**
+     * Returns a new AbsHMatrix object. Caller must take ownership.
+     */
+    virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const = 0;
 
-  //! Pointer to TrackPoint where the measurement belongs to
-  TrackPoint* trackPoint_; //! No ownership
+    virtual void Print(const Option_t* = "") const;
 
- public:
-  ClassDef(AbsMeasurement, 3)
-};
+
+  private:
+    //! protect from calling assignment operator from outside the class. Use #clone() if you want a copy!
+    AbsMeasurement& operator=(const AbsMeasurement&); // default cannot work because TVector and TMatrix = operators don't do resizing
+
+  protected:
+    //! protect from calling copy c'tor from outside the class. Use #clone() if you want a copy!
+    AbsMeasurement(const AbsMeasurement&);
+
+    TVectorD rawHitCoords_;
+    TMatrixDSym rawHitCov_;
+    int detId_; // detId id is -1 per default
+    int hitId_; // hitId id is -1 per default
+
+    //! Pointer to TrackPoint where the measurement belongs to
+    TrackPoint* trackPoint_; //! No ownership
+
+  public:
+    ClassDef(AbsMeasurement, 3)
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/core/include/AbsTrackRep.h
+++ b/core/include/AbsTrackRep.h
@@ -36,341 +36,346 @@
 
 namespace genfit {
 
-/**
- * @brief Simple struct containing MaterialProperties and stepsize in the material.
- */
-struct MatStep {
-  Material material_;
-  double stepSize_;
+  /**
+   * @brief Simple struct containing MaterialProperties and stepsize in the material.
+   */
+  struct MatStep {
+    Material material_;
+    double stepSize_;
 
-  MatStep() {
-    stepSize_ = 0;
-  }
+    MatStep()
+    {
+      stepSize_ = 0;
+    }
 
-};
+  };
 
-class StateOnPlane;
-class MeasuredStateOnPlane;
-class AbsMeasurement;
-
-/**
- * @brief Abstract base class for a track representation
- *
- *  Provides functionality to extrapolate a StateOnPlane to another DetPlane,
- *  to the POCA to a line or a point, or a cylinder or sphere.
- *  Defines a set of parameters describing the track.
- *  StateOnPlane objects are always defined with a track parameterization of a specific AbsTrackRep.
- *  The AbsTrackRep provides functionality to translate from the internal representation of a state
- *  into cartesian position and momentum (and covariance) and vice versa.
- */
-class AbsTrackRep : public TObject {
-
- public:
-
-  AbsTrackRep();
-  AbsTrackRep(int pdgCode, char propDir = 0);
-
-  virtual ~AbsTrackRep() {;}
-
-  //! Clone the trackRep.
-  virtual AbsTrackRep* clone() const = 0;
+  class StateOnPlane;
+  class MeasuredStateOnPlane;
+  class AbsMeasurement;
 
   /**
-   * @brief Extrapolates the state to plane, and returns the extrapolation length
-   *        and, via reference, the extrapolated state.
+   * @brief Abstract base class for a track representation
    *
-   * If stopAtBoundary is true, the extrapolation stops as soon as a material boundary is encountered.
-   *
-   * If state has a covariance, jacobian and noise matrices will be calculated and the covariance will be propagated.
-   * If state has no covariance, jacobian and noise will only be calculated if calcJacobianNoise == true.
+   *  Provides functionality to extrapolate a StateOnPlane to another DetPlane,
+   *  to the POCA to a line or a point, or a cylinder or sphere.
+   *  Defines a set of parameters describing the track.
+   *  StateOnPlane objects are always defined with a track parameterization of a specific AbsTrackRep.
+   *  The AbsTrackRep provides functionality to translate from the internal representation of a state
+   *  into cartesian position and momentum (and covariance) and vice versa.
    */
-  virtual double extrapolateToPlane(
+  class AbsTrackRep : public TObject {
+
+  public:
+
+    AbsTrackRep();
+    AbsTrackRep(int pdgCode, char propDir = 0);
+
+    virtual ~AbsTrackRep() {;}
+
+    //! Clone the trackRep.
+    virtual AbsTrackRep* clone() const = 0;
+
+    /**
+     * @brief Extrapolates the state to plane, and returns the extrapolation length
+     *        and, via reference, the extrapolated state.
+     *
+     * If stopAtBoundary is true, the extrapolation stops as soon as a material boundary is encountered.
+     *
+     * If state has a covariance, jacobian and noise matrices will be calculated and the covariance will be propagated.
+     * If state has no covariance, jacobian and noise will only be calculated if calcJacobianNoise == true.
+     */
+    virtual double extrapolateToPlane(
       StateOnPlane& state,
       const genfit::SharedPlanePtr& plane,
       bool stopAtBoundary = false,
       bool calcJacobianNoise = false) const = 0;
 
-  /**
-   * @brief Extrapolates the state to the POCA to a line, and returns the extrapolation length
-   *        and, via reference, the extrapolated state.
-   *
-   * If stopAtBoundary is true, the extrapolation stops as soon as a material boundary is encountered.
-   *
-   * If state has a covariance, jacobian and noise matrices will be calculated and the covariance will be propagated.
-   * If state has no covariance, jacobian and noise will only be calculated if calcJacobianNoise == true.
-   */
-  virtual double extrapolateToLine(StateOnPlane& state,
-      const TVector3& linePoint,
-      const TVector3& lineDirection,
-      bool stopAtBoundary = false,
-      bool calcJacobianNoise = false) const = 0;
+    /**
+     * @brief Extrapolates the state to the POCA to a line, and returns the extrapolation length
+     *        and, via reference, the extrapolated state.
+     *
+     * If stopAtBoundary is true, the extrapolation stops as soon as a material boundary is encountered.
+     *
+     * If state has a covariance, jacobian and noise matrices will be calculated and the covariance will be propagated.
+     * If state has no covariance, jacobian and noise will only be calculated if calcJacobianNoise == true.
+     */
+    virtual double extrapolateToLine(StateOnPlane& state,
+                                     const TVector3& linePoint,
+                                     const TVector3& lineDirection,
+                                     bool stopAtBoundary = false,
+                                     bool calcJacobianNoise = false) const = 0;
 
-  /**
-   * @brief Resembles the interface of GFAbsTrackRep in old versions of genfit
-   *
-   * This interface to extrapolateToLine is intended to resemble the
-   * interface of GFAbsTrackRep in old versions of genfit and is
-   * implemented by default via the preceding function.
-   *
-   * If stopAtBoundary is true, the extrapolation stops as soon as a material boundary is encountered.
-   *
-   * If state has a covariance, jacobian and noise matrices will be calculated and the covariance will be propagated.
-   * If state has no covariance, jacobian and noise will only be calculated if calcJacobianNoise == true.
-   */
-  virtual double extrapolateToLine(StateOnPlane& state,
-      const TVector3& point1,
-      const TVector3& point2,
-      TVector3& poca,
-      TVector3& dirInPoca,
-      TVector3& poca_onwire,
-      bool stopAtBoundary = false,
-      bool calcJacobianNoise = false) const {
-    TVector3 wireDir(point2 - point1);
-    wireDir = wireDir.Unit();
-    double retval = this->extrapolateToLine(state, point1, wireDir, stopAtBoundary, calcJacobianNoise);
-    poca = this->getPos(state);
-    dirInPoca = this->getMom(state);
-    dirInPoca = dirInPoca.Unit();
+    /**
+     * @brief Resembles the interface of GFAbsTrackRep in old versions of genfit
+     *
+     * This interface to extrapolateToLine is intended to resemble the
+     * interface of GFAbsTrackRep in old versions of genfit and is
+     * implemented by default via the preceding function.
+     *
+     * If stopAtBoundary is true, the extrapolation stops as soon as a material boundary is encountered.
+     *
+     * If state has a covariance, jacobian and noise matrices will be calculated and the covariance will be propagated.
+     * If state has no covariance, jacobian and noise will only be calculated if calcJacobianNoise == true.
+     */
+    virtual double extrapolateToLine(StateOnPlane& state,
+                                     const TVector3& point1,
+                                     const TVector3& point2,
+                                     TVector3& poca,
+                                     TVector3& dirInPoca,
+                                     TVector3& poca_onwire,
+                                     bool stopAtBoundary = false,
+                                     bool calcJacobianNoise = false) const
+    {
+      TVector3 wireDir(point2 - point1);
+      wireDir = wireDir.Unit();
+      double retval = this->extrapolateToLine(state, point1, wireDir, stopAtBoundary, calcJacobianNoise);
+      poca = this->getPos(state);
+      dirInPoca = this->getMom(state);
+      dirInPoca = dirInPoca.Unit();
 
-    poca_onwire = point1 + wireDir*((poca - point1)*wireDir);
-    
-    return retval;
-  }
+      poca_onwire = point1 + wireDir * ((poca - point1) * wireDir);
 
-  /**
-   * @brief Extrapolates the state to the POCA to a point, and returns the extrapolation length
-   *        and, via reference, the extrapolated state.
-   *
-   * If stopAtBoundary is true, the extrapolation stops as soon as a material boundary is encountered.
-   *
-   * If state has a covariance, jacobian and noise matrices will be calculated and the covariance will be propagated.
-   * If state has no covariance, jacobian and noise will only be calculated if calcJacobianNoise == true.
-   */
-  virtual double extrapolateToPoint(StateOnPlane& state,
-      const TVector3& point,
-      bool stopAtBoundary = false,
-      bool calcJacobianNoise = false) const = 0;
+      return retval;
+    }
 
-  /**
-   * @brief Extrapolates the state to the POCA to a point in the metric of G, and returns the extrapolation length
-   *        and, via reference, the extrapolated state.
-   *
-   * If stopAtBoundary is true, the extrapolation stops as soon as a material boundary is encountered.
-   *
-   * If state has a covariance, jacobian and noise matrices will be calculated and the covariance will be propagated.
-   * If state has no covariance, jacobian and noise will only be calculated if calcJacobianNoise == true.
-   */
-  virtual double extrapolateToPoint(StateOnPlane& state,
-      const TVector3& point,
-      const TMatrixDSym& G, // weight matrix (metric)
-      bool stopAtBoundary = false,
-      bool calcJacobianNoise = false) const = 0;
+    /**
+     * @brief Extrapolates the state to the POCA to a point, and returns the extrapolation length
+     *        and, via reference, the extrapolated state.
+     *
+     * If stopAtBoundary is true, the extrapolation stops as soon as a material boundary is encountered.
+     *
+     * If state has a covariance, jacobian and noise matrices will be calculated and the covariance will be propagated.
+     * If state has no covariance, jacobian and noise will only be calculated if calcJacobianNoise == true.
+     */
+    virtual double extrapolateToPoint(StateOnPlane& state,
+                                      const TVector3& point,
+                                      bool stopAtBoundary = false,
+                                      bool calcJacobianNoise = false) const = 0;
 
-  /**
-   * @brief Extrapolates the state to the cylinder surface, and returns the extrapolation length
-   *       and, via reference, the extrapolated state.
-   *
-   * If stopAtBoundary is true, the extrapolation stops as soon as a material boundary is encountered.
-   *
-   * If state has a covariance, jacobian and noise matrices will be calculated and the covariance will be propagated.
-   * If state has no covariance, jacobian and noise will only be calculated if calcJacobianNoise == true.
-   */
-  virtual double extrapolateToCylinder(StateOnPlane& state,
-      double radius,
-      const TVector3& linePoint = TVector3(0.,0.,0.),
-      const TVector3& lineDirection = TVector3(0.,0.,1.),
-      bool stopAtBoundary = false,
-      bool calcJacobianNoise = false) const = 0;
+    /**
+     * @brief Extrapolates the state to the POCA to a point in the metric of G, and returns the extrapolation length
+     *        and, via reference, the extrapolated state.
+     *
+     * If stopAtBoundary is true, the extrapolation stops as soon as a material boundary is encountered.
+     *
+     * If state has a covariance, jacobian and noise matrices will be calculated and the covariance will be propagated.
+     * If state has no covariance, jacobian and noise will only be calculated if calcJacobianNoise == true.
+     */
+    virtual double extrapolateToPoint(StateOnPlane& state,
+                                      const TVector3& point,
+                                      const TMatrixDSym& G, // weight matrix (metric)
+                                      bool stopAtBoundary = false,
+                                      bool calcJacobianNoise = false) const = 0;
 
-  /**
-   * @brief Extrapolates the state to the cone surface, and returns the extrapolation length
-   *       and, via reference, the extrapolated state.
-   *
-   * If stopAtBoundary is true, the extrapolation stops as soon as a material boundary is encountered.
-   *
-   * If state has a covariance, jacobian and noise matrices will be calculated and the covariance will be propagated.
-   * If state has no covariance, jacobian and noise will only be calculated if calcJacobianNoise == true.
-   */
-  virtual double extrapolateToCone(StateOnPlane& state,
-      double radius,
-      const TVector3& linePoint = TVector3(0.,0.,0.),
-      const TVector3& lineDirection = TVector3(0.,0.,1.),
-      bool stopAtBoundary = false,
-      bool calcJacobianNoise = false) const = 0;
+    /**
+     * @brief Extrapolates the state to the cylinder surface, and returns the extrapolation length
+     *       and, via reference, the extrapolated state.
+     *
+     * If stopAtBoundary is true, the extrapolation stops as soon as a material boundary is encountered.
+     *
+     * If state has a covariance, jacobian and noise matrices will be calculated and the covariance will be propagated.
+     * If state has no covariance, jacobian and noise will only be calculated if calcJacobianNoise == true.
+     */
+    virtual double extrapolateToCylinder(StateOnPlane& state,
+                                         double radius,
+                                         const TVector3& linePoint = TVector3(0., 0., 0.),
+                                         const TVector3& lineDirection = TVector3(0., 0., 1.),
+                                         bool stopAtBoundary = false,
+                                         bool calcJacobianNoise = false) const = 0;
 
-  /**
-   * @brief Extrapolates the state to the sphere surface, and returns the extrapolation length
-   *       and, via reference, the extrapolated state.
-   *
-   * If stopAtBoundary is true, the extrapolation stops as soon as a material boundary is encountered.
-   *
-   * If state has a covariance, jacobian and noise matrices will be calculated and the covariance will be propagated.
-   * If state has no covariance, jacobian and noise will only be calculated if calcJacobianNoise == true.
-   */
-  virtual double extrapolateToSphere(StateOnPlane& state,
-      double radius,
-      const TVector3& point = TVector3(0.,0.,0.),
-      bool stopAtBoundary = false,
-      bool calcJacobianNoise = false) const = 0;
+    /**
+     * @brief Extrapolates the state to the cone surface, and returns the extrapolation length
+     *       and, via reference, the extrapolated state.
+     *
+     * If stopAtBoundary is true, the extrapolation stops as soon as a material boundary is encountered.
+     *
+     * If state has a covariance, jacobian and noise matrices will be calculated and the covariance will be propagated.
+     * If state has no covariance, jacobian and noise will only be calculated if calcJacobianNoise == true.
+     */
+    virtual double extrapolateToCone(StateOnPlane& state,
+                                     double radius,
+                                     const TVector3& linePoint = TVector3(0., 0., 0.),
+                                     const TVector3& lineDirection = TVector3(0., 0., 1.),
+                                     bool stopAtBoundary = false,
+                                     bool calcJacobianNoise = false) const = 0;
 
-  /**
-   * @brief Extrapolates the state by step (cm) and returns the extrapolation length
-   *       and, via reference, the extrapolated state.
-   *
-   * If stopAtBoundary is true, the extrapolation stops as soon as a material boundary is encountered.
-   *
-   * If state has a covariance, jacobian and noise matrices will be calculated and the covariance will be propagated.
-   * If state has no covariance, jacobian and noise will only be calculated if calcJacobianNoise == true.
-   */
-  virtual double extrapolateBy(StateOnPlane& state,
-      double step,
-      bool stopAtBoundary = false,
-      bool calcJacobianNoise = false) const = 0;
+    /**
+     * @brief Extrapolates the state to the sphere surface, and returns the extrapolation length
+     *       and, via reference, the extrapolated state.
+     *
+     * If stopAtBoundary is true, the extrapolation stops as soon as a material boundary is encountered.
+     *
+     * If state has a covariance, jacobian and noise matrices will be calculated and the covariance will be propagated.
+     * If state has no covariance, jacobian and noise will only be calculated if calcJacobianNoise == true.
+     */
+    virtual double extrapolateToSphere(StateOnPlane& state,
+                                       double radius,
+                                       const TVector3& point = TVector3(0., 0., 0.),
+                                       bool stopAtBoundary = false,
+                                       bool calcJacobianNoise = false) const = 0;
 
-  //! extrapolate to an AbsMeasurement
-  double extrapolateToMeasurement(StateOnPlane& state,
-      const AbsMeasurement* measurement,
-      bool stopAtBoundary = false,
-      bool calcJacobianNoise = false) const;
+    /**
+     * @brief Extrapolates the state by step (cm) and returns the extrapolation length
+     *       and, via reference, the extrapolated state.
+     *
+     * If stopAtBoundary is true, the extrapolation stops as soon as a material boundary is encountered.
+     *
+     * If state has a covariance, jacobian and noise matrices will be calculated and the covariance will be propagated.
+     * If state has no covariance, jacobian and noise will only be calculated if calcJacobianNoise == true.
+     */
+    virtual double extrapolateBy(StateOnPlane& state,
+                                 double step,
+                                 bool stopAtBoundary = false,
+                                 bool calcJacobianNoise = false) const = 0;
 
-  //! Get the dimension of the state vector used by the track representation.
-  virtual unsigned int getDim() const = 0;
+    //! extrapolate to an AbsMeasurement
+    double extrapolateToMeasurement(StateOnPlane& state,
+                                    const AbsMeasurement* measurement,
+                                    bool stopAtBoundary = false,
+                                    bool calcJacobianNoise = false) const;
 
-  //! Get the cartesian position of a state.
-  virtual TVector3 getPos(const StateOnPlane& state) const = 0;
+    //! Get the dimension of the state vector used by the track representation.
+    virtual unsigned int getDim() const = 0;
 
-  //! Get the cartesian momentum vector of a state.
-  virtual TVector3 getMom(const StateOnPlane& state) const = 0;
+    //! Get the cartesian position of a state.
+    virtual TVector3 getPos(const StateOnPlane& state) const = 0;
 
-  //! Get the direction vector of a state.
-  TVector3 getDir(const StateOnPlane& state) const {return getMom(state).Unit();}
+    //! Get the cartesian momentum vector of a state.
+    virtual TVector3 getMom(const StateOnPlane& state) const = 0;
 
-  //! Get cartesian position and momentum vector of a state.
-  virtual void getPosMom(const StateOnPlane& state, TVector3& pos, TVector3& mom) const = 0;
+    //! Get the direction vector of a state.
+    TVector3 getDir(const StateOnPlane& state) const {return getMom(state).Unit();}
 
-  //! Get cartesian position and direction vector of a state.
-  void getPosDir(const StateOnPlane& state, TVector3& pos, TVector3& dir) const {getPosMom(state, pos, dir); dir.SetMag(1.);}
+    //! Get cartesian position and momentum vector of a state.
+    virtual void getPosMom(const StateOnPlane& state, TVector3& pos, TVector3& mom) const = 0;
 
-  //! Get the 6D state vector (x, y, z, p_x, p_y, p_z).
-  virtual TVectorD get6DState(const StateOnPlane& state) const;
+    //! Get cartesian position and direction vector of a state.
+    void getPosDir(const StateOnPlane& state, TVector3& pos, TVector3& dir) const {getPosMom(state, pos, dir); dir.SetMag(1.);}
 
-  //! Get the 6D covariance.
-  virtual TMatrixDSym get6DCov(const MeasuredStateOnPlane& state) const = 0;
+    //! Get the 6D state vector (x, y, z, p_x, p_y, p_z).
+    virtual TVectorD get6DState(const StateOnPlane& state) const;
 
-  //! Translates MeasuredStateOnPlane into 3D position, momentum and 6x6 covariance.
-  virtual void getPosMomCov(const MeasuredStateOnPlane& state, TVector3& pos, TVector3& mom, TMatrixDSym& cov) const = 0;
+    //! Get the 6D covariance.
+    virtual TMatrixDSym get6DCov(const MeasuredStateOnPlane& state) const = 0;
 
-  //! Translates MeasuredStateOnPlane into 6D state vector (x, y, z, p_x, p_y, p_z) and 6x6 covariance.
-  virtual void get6DStateCov(const MeasuredStateOnPlane& state, TVectorD& stateVec, TMatrixDSym& cov) const;
+    //! Translates MeasuredStateOnPlane into 3D position, momentum and 6x6 covariance.
+    virtual void getPosMomCov(const MeasuredStateOnPlane& state, TVector3& pos, TVector3& mom, TMatrixDSym& cov) const = 0;
 
-  //! get the magnitude of the momentum in GeV.
-  virtual double getMomMag(const StateOnPlane& state) const = 0;
-  //! get the variance of the absolute value of the momentum .
-  virtual double getMomVar(const MeasuredStateOnPlane& state) const = 0;
+    //! Translates MeasuredStateOnPlane into 6D state vector (x, y, z, p_x, p_y, p_z) and 6x6 covariance.
+    virtual void get6DStateCov(const MeasuredStateOnPlane& state, TVectorD& stateVec, TMatrixDSym& cov) const;
 
-  //! Get the pdg code.
-  int getPDG() const {return pdgCode_;}
+    //! get the magnitude of the momentum in GeV.
+    virtual double getMomMag(const StateOnPlane& state) const = 0;
+    //! get the variance of the absolute value of the momentum .
+    virtual double getMomVar(const MeasuredStateOnPlane& state) const = 0;
 
-  //! Get the charge of the particle of the pdg code
-  double getPDGCharge() const;
+    //! Get the pdg code.
+    int getPDG() const {return pdgCode_;}
 
-  /**
-   * @brief Get the (fitted) charge of a state.
-   * This is not always equal the pdg charge (e.g. if the charge sign was flipped during the fit).
-   */
-  virtual double getCharge(const StateOnPlane& state) const = 0;
-  //! Get charge over momentum.
-  virtual double getQop(const StateOnPlane& state) const = 0;
-  //! Get tha particle mass in GeV/c^2
-  double getMass(const StateOnPlane& state) const;
+    //! Get the charge of the particle of the pdg code
+    double getPDGCharge() const;
 
-  //! Get propagation direction. (-1, 0, 1) -> (backward, auto, forward).
-  char getPropDir() const {return propDir_;}
+    /**
+     * @brief Get the (fitted) charge of a state.
+     * This is not always equal the pdg charge (e.g. if the charge sign was flipped during the fit).
+     */
+    virtual double getCharge(const StateOnPlane& state) const = 0;
+    //! Get charge over momentum.
+    virtual double getQop(const StateOnPlane& state) const = 0;
+    //! Get tha particle mass in GeV/c^2
+    double getMass(const StateOnPlane& state) const;
 
-  //! Get the jacobian and noise matrix of the last extrapolation.
-  virtual void getForwardJacobianAndNoise(TMatrixD& jacobian, TMatrixDSym& noise, TVectorD& deltaState) const = 0;
+    //! Get propagation direction. (-1, 0, 1) -> (backward, auto, forward).
+    char getPropDir() const {return propDir_;}
 
-  //! Get the jacobian and noise matrix of the last extrapolation if it would have been done in opposite direction.
-  virtual void getBackwardJacobianAndNoise(TMatrixD& jacobian, TMatrixDSym& noise, TVectorD& deltaState) const = 0;
+    //! Get the jacobian and noise matrix of the last extrapolation.
+    virtual void getForwardJacobianAndNoise(TMatrixD& jacobian, TMatrixDSym& noise, TVectorD& deltaState) const = 0;
 
-  //! Get stepsizes and material properties of crossed materials of the last extrapolation.
-  virtual std::vector<genfit::MatStep> getSteps() const = 0;
+    //! Get the jacobian and noise matrix of the last extrapolation if it would have been done in opposite direction.
+    virtual void getBackwardJacobianAndNoise(TMatrixD& jacobian, TMatrixDSym& noise, TVectorD& deltaState) const = 0;
 
-  //! Get the accumulated X/X0 (path / radiation length) of the material crossed in the last extrapolation.
-  virtual double getRadiationLenght() const = 0;
+    //! Get stepsizes and material properties of crossed materials of the last extrapolation.
+    virtual std::vector<genfit::MatStep> getSteps() const = 0;
 
-  //! Get the time corresponding to the StateOnPlane.  Extrapolation
-  // should keep this up to date with the time of flight.
-  virtual double getTime(const StateOnPlane&) const = 0;
+    //! Get the accumulated X/X0 (path / radiation length) of the material crossed in the last extrapolation.
+    virtual double getRadiationLenght() const = 0;
 
-  /**
-   * @brief Calculate Jacobian of transportation numerically.
-   * Slow but accurate. Can be used to validate (semi)analytic calculations.
-   */
-  void calcJacobianNumerically(const genfit::StateOnPlane& origState,
-                                   const genfit::SharedPlanePtr destPlane,
-                                   TMatrixD& jacobian) const;
+    //! Get the time corresponding to the StateOnPlane.  Extrapolation
+    // should keep this up to date with the time of flight.
+    virtual double getTime(const StateOnPlane&) const = 0;
 
-  //! try to multiply pdg code with -1. (Switch from particle to anti-particle and vice versa).
-  bool switchPDGSign();
+    /**
+     * @brief Calculate Jacobian of transportation numerically.
+     * Slow but accurate. Can be used to validate (semi)analytic calculations.
+     */
+    void calcJacobianNumerically(const genfit::StateOnPlane& origState,
+                                 const genfit::SharedPlanePtr destPlane,
+                                 TMatrixD& jacobian) const;
 
-  //! Set position and momentum of state.
-  virtual void setPosMom(StateOnPlane& state, const TVector3& pos, const TVector3& mom) const = 0;
-  //! Set position and momentum of state.
-  virtual void setPosMom(StateOnPlane& state, const TVectorD& state6) const = 0;
-  //! Set position and momentum and error of state.
-  virtual void setPosMomErr(MeasuredStateOnPlane& state, const TVector3& pos, const TVector3& mom, const TVector3& posErr, const TVector3& momErr) const = 0;
-  //! Set position, momentum and covariance of state.
-  virtual void setPosMomCov(MeasuredStateOnPlane& state, const TVector3& pos, const TVector3& mom, const TMatrixDSym& cov6x6) const = 0;
-  //! Set position, momentum and covariance of state.
-  virtual void setPosMomCov(MeasuredStateOnPlane& state, const TVectorD& state6, const TMatrixDSym& cov6x6) const = 0;
+    //! try to multiply pdg code with -1. (Switch from particle to anti-particle and vice versa).
+    bool switchPDGSign();
 
-  //! Set the sign of the charge according to charge.
-  virtual void setChargeSign(StateOnPlane& state, double charge) const = 0;
-  //! Set charge/momentum.
-  virtual void setQop(StateOnPlane& state, double qop) const = 0;
-  //! Set time at which the state was defined
-  virtual void setTime(StateOnPlane& state, double time) const = 0;
+    //! Set position and momentum of state.
+    virtual void setPosMom(StateOnPlane& state, const TVector3& pos, const TVector3& mom) const = 0;
+    //! Set position and momentum of state.
+    virtual void setPosMom(StateOnPlane& state, const TVectorD& state6) const = 0;
+    //! Set position and momentum and error of state.
+    virtual void setPosMomErr(MeasuredStateOnPlane& state, const TVector3& pos, const TVector3& mom, const TVector3& posErr,
+                              const TVector3& momErr) const = 0;
+    //! Set position, momentum and covariance of state.
+    virtual void setPosMomCov(MeasuredStateOnPlane& state, const TVector3& pos, const TVector3& mom,
+                              const TMatrixDSym& cov6x6) const = 0;
+    //! Set position, momentum and covariance of state.
+    virtual void setPosMomCov(MeasuredStateOnPlane& state, const TVectorD& state6, const TMatrixDSym& cov6x6) const = 0;
 
-  //! Set propagation direction. (-1, 0, 1) -> (backward, auto, forward).
-  void setPropDir(int dir) {
-    if (dir>0) propDir_ = 1;
-    else if (dir<0) propDir_ = -1;
-    else propDir_ = 0;
+    //! Set the sign of the charge according to charge.
+    virtual void setChargeSign(StateOnPlane& state, double charge) const = 0;
+    //! Set charge/momentum.
+    virtual void setQop(StateOnPlane& state, double qop) const = 0;
+    //! Set time at which the state was defined
+    virtual void setTime(StateOnPlane& state, double time) const = 0;
+
+    //! Set propagation direction. (-1, 0, 1) -> (backward, auto, forward).
+    void setPropDir(int dir)
+    {
+      if (dir > 0) propDir_ = 1;
+      else if (dir < 0) propDir_ = -1;
+      else propDir_ = 0;
+    };
+
+    //! Switch propagation direction. Has no effect if propDir_ is set to 0.
+    void switchPropDir() {propDir_ = -1 * propDir_;}
+
+    //! check if other is of same type (e.g. RKTrackRep).
+    virtual bool isSameType(const AbsTrackRep* other) = 0;
+
+    //! check if other is of same type (e.g. RKTrackRep) and has same pdg code.
+    virtual bool isSame(const AbsTrackRep* other) = 0;
+
+    virtual void setDebugLvl(unsigned int lvl = 1) {debugLvl_ = lvl;}
+
+    virtual void Print(const Option_t* = "") const;
+
+  protected:
+
+    //! protect from calling copy c'tor from outside the class. Use #clone() if you want a copy!
+    AbsTrackRep(const AbsTrackRep&);
+    //! protect from calling assignment operator from outside the class. Use #clone() instead!
+    AbsTrackRep& operator=(const AbsTrackRep&);
+
+
+    //! Particle code
+    int pdgCode_;
+    //! propagation direction (-1, 0, 1) -> (backward, auto, forward)
+    char propDir_;
+
+    unsigned int debugLvl_;
+
+  public:
+    ClassDef(AbsTrackRep, 1)
+
   };
-
-  //! Switch propagation direction. Has no effect if propDir_ is set to 0.
-  void switchPropDir(){propDir_ = -1*propDir_;}
-
-  //! check if other is of same type (e.g. RKTrackRep).
-  virtual bool isSameType(const AbsTrackRep* other) = 0;
-
-  //! check if other is of same type (e.g. RKTrackRep) and has same pdg code.
-  virtual bool isSame(const AbsTrackRep* other) = 0;
-
-  virtual void setDebugLvl(unsigned int lvl = 1) {debugLvl_ = lvl;}
-
-  virtual void Print(const Option_t* = "") const;
-
- protected:
-
-  //! protect from calling copy c'tor from outside the class. Use #clone() if you want a copy!
-  AbsTrackRep(const AbsTrackRep&);
-  //! protect from calling assignment operator from outside the class. Use #clone() instead!
-  AbsTrackRep& operator=(const AbsTrackRep&);
-
-
-  //! Particle code
-  int pdgCode_;
-  //! propagation direction (-1, 0, 1) -> (backward, auto, forward)
-  char propDir_;
-
-  unsigned int debugLvl_;
-
- public:
-  ClassDef(AbsTrackRep,1)
-
-};
 
 } /* End of namespace genfit */
 /** @} */

--- a/core/include/DetPlane.h
+++ b/core/include/DetPlane.h
@@ -41,156 +41,161 @@
 
 namespace genfit {
 
-/** @brief Detector plane.
- *
- * A detector plane is the principle object to define coordinate systems for
- * track fitting in genfit. Since a particle trajectory is a
- * one-dimensional object (regardless of any specific parameterization)
- * positions with respect to the track are always measured in a plane.
- *
- * Which plane is chosen depends on the type of detector. Fixed plane
- * detectors have their detector plane defined by their mechanical setup. While
- * wire chambers or time projection chambers might want to define a detector
- * plane more flexibly.
- *
- * This class parameterizes a plane in terms of an origin vector o
- * and two plane-spanning directions u and v.
- */
-class DetPlane : public TObject {
+  /** @brief Detector plane.
+   *
+   * A detector plane is the principle object to define coordinate systems for
+   * track fitting in genfit. Since a particle trajectory is a
+   * one-dimensional object (regardless of any specific parameterization)
+   * positions with respect to the track are always measured in a plane.
+   *
+   * Which plane is chosen depends on the type of detector. Fixed plane
+   * detectors have their detector plane defined by their mechanical setup. While
+   * wire chambers or time projection chambers might want to define a detector
+   * plane more flexibly.
+   *
+   * This class parameterizes a plane in terms of an origin vector o
+   * and two plane-spanning directions u and v.
+   */
+  class DetPlane : public TObject {
 
- public:
+  public:
 
 
-  // Constructors/Destructors ---------
-  DetPlane(AbsFinitePlane* finite = nullptr);
+    // Constructors/Destructors ---------
+    DetPlane(AbsFinitePlane* finite = nullptr);
 
-  DetPlane(const TVector3& o,
+    DetPlane(const TVector3& o,
              const TVector3& u,
              const TVector3& v,
              AbsFinitePlane* finite = nullptr);
 
-  DetPlane(const TVector3& o,
+    DetPlane(const TVector3& o,
              const TVector3& n,
              AbsFinitePlane* finite = nullptr);
 
-  virtual ~DetPlane();
+    virtual ~DetPlane();
 
-  DetPlane(const DetPlane&);
-  DetPlane& operator=(DetPlane);
-  void swap(DetPlane& other); // nothrow
+    DetPlane(const DetPlane&);
+    DetPlane& operator=(DetPlane);
+    void swap(DetPlane& other); // nothrow
 
-  // Accessors -----------------------
-  const TVector3& getO() const {return o_;}
-  const TVector3& getU() const {return u_;}
-  const TVector3& getV() const {return v_;}
+    // Accessors -----------------------
+    const TVector3& getO() const {return o_;}
+    const TVector3& getU() const {return u_;}
+    const TVector3& getV() const {return v_;}
 
-  // Modifiers -----------------------
-  void set(const TVector3& o,
-           const TVector3& u,
-           const TVector3& v);
-  void setO(const TVector3& o);
-  void setO(double, double, double);
-  void setU(const TVector3& u);
-  void setU(double, double, double);
-  void setV(const TVector3& v);
-  void setV(double, double, double);
-  void setUV(const TVector3& u, const TVector3& v);
-  void setON(const TVector3& o, const TVector3& n);
+    // Modifiers -----------------------
+    void set(const TVector3& o,
+             const TVector3& u,
+             const TVector3& v);
+    void setO(const TVector3& o);
+    void setO(double, double, double);
+    void setU(const TVector3& u);
+    void setU(double, double, double);
+    void setV(const TVector3& v);
+    void setV(double, double, double);
+    void setUV(const TVector3& u, const TVector3& v);
+    void setON(const TVector3& o, const TVector3& n);
 
-  //! Optionally, set the finite plane definition. This is most important for
-  //! avoiding fake intersection points in fitting of curlers. This should
-  //! be implemented for silicon detectors most importantly.
-  void setFinitePlane(AbsFinitePlane* finite){finitePlane_.reset(finite);}
+    //! Optionally, set the finite plane definition. This is most important for
+    //! avoiding fake intersection points in fitting of curlers. This should
+    //! be implemented for silicon detectors most importantly.
+    void setFinitePlane(AbsFinitePlane* finite) {finitePlane_.reset(finite);}
 
-  // Operations ----------------------
-  TVector3 getNormal() const;
-  void setNormal(const TVector3& n);
-  void setNormal(double, double, double);
-  void setNormal(const double& theta, const double& phi);
+    // Operations ----------------------
+    TVector3 getNormal() const;
+    void setNormal(const TVector3& n);
+    void setNormal(double, double, double);
+    void setNormal(const double& theta, const double& phi);
 
-  //! projecting a direction onto the plane:
-  TVector2 project(const TVector3& x) const;
+    //! projecting a direction onto the plane:
+    TVector2 project(const TVector3& x) const;
 
-  //! transform from Lab system into plane
-  TVector2 LabToPlane(const TVector3& x) const;
+    //! transform from Lab system into plane
+    TVector2 LabToPlane(const TVector3& x) const;
 
-  //! transform from plane coordinates to lab system
-  TVector3 toLab(const TVector2& x) const;
+    //! transform from plane coordinates to lab system
+    TVector3 toLab(const TVector2& x) const;
 
-  // get vector from point to plane (normal)
-  TVector3 dist(const TVector3& point) const;
+    // get vector from point to plane (normal)
+    TVector3 dist(const TVector3& point) const;
 
-  //! gives u,v coordinates of the intersection point of a straight line with plane
-  TVector2 straightLineToPlane(const TVector3& point, const TVector3& dir) const;
+    //! gives u,v coordinates of the intersection point of a straight line with plane
+    TVector2 straightLineToPlane(const TVector3& point, const TVector3& dir) const;
 
-  //! gives u,v coordinates of the intersection point of a straight line with plane
-  void straightLineToPlane(const double& posX, const double& posY, const double& posZ,
-                           const double& dirX, const double& dirY, const double& dirZ,
-                           double& u, double& v) const;
+    //! gives u,v coordinates of the intersection point of a straight line with plane
+    void straightLineToPlane(const double& posX, const double& posY, const double& posZ,
+                             const double& dirX, const double& dirY, const double& dirZ,
+                             double& u, double& v) const;
 
-  void Print(const Option_t* = "") const;
+    void Print(const Option_t* = "") const;
 
-  //! Checks equality of planes by comparing the 9 double values that define them.
-  friend bool operator== (const DetPlane& lhs, const DetPlane& rhs);
-  //! returns NOT ==
-  friend bool operator!= (const DetPlane& lhs, const DetPlane& rhs);
+    //! Checks equality of planes by comparing the 9 double values that define them.
+    friend bool operator== (const DetPlane& lhs, const DetPlane& rhs);
+    //! returns NOT ==
+    friend bool operator!= (const DetPlane& lhs, const DetPlane& rhs);
 
-  //! absolute distance from a point to the plane
-  double distance(const TVector3& point) const;
-  double distance(double, double, double) const;
+    //! absolute distance from a point to the plane
+    double distance(const TVector3& point) const;
+    double distance(double, double, double) const;
 
 
-  //! intersect in the active area? C.f. AbsFinitePlane
-  bool isInActive(const TVector3& point, const TVector3& dir) const {
-    if(finitePlane_.get() == nullptr) return true;
-    return this->isInActive( this->straightLineToPlane(point,dir));
-  }
+    //! intersect in the active area? C.f. AbsFinitePlane
+    bool isInActive(const TVector3& point, const TVector3& dir) const
+    {
+      if (finitePlane_.get() == nullptr) return true;
+      return this->isInActive(this->straightLineToPlane(point, dir));
+    }
 
-  //! intersect in the active area? C.f. AbsFinitePlane
-  bool isInActive(const double& posX, const double& posY, const double& posZ,
-                  const double& dirX, const double& dirY, const double& dirZ) const {
-    if(finitePlane_.get() == nullptr) return true;
-    double u, v;
-    this->straightLineToPlane(posX, posY, posZ, dirX, dirY, dirZ, u, v);
-    return this->isInActive(u, v);
-  }
+    //! intersect in the active area? C.f. AbsFinitePlane
+    bool isInActive(const double& posX, const double& posY, const double& posZ,
+                    const double& dirX, const double& dirY, const double& dirZ) const
+    {
+      if (finitePlane_.get() == nullptr) return true;
+      double u, v;
+      this->straightLineToPlane(posX, posY, posZ, dirX, dirY, dirZ, u, v);
+      return this->isInActive(u, v);
+    }
 
-  //! isInActive methods refer to finite plane. C.f. AbsFinitePlane
-  bool isInActive(double u, double v) const{
-    if(finitePlane_.get() == nullptr) return true;
-    return finitePlane_->isInActive(u,v);
-  }
+    //! isInActive methods refer to finite plane. C.f. AbsFinitePlane
+    bool isInActive(double u, double v) const
+    {
+      if (finitePlane_.get() == nullptr) return true;
+      return finitePlane_->isInActive(u, v);
+    }
 
-  //! isInActive methods refer to finite plane. C.f. AbsFinitePlane
-  bool isInActive(const TVector2& v) const{
-    return isInActive(v.X(),v.Y());
-  }
+    //! isInActive methods refer to finite plane. C.f. AbsFinitePlane
+    bool isInActive(const TVector2& v) const
+    {
+      return isInActive(v.X(), v.Y());
+    }
 
-  bool isFinite() const {
-    return (finitePlane_.get() != nullptr);
-  }
+    bool isFinite() const
+    {
+      return (finitePlane_.get() != nullptr);
+    }
 
-  //! rotate u and v around normal. Angle is in rad. More for debugging than for actual use.
-  void rotate(double angle);
+    //! rotate u and v around normal. Angle is in rad. More for debugging than for actual use.
+    void rotate(double angle);
 
-  //! delete finitePlane_ and set O, U, V to default values
-  void reset();
+    //! delete finitePlane_ and set O, U, V to default values
+    void reset();
 
- private:
-  // Private Methods -----------------
-  //! ensures orthonormal coordinates
-  void sane();
+  private:
+    // Private Methods -----------------
+    //! ensures orthonormal coordinates
+    void sane();
 
-  TVector3 o_;
-  TVector3 u_;
-  TVector3 v_;
+    TVector3 o_;
+    TVector3 u_;
+    TVector3 v_;
 
-  std::unique_ptr<AbsFinitePlane> finitePlane_; // Ownership
+    std::unique_ptr<AbsFinitePlane> finitePlane_; // Ownership
 
- public:
-  ClassDef(DetPlane,1)
+  public:
+    ClassDef(DetPlane, 1)
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/core/include/Exception.h
+++ b/core/include/Exception.h
@@ -34,69 +34,69 @@
 
 namespace genfit {
 
-/** @brief Exception class for error handling in GENFIT (provides storage for diagnostic information)
- *
- *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
- *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
- *
- * This is the class that is used for all error handling in GENFIT.
- * It is a utility class that allows to store numbers and matrices together
- * with an error string. The exception class can then be thrown when an error
- * is detected and the C++ exception handling facilities can be used to
- * catch and process the exception.
- */
-class Exception : public std::exception {
-
- public:
-  /** @brief Initializing constructor
+  /** @brief Exception class for error handling in GENFIT (provides storage for diagnostic information)
    *
-   * @param excString error message.
-   * @param line line at which the exception is created. Can be set through __LINE__ macro.
-   * @param file sourcefile in which the exception is created. Can be set through __FILE__ macro.
+   *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
+   *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
+   *
+   * This is the class that is used for all error handling in GENFIT.
+   * It is a utility class that allows to store numbers and matrices together
+   * with an error string. The exception class can then be thrown when an error
+   * is detected and the C++ exception handling facilities can be used to
+   * catch and process the exception.
    */
-  Exception(std::string excString, int line, std::string  file);
-  virtual ~Exception() noexcept;
+  class Exception : public std::exception {
 
-  //! Set fatal flag.
-  void setFatal (bool b=true){fatal_=b;}
-  //! Get fatal flag.
-  bool isFatal (){return fatal_;}
-  //! Set list of numbers with description.
-  void setNumbers (std::string, const std::vector<double>&);
-  //! Set list of matrices with description.
-  void setMatrices(std::string, const std::vector<TMatrixD>&);
+  public:
+    /** @brief Initializing constructor
+     *
+     * @param excString error message.
+     * @param line line at which the exception is created. Can be set through __LINE__ macro.
+     * @param file sourcefile in which the exception is created. Can be set through __FILE__ macro.
+     */
+    Exception(std::string excString, int line, std::string  file);
+    virtual ~Exception() noexcept;
 
-  //! Print information in the exception object.
-  void info();
+    //! Set fatal flag.
+    void setFatal(bool b = true) {fatal_ = b;}
+    //! Get fatal flag.
+    bool isFatal() {return fatal_;}
+    //! Set list of numbers with description.
+    void setNumbers(std::string, const std::vector<double>&);
+    //! Set list of matrices with description.
+    void setMatrices(std::string, const std::vector<TMatrixD>&);
 
-  //! Standard error message handling for exceptions. use like "std::cerr << e.what();"
-  virtual const char* what() const noexcept;
+    //! Print information in the exception object.
+    void info();
 
-  std::string getExcString(){return excString_;}
+    //! Standard error message handling for exceptions. use like "std::cerr << e.what();"
+    virtual const char* what() const noexcept;
 
-  //! "std::cerr << e.what();" will not write anything.
-  static void quiet(bool b=true){quiet_=b;}
+    std::string getExcString() {return excString_;}
 
- private:
+    //! "std::cerr << e.what();" will not write anything.
+    static void quiet(bool b = true) {quiet_ = b;}
 
-  static bool quiet_;
+  private:
 
-  std::string excString_;
-  int line_;
-  std::string file_;
+    static bool quiet_;
 
-  std::string errorMessage_;
+    std::string excString_;
+    int line_;
+    std::string file_;
 
-  std::string numbersLabel_;
-  std::string matricesLabel_;
-  std::vector<double> numbers_;
-  std::vector<TMatrixD> matrices_;
+    std::string errorMessage_;
 
-  bool fatal_;
+    std::string numbersLabel_;
+    std::string matricesLabel_;
+    std::vector<double> numbers_;
+    std::vector<TMatrixD> matrices_;
 
-  //ClassDef(Exception,1)
+    bool fatal_;
 
-};
+    //ClassDef(Exception,1)
+
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/core/include/FieldManager.h
+++ b/core/include/FieldManager.h
@@ -35,113 +35,122 @@
 namespace genfit {
 
 #ifdef CACHE
-/**
- * @brief Cache B field at a position. Used by FieldManager.
- */
-struct fieldCache {
-  double posX; double posY; double posZ;
-  double Bx; double By; double Bz;
-};
+  /**
+   * @brief Cache B field at a position. Used by FieldManager.
+   */
+  struct fieldCache {
+    double posX; double posY; double posZ;
+    double Bx; double By; double Bz;
+  };
 #endif
 
 
-/** @brief Singleton which provides access to magnetic field maps.
- *
- *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
- *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
- */
-class FieldManager {
+  /** @brief Singleton which provides access to magnetic field maps.
+   *
+   *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
+   *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
+   */
+  class FieldManager {
 
- public:
+  public:
 
-  AbsBField* getField(){
-    checkInitialized();
-    return field_;
-  }
+    AbsBField* getField()
+    {
+      checkInitialized();
+      return field_;
+    }
 
-  //! This does NOT use the cache!
-  TVector3 getFieldVal(const TVector3& position){
-    checkInitialized();
-    return field_->get(position);
-  }
+    //! This does NOT use the cache!
+    TVector3 getFieldVal(const TVector3& position)
+    {
+      checkInitialized();
+      return field_->get(position);
+    }
 
 #ifdef CACHE
-  void getFieldVal(const double& posX, const double& posY, const double& posZ, double& Bx, double& By, double& Bz);
+    void getFieldVal(const double& posX, const double& posY, const double& posZ, double& Bx, double& By, double& Bz);
 #else
-  inline void getFieldVal(const double& posX, const double& posY, const double& posZ, double& Bx, double& By, double& Bz) {
-    checkInitialized();
-    return field_->get(posX, posY, posZ, Bx, By, Bz);
-  }
+    inline void getFieldVal(const double& posX, const double& posY, const double& posZ, double& Bx, double& By, double& Bz)
+    {
+      checkInitialized();
+      return field_->get(posX, posY, posZ, Bx, By, Bz);
+    }
 #endif
 
-  //! set the magnetic field here. Magnetic field classes must be derived from AbsBField.
-  void init(AbsBField* b) {
-    field_=b;
-  }
-
-  void destruct() {
-    if (instance_ != nullptr) {
-      delete instance_;
-      instance_ = nullptr;
+    //! set the magnetic field here. Magnetic field classes must be derived from AbsBField.
+    void init(AbsBField* b)
+    {
+      field_ = b;
     }
-  }
 
-  bool isInitialized() { return field_ != nullptr; }
-
-  void checkInitialized() {
-    if(! isInitialized()){
-      errorOut << "FieldManager hasn't been initialized with a correct AbsBField pointer!" << std::endl;
-      std::string msg("FieldManager hasn't been initialized with a correct AbsBField pointer!");
-      std::runtime_error err(msg);
-      throw err;
+    void destruct()
+    {
+      if (instance_ != nullptr) {
+        delete instance_;
+        instance_ = nullptr;
+      }
     }
-  }
 
-  static void checkInstanciated() {
-    if(instance_==nullptr){
-      errorOut << "FieldManager hasn't been instantiated yet, call getInstance() and init() before getFieldVal()!" << std::endl;
-      std::string msg("FieldManager hasn't been instantiated yet, call getInstance() and init() before getFieldVal()!");
-      std::runtime_error err(msg);
-      throw err;
+    bool isInitialized() { return field_ != nullptr; }
+
+    void checkInitialized()
+    {
+      if (! isInitialized()) {
+        errorOut << "FieldManager hasn't been initialized with a correct AbsBField pointer!" << std::endl;
+        std::string msg("FieldManager hasn't been initialized with a correct AbsBField pointer!");
+        std::runtime_error err(msg);
+        throw err;
+      }
     }
-  }
+
+    static void checkInstanciated()
+    {
+      if (instance_ == nullptr) {
+        errorOut << "FieldManager hasn't been instantiated yet, call getInstance() and init() before getFieldVal()!" << std::endl;
+        std::string msg("FieldManager hasn't been instantiated yet, call getInstance() and init() before getFieldVal()!");
+        std::runtime_error err(msg);
+        throw err;
+      }
+    }
 
 #ifdef CACHE
-  //! Cache last lookup positions, and use stored field values if a lookup at (almost) the same position is done.
-  void useCache(bool opt = true, unsigned int nBuckets = 8);
+    //! Cache last lookup positions, and use stored field values if a lookup at (almost) the same position is done.
+    void useCache(bool opt = true, unsigned int nBuckets = 8);
 #else
-  void useCache(bool opt = true, unsigned int nBuckets = 8) {
-    std::cerr << "genfit::FieldManager::useCache() - FieldManager is compiled w/o CACHE, no caching will be done!" << std::endl;
-  }
-#endif
-
-  //! Get singleton instance.
-  static FieldManager* getInstance(){
-    if(instance_ == nullptr) {
-      instance_ = new FieldManager();
+    void useCache(bool opt = true, unsigned int nBuckets = 8)
+    {
+      std::cerr << "genfit::FieldManager::useCache() - FieldManager is compiled w/o CACHE, no caching will be done!" << std::endl;
     }
-    return instance_;
-  }
+#endif
+
+    //! Get singleton instance.
+    static FieldManager* getInstance()
+    {
+      if (instance_ == nullptr) {
+        instance_ = new FieldManager();
+      }
+      return instance_;
+    }
 
 
- private:
+  private:
 
-  FieldManager() {}
+    FieldManager() {}
 #ifdef CACHE
-  ~FieldManager() { delete cache_; }
+    ~FieldManager() { delete cache_; }
 #else
-  ~FieldManager() { }
+    ~FieldManager() { }
 #endif
-  static FieldManager* instance_;
-  static AbsBField* field_;
+    static FieldManager* instance_;
+    static AbsBField* field_;
 
 #ifdef CACHE
-  static bool useCache_;
-  static unsigned int n_buckets_;
-  static fieldCache* cache_;
+    static bool useCache_;
+    static unsigned int n_buckets_;
+    static fieldCache* cache_;
 #endif
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/core/include/FitStatus.h
+++ b/core/include/FitStatus.h
@@ -30,141 +30,143 @@
 namespace genfit {
 
 
-/**
- * @brief Info which information has been pruned from the Track.
- *
- * Possible options:
-   * C:  prune all reps except cardinalRep
-   * F:  prune all points except first point (also prune referenceInfo from fitterInfos)
-   * L:  prune all points except last point (also prune referenceInfo from fitterInfos)
-   * FL: prune all points except first and last point (also prune referenceInfo from fitterInfos)
-   * W:  prune rawMeasurements from TrackPoints
-   * R:  prune referenceInfo from fitterInfos
-   * M:  prune measurementInfo from fitterInfos
-   * I:  if F, L, or FL is set, prune forward (backward) info of first (last) point
-   * U:  if fitterInfo is a KalmanFitterInfo, prune predictions and keep updates
- */
-struct PruneFlags {
-  PruneFlags();
-  void reset();
-  //! does not reset! If a flag is already true and is not in opt, it will stay true.
-  void setFlags(Option_t* option = "");
-  //! check if all the given flags are set
-  bool hasFlags(Option_t* option = "CFLWRMIU") const;
-  //! check if any of the flags is set
-  bool isPruned() const;
-
-  void Print(const Option_t* = "") const;
-
-private:
-  enum fields { C = 1 << 0,
-		F = 1 << 1,
-		L = 1 << 2,
-		W = 1 << 3,
-		R = 1 << 4,
-		M = 1 << 5,
-		I = 1 << 6,
-		U = 1 << 7 };
-
-  int value; // bitfield composed from above.  ROOT cannot deal with
-	     // bitfield notation, so this is done manually.
-
-  // No ClassDef here.  Update FitStatus version number when changing this.
-};
-
-
-/** @brief Class where important numbers and properties of a fit can be stored.
- *
- *  @author Johannes Rauch (Technische Universit&auml;t M&uuml;nchen, original author)
- */
-class FitStatus {
-
- public:
-
-  FitStatus() :
-    isFitted_(false), isFitConvergedFully_(false), isFitConvergedPartially_(false), nFailedPoints_(0),
-    trackHasChanged_(false), pruneFlags_(), charge_(0), chi2_(-1e99), ndf_(-1e99)
-  {;}
-
-  virtual ~FitStatus() {};
-
-  virtual FitStatus* clone() const {return new FitStatus(*this);}
-
-  //! Has the track been fitted?
-  bool isFitted() const {return isFitted_;}
-  //! Did the fit converge (in all Points or only partially)?
   /**
-   * Per default, this function will only be true, if all TrackPoints
-   * (with measurements) have been used in the fit, and the fit has converged.
+   * @brief Info which information has been pruned from the Track.
    *
-   * If one or more TrackPoints have been skipped
-   * (e.g. plane could not be constructed or extrapolation to plane failed),
-   * but the fit otherwise met the convergence criteria, isFitConverged(false)
-   * will return true.
+   * Possible options:
+     * C:  prune all reps except cardinalRep
+     * F:  prune all points except first point (also prune referenceInfo from fitterInfos)
+     * L:  prune all points except last point (also prune referenceInfo from fitterInfos)
+     * FL: prune all points except first and last point (also prune referenceInfo from fitterInfos)
+     * W:  prune rawMeasurements from TrackPoints
+     * R:  prune referenceInfo from fitterInfos
+     * M:  prune measurementInfo from fitterInfos
+     * I:  if F, L, or FL is set, prune forward (backward) info of first (last) point
+     * U:  if fitterInfo is a KalmanFitterInfo, prune predictions and keep updates
    */
-  bool isFitConverged(bool inAllPoints = true) const {
-    if (inAllPoints)
+  struct PruneFlags {
+    PruneFlags();
+    void reset();
+    //! does not reset! If a flag is already true and is not in opt, it will stay true.
+    void setFlags(Option_t* option = "");
+    //! check if all the given flags are set
+    bool hasFlags(Option_t* option = "CFLWRMIU") const;
+    //! check if any of the flags is set
+    bool isPruned() const;
+
+    void Print(const Option_t* = "") const;
+
+  private:
+    enum fields { C = 1 << 0,
+                  F = 1 << 1,
+                  L = 1 << 2,
+                  W = 1 << 3,
+                  R = 1 << 4,
+                  M = 1 << 5,
+                  I = 1 << 6,
+                  U = 1 << 7
+                };
+
+    int value; // bitfield composed from above.  ROOT cannot deal with
+    // bitfield notation, so this is done manually.
+
+    // No ClassDef here.  Update FitStatus version number when changing this.
+  };
+
+
+  /** @brief Class where important numbers and properties of a fit can be stored.
+   *
+   *  @author Johannes Rauch (Technische Universit&auml;t M&uuml;nchen, original author)
+   */
+  class FitStatus {
+
+  public:
+
+    FitStatus() :
+      isFitted_(false), isFitConvergedFully_(false), isFitConvergedPartially_(false), nFailedPoints_(0),
+      trackHasChanged_(false), pruneFlags_(), charge_(0), chi2_(-1e99), ndf_(-1e99)
+    {;}
+
+    virtual ~FitStatus() {};
+
+    virtual FitStatus* clone() const {return new FitStatus(*this);}
+
+    //! Has the track been fitted?
+    bool isFitted() const {return isFitted_;}
+    //! Did the fit converge (in all Points or only partially)?
+    /**
+     * Per default, this function will only be true, if all TrackPoints
+     * (with measurements) have been used in the fit, and the fit has converged.
+     *
+     * If one or more TrackPoints have been skipped
+     * (e.g. plane could not be constructed or extrapolation to plane failed),
+     * but the fit otherwise met the convergence criteria, isFitConverged(false)
+     * will return true.
+     */
+    bool isFitConverged(bool inAllPoints = true) const
+    {
+      if (inAllPoints)
         return isFitConvergedFully_;
-    return isFitConvergedPartially_;
-  }
-  bool isFitConvergedFully() const {return isFitConvergedFully_;}
-  bool isFitConvergedPartially() const {return isFitConvergedPartially_;}
-  int getNFailedPoints() const {return nFailedPoints_;}
-  //! Has anything in the Track been changed since the fit?
-  bool hasTrackChanged() const {return trackHasChanged_;}
-  //! Has the track been pruned after the fit?
-  bool isTrackPruned() const {return pruneFlags_.isPruned();}
-  //! Get the fitted charge.
-  double getCharge() const {return charge_;}
-  //! Get chi^2 of the fit.
-  double getChi2() const {return chi2_;}
-  //! Get the degrees of freedom of the fit.
-  double getNdf() const {return ndf_;}
-  /**
-   * @brief Get the p value of the fit.
-   *
-   * Virtual, because the fitter may use a different probability distribution.
-   */
-  virtual double getPVal() const {return std::max(0.,ROOT::Math::chisquared_cdf_c(chi2_, ndf_));}
+      return isFitConvergedPartially_;
+    }
+    bool isFitConvergedFully() const {return isFitConvergedFully_;}
+    bool isFitConvergedPartially() const {return isFitConvergedPartially_;}
+    int getNFailedPoints() const {return nFailedPoints_;}
+    //! Has anything in the Track been changed since the fit?
+    bool hasTrackChanged() const {return trackHasChanged_;}
+    //! Has the track been pruned after the fit?
+    bool isTrackPruned() const {return pruneFlags_.isPruned();}
+    //! Get the fitted charge.
+    double getCharge() const {return charge_;}
+    //! Get chi^2 of the fit.
+    double getChi2() const {return chi2_;}
+    //! Get the degrees of freedom of the fit.
+    double getNdf() const {return ndf_;}
+    /**
+     * @brief Get the p value of the fit.
+     *
+     * Virtual, because the fitter may use a different probability distribution.
+     */
+    virtual double getPVal() const {return std::max(0., ROOT::Math::chisquared_cdf_c(chi2_, ndf_));}
 
-  void setIsFitted(bool fitted = true) {isFitted_ = fitted;}
-  void setIsFitConvergedFully(bool fitConverged = true) {isFitConvergedFully_ = fitConverged;}
-  void setIsFitConvergedPartially(bool fitConverged = true) {isFitConvergedPartially_ = fitConverged;}
-  void setNFailedPoints(int nFailedPoints) {nFailedPoints_ = nFailedPoints;}
-  void setHasTrackChanged(bool trackChanged = true) {trackHasChanged_ = trackChanged;}
-  void setCharge(double charge) {charge_ = charge;}
+    void setIsFitted(bool fitted = true) {isFitted_ = fitted;}
+    void setIsFitConvergedFully(bool fitConverged = true) {isFitConvergedFully_ = fitConverged;}
+    void setIsFitConvergedPartially(bool fitConverged = true) {isFitConvergedPartially_ = fitConverged;}
+    void setNFailedPoints(int nFailedPoints) {nFailedPoints_ = nFailedPoints;}
+    void setHasTrackChanged(bool trackChanged = true) {trackHasChanged_ = trackChanged;}
+    void setCharge(double charge) {charge_ = charge;}
 
-  PruneFlags& getPruneFlags() {return pruneFlags_;}
+    PruneFlags& getPruneFlags() {return pruneFlags_;}
 
-  void setChi2(const double& chi2) {chi2_ = chi2;}
-  void setNdf(const double& ndf) {ndf_ = ndf;}
+    void setChi2(const double& chi2) {chi2_ = chi2;}
+    void setNdf(const double& ndf) {ndf_ = ndf;}
 
-  virtual void Print(const Option_t* = "") const;
+    virtual void Print(const Option_t* = "") const;
 
- protected:
+  protected:
 
-  //! has the track been fitted?
-  bool isFitted_;
-  //! did the fit converge with all TrackPoints?
-  bool isFitConvergedFully_;
-  //! did the fit converge with a subset of all TrackPoints?
-  bool isFitConvergedPartially_;
-  //! Number of failed TrackPoints
-  int nFailedPoints_;
-  //! has anything in the Track been changed since the fit? -> fit isn't valid anymore
-  bool trackHasChanged_;
-  //! Prune flags
-  PruneFlags pruneFlags_;
-  //! fitted charge
-  double charge_;
+    //! has the track been fitted?
+    bool isFitted_;
+    //! did the fit converge with all TrackPoints?
+    bool isFitConvergedFully_;
+    //! did the fit converge with a subset of all TrackPoints?
+    bool isFitConvergedPartially_;
+    //! Number of failed TrackPoints
+    int nFailedPoints_;
+    //! has anything in the Track been changed since the fit? -> fit isn't valid anymore
+    bool trackHasChanged_;
+    //! Prune flags
+    PruneFlags pruneFlags_;
+    //! fitted charge
+    double charge_;
 
-  //! These are provided for the sake of the fitter, and their interpretation may vary.
-  //! For the Kalman-derived fitters in particular, this corresponds to the backwards fit.
-  double chi2_;
-  double ndf_;
+    //! These are provided for the sake of the fitter, and their interpretation may vary.
+    //! For the Kalman-derived fitters in particular, this corresponds to the backwards fit.
+    double chi2_;
+    double ndf_;
 
-  ClassDef(FitStatus, 3);
-};
+    ClassDef(FitStatus, 3);
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/core/include/IO.h
+++ b/core/include/IO.h
@@ -27,15 +27,15 @@
 
 namespace genfit {
 
-/** Default stream for debug output.  Defaults to std::cout.
-   Override destination with debugOut.rdbuf(newStream.rdbuf()).  */
-extern std::ostream debugOut;
-/** Default stream for error output.  Defaults to std::cerr.
-    Override destination with errorOut.rdbuf(newStream.rdbuf()).  */
-extern std::ostream errorOut;
-/** Default stream for output of Print calls.  Defaults to std::cout.
-   Override destination with printOut.rdbuf(newStream.rdbuf()).  */
-extern std::ostream printOut;
+  /** Default stream for debug output.  Defaults to std::cout.
+     Override destination with debugOut.rdbuf(newStream.rdbuf()).  */
+  extern std::ostream debugOut;
+  /** Default stream for error output.  Defaults to std::cerr.
+      Override destination with errorOut.rdbuf(newStream.rdbuf()).  */
+  extern std::ostream errorOut;
+  /** Default stream for output of Print calls.  Defaults to std::cout.
+     Override destination with printOut.rdbuf(newStream.rdbuf()).  */
+  extern std::ostream printOut;
 
 }
 

--- a/core/include/Material.h
+++ b/core/include/Material.h
@@ -5,30 +5,30 @@
 
 namespace genfit {
 
-    struct Material {
-        double density;  /// Density in g / cm^3
-        double Z;  /// Atomic number
-        double A;  /// Mass number in g / mol
-        double radiationLength;  /// Radiation Length in cm
-        double mEE;  /// Mean excitaiton energy in eV
+  struct Material {
+    double density;  /// Density in g / cm^3
+    double Z;  /// Atomic number
+    double A;  /// Mass number in g / mol
+    double radiationLength;  /// Radiation Length in cm
+    double mEE;  /// Mean excitaiton energy in eV
 
-        Material() : density(0), Z(0), A(0), radiationLength(0), mEE(0) {}
+    Material() : density(0), Z(0), A(0), radiationLength(0), mEE(0) {}
 
-        Material(double density_, double Z_, double A_, double radiationLength_, double mEE_) :
-                density(density_), Z(Z_), A(A_), radiationLength(radiationLength_), mEE(mEE_) {}
+    Material(double density_, double Z_, double A_, double radiationLength_, double mEE_) :
+      density(density_), Z(Z_), A(A_), radiationLength(radiationLength_), mEE(mEE_) {}
 
-        Material(const Material &material) = default;
+    Material(const Material& material) = default;
 
-        virtual ~Material() {};
+    virtual ~Material() {};
 
-        void Print(const Option_t* = "") const;
+    void Print(const Option_t* = "") const;
 
-        ClassDef(Material, 1)
-    };
+    ClassDef(Material, 1)
+  };
 
-    bool operator==(const Material &lhs, const Material &rhs);
+  bool operator==(const Material& lhs, const Material& rhs);
 
-    bool operator!=(const Material &lhs, const Material &rhs);
+  bool operator!=(const Material& lhs, const Material& rhs);
 
 }
 

--- a/core/include/MeasuredStateOnPlane.h
+++ b/core/include/MeasuredStateOnPlane.h
@@ -33,108 +33,113 @@
 
 namespace genfit {
 
-/**
- *  @brief #StateOnPlane with additional covariance matrix.
- */
-class MeasuredStateOnPlane : public StateOnPlane {
+  /**
+   *  @brief #StateOnPlane with additional covariance matrix.
+   */
+  class MeasuredStateOnPlane : public StateOnPlane {
 
- public:
+  public:
 
-  MeasuredStateOnPlane(const AbsTrackRep* rep = nullptr);
-  MeasuredStateOnPlane(const TVectorD& state, const TMatrixDSym& cov, const genfit::SharedPlanePtr& plane, const AbsTrackRep* rep);
-  MeasuredStateOnPlane(const TVectorD& state, const TMatrixDSym& cov, const genfit::SharedPlanePtr& plane, const AbsTrackRep* rep, const TVectorD& auxInfo);
-  MeasuredStateOnPlane(const MeasuredStateOnPlane& o);
-  MeasuredStateOnPlane(const StateOnPlane& state, const TMatrixDSym& cov);
+    MeasuredStateOnPlane(const AbsTrackRep* rep = nullptr);
+    MeasuredStateOnPlane(const TVectorD& state, const TMatrixDSym& cov, const genfit::SharedPlanePtr& plane, const AbsTrackRep* rep);
+    MeasuredStateOnPlane(const TVectorD& state, const TMatrixDSym& cov, const genfit::SharedPlanePtr& plane, const AbsTrackRep* rep,
+                         const TVectorD& auxInfo);
+    MeasuredStateOnPlane(const MeasuredStateOnPlane& o);
+    MeasuredStateOnPlane(const StateOnPlane& state, const TMatrixDSym& cov);
 
-  MeasuredStateOnPlane& operator=(MeasuredStateOnPlane other);
-  void swap(MeasuredStateOnPlane& other); // nothrow
+    MeasuredStateOnPlane& operator=(MeasuredStateOnPlane other);
+    void swap(MeasuredStateOnPlane& other); // nothrow
 
-  virtual ~MeasuredStateOnPlane() {}
-  virtual MeasuredStateOnPlane* clone() const override {return new MeasuredStateOnPlane(*this);}
-
-
-  const TMatrixDSym& getCov() const {return cov_;}
-  TMatrixDSym& getCov() {return cov_;}
-
-  //! Blow up covariance matrix with blowUpFac. Per default, off diagonals are reset to 0 and the maximum values are limited to maxVal.
-  void blowUpCov(double blowUpFac, bool resetOffDiagonals = true, double maxVal = -1.);
-
-  void setStateCov(const TVectorD& state, const TMatrixDSym& cov) {setState(state); setCov(cov);}
-  void setStateCovPlane(const TVectorD& state, const TMatrixDSym& cov, const SharedPlanePtr& plane) {setStatePlane(state, plane); setCov(cov);}
-  void setCov(const TMatrixDSym& cov) {if(cov_.GetNrows() == 0) cov_.ResizeTo(cov); cov_ = cov;}
-
-  // Shortcuts to TrackRep functions
-  TMatrixDSym get6DCov() const {return getRep()->get6DCov(*this);};
-  void getPosMomCov(TVector3& pos, TVector3& mom, TMatrixDSym& cov) const {getRep()->getPosMomCov(*this, pos, mom, cov);}
-  void get6DStateCov(TVectorD& stateVec, TMatrixDSym& cov) const {getRep()->get6DStateCov(*this, stateVec, cov);}
-  double getMomVar() const {return getRep()->getMomVar(*this);}
-
-  void setPosMomErr(const TVector3& pos, const TVector3& mom, const TVector3& posErr, const TVector3& momErr) {getRep()->setPosMomErr(*this, pos, mom, posErr, momErr);}
-  void setPosMomCov(const TVector3& pos, const TVector3& mom, const TMatrixDSym& cov6x6) {getRep()->setPosMomCov(*this, pos, mom, cov6x6);}
-  void setPosMomCov(const TVectorD& state6, const TMatrixDSym& cov6x6) {getRep()->setPosMomCov(*this, state6, cov6x6);}
+    virtual ~MeasuredStateOnPlane() {}
+    virtual MeasuredStateOnPlane* clone() const override {return new MeasuredStateOnPlane(*this);}
 
 
-  virtual void Print(Option_t* option = "") const override;
+    const TMatrixDSym& getCov() const {return cov_;}
+    TMatrixDSym& getCov() {return cov_;}
 
- protected:
+    //! Blow up covariance matrix with blowUpFac. Per default, off diagonals are reset to 0 and the maximum values are limited to maxVal.
+    void blowUpCov(double blowUpFac, bool resetOffDiagonals = true, double maxVal = -1.);
 
-  TMatrixDSym cov_;
+    void setStateCov(const TVectorD& state, const TMatrixDSym& cov) {setState(state); setCov(cov);}
+    void setStateCovPlane(const TVectorD& state, const TMatrixDSym& cov, const SharedPlanePtr& plane) {setStatePlane(state, plane); setCov(cov);}
+    void setCov(const TMatrixDSym& cov) {if (cov_.GetNrows() == 0) cov_.ResizeTo(cov); cov_ = cov;}
 
- public:
-  ClassDefOverride(MeasuredStateOnPlane,1)
+    // Shortcuts to TrackRep functions
+    TMatrixDSym get6DCov() const {return getRep()->get6DCov(*this);};
+    void getPosMomCov(TVector3& pos, TVector3& mom, TMatrixDSym& cov) const {getRep()->getPosMomCov(*this, pos, mom, cov);}
+    void get6DStateCov(TVectorD& stateVec, TMatrixDSym& cov) const {getRep()->get6DStateCov(*this, stateVec, cov);}
+    double getMomVar() const {return getRep()->getMomVar(*this);}
 
-};
+    void setPosMomErr(const TVector3& pos, const TVector3& mom, const TVector3& posErr, const TVector3& momErr) {getRep()->setPosMomErr(*this, pos, mom, posErr, momErr);}
+    void setPosMomCov(const TVector3& pos, const TVector3& mom, const TMatrixDSym& cov6x6) {getRep()->setPosMomCov(*this, pos, mom, cov6x6);}
+    void setPosMomCov(const TVectorD& state6, const TMatrixDSym& cov6x6) {getRep()->setPosMomCov(*this, state6, cov6x6);}
 
 
-/**
- * @brief Calculate weighted average between two MeasuredStateOnPlanes
- */
-MeasuredStateOnPlane calcAverageState(const MeasuredStateOnPlane& forwardState, const MeasuredStateOnPlane& backwardState);
+    virtual void Print(Option_t* option = "") const override;
+
+  protected:
+
+    TMatrixDSym cov_;
+
+  public:
+    ClassDefOverride(MeasuredStateOnPlane, 1)
+
+  };
 
 
-inline void MeasuredStateOnPlane::swap(MeasuredStateOnPlane& other) {
-  StateOnPlane::swap(other);
-  this->cov_.ResizeTo(other.cov_);
-  std::swap(this->cov_, other.cov_);
-}
+  /**
+   * @brief Calculate weighted average between two MeasuredStateOnPlanes
+   */
+  MeasuredStateOnPlane calcAverageState(const MeasuredStateOnPlane& forwardState, const MeasuredStateOnPlane& backwardState);
 
-inline MeasuredStateOnPlane::MeasuredStateOnPlane(const AbsTrackRep* rep) :
-  StateOnPlane(rep), cov_(0,0)
-{
-  if (rep != nullptr) {
-    cov_.ResizeTo(rep->getDim(), rep->getDim());
+
+  inline void MeasuredStateOnPlane::swap(MeasuredStateOnPlane& other)
+  {
+    StateOnPlane::swap(other);
+    this->cov_.ResizeTo(other.cov_);
+    std::swap(this->cov_, other.cov_);
   }
-}
 
-inline MeasuredStateOnPlane::MeasuredStateOnPlane(const TVectorD& state, const TMatrixDSym& cov, const SharedPlanePtr& plane, const AbsTrackRep* rep) :
-  StateOnPlane(state, plane, rep), cov_(cov)
-{
-  assert(rep != nullptr);
-  //assert(cov_.GetNcols() == (signed)rep->getDim());
-}
+  inline MeasuredStateOnPlane::MeasuredStateOnPlane(const AbsTrackRep* rep) :
+    StateOnPlane(rep), cov_(0, 0)
+  {
+    if (rep != nullptr) {
+      cov_.ResizeTo(rep->getDim(), rep->getDim());
+    }
+  }
 
-inline MeasuredStateOnPlane::MeasuredStateOnPlane(const TVectorD& state, const TMatrixDSym& cov, const SharedPlanePtr& plane, const AbsTrackRep* rep, const TVectorD& auxInfo) :
-  StateOnPlane(state, plane, rep, auxInfo), cov_(cov)
-{
-  assert(rep != nullptr);
-  //assert(cov_.GetNcols() == (signed)rep->getDim());
-}
+  inline MeasuredStateOnPlane::MeasuredStateOnPlane(const TVectorD& state, const TMatrixDSym& cov, const SharedPlanePtr& plane,
+                                                    const AbsTrackRep* rep) :
+    StateOnPlane(state, plane, rep), cov_(cov)
+  {
+    assert(rep != nullptr);
+    //assert(cov_.GetNcols() == (signed)rep->getDim());
+  }
 
-inline MeasuredStateOnPlane::MeasuredStateOnPlane(const MeasuredStateOnPlane& o) :
-  StateOnPlane(o), cov_(o.cov_)
-{
-}
+  inline MeasuredStateOnPlane::MeasuredStateOnPlane(const TVectorD& state, const TMatrixDSym& cov, const SharedPlanePtr& plane,
+                                                    const AbsTrackRep* rep, const TVectorD& auxInfo) :
+    StateOnPlane(state, plane, rep, auxInfo), cov_(cov)
+  {
+    assert(rep != nullptr);
+    //assert(cov_.GetNcols() == (signed)rep->getDim());
+  }
 
-inline MeasuredStateOnPlane::MeasuredStateOnPlane(const StateOnPlane& state, const TMatrixDSym& cov) :
-  StateOnPlane(state), cov_(cov)
-{
-  //assert(cov_.GetNcols() == (signed)getRep()->getDim());
-}
+  inline MeasuredStateOnPlane::MeasuredStateOnPlane(const MeasuredStateOnPlane& o) :
+    StateOnPlane(o), cov_(o.cov_)
+  {
+  }
 
-inline MeasuredStateOnPlane& MeasuredStateOnPlane::operator=(MeasuredStateOnPlane other) {
-  swap(other);
-  return *this;
-}
+  inline MeasuredStateOnPlane::MeasuredStateOnPlane(const StateOnPlane& state, const TMatrixDSym& cov) :
+    StateOnPlane(state), cov_(cov)
+  {
+    //assert(cov_.GetNcols() == (signed)getRep()->getDim());
+  }
+
+  inline MeasuredStateOnPlane& MeasuredStateOnPlane::operator=(MeasuredStateOnPlane other)
+  {
+    swap(other);
+    return *this;
+  }
 
 
 } /* End of namespace genfit */

--- a/core/include/MeasurementFactory.h
+++ b/core/include/MeasurementFactory.h
@@ -34,118 +34,122 @@
 
 namespace genfit {
 
-class AbsMeasurement;
+  class AbsMeasurement;
 
-/** @brief Factory object to create AbsMeasurement objects from digitized and clustered data
- *
- * The MeasurementFactory is used to automatically fill Track objects
- * with hit data. For each detector type used an
- * AbsMeasurementProducer has to be registered in the factory. The
- * factory can then use the index information from a TrackCand object
- * to load the indexed hits into the Track.
- *
- * @sa AbsMeasurementProducer
- * @sa TrackCand
- */
-template <class measurement_T>
-class MeasurementFactory {
- private:
-  std::map<int, AbsMeasurementProducer<measurement_T>*> hitProdMap_;
-
-
- public:
-  MeasurementFactory() {};
-  virtual ~MeasurementFactory() { clear(); }
-
-  /** @brief Register a producer module to the factory
+  /** @brief Factory object to create AbsMeasurement objects from digitized and clustered data
    *
-   * For each type of hit a separate producer is needed. The type of hit
-   * is identified by the detector ID (detID). This index corresponds to the
-   * detector ID that is stored in the TrackCand.
-   */
-  void addProducer(int detID, AbsMeasurementProducer<measurement_T>* hitProd);
-
-  /** @brief Clear all hit producers
-   */
-  void clear();
-
-  /** @brief Create a Measurement
+   * The MeasurementFactory is used to automatically fill Track objects
+   * with hit data. For each detector type used an
+   * AbsMeasurementProducer has to be registered in the factory. The
+   * factory can then use the index information from a TrackCand object
+   * to load the indexed hits into the Track.
    *
-   * Measurements have to implement a Constructor which takes the cluster object
-   * from which the Measurement is built as the only parameter.
    * @sa AbsMeasurementProducer
+   * @sa TrackCand
    */
-  measurement_T* createOne (int detID, int index, const TrackCandHit* hit) const;
-
-  /** @brief Create a collection of Measurements
-   *
-   * This is the standard way to prepare the hit collection for a Track. The
-   * resulting collection can contain hits from several detectors. The order
-   * of the hits is the same as in the TrackCand. It is assumed that this order
-   * is already along the Track.
-   *
-   * Measurements have to implement a constructor which takes the cluster object
-   * from which the Measurement is built as the only parameter.
-   * @sa AbsMeasurementProducer
-   */
-  std::vector<measurement_T*> createMany(const TrackCand& cand) const;
-
-};
+  template <class measurement_T>
+  class MeasurementFactory {
+  private:
+    std::map<int, AbsMeasurementProducer<measurement_T>*> hitProdMap_;
 
 
-template <class measurement_T>
-void MeasurementFactory<measurement_T>::addProducer(int detID, AbsMeasurementProducer<measurement_T>* hitProd) {
-  typename std::map<int, AbsMeasurementProducer<measurement_T>*>::iterator it = hitProdMap_.find(detID);
-  if(it == hitProdMap_.end()) {
-    hitProdMap_[detID] = hitProd;
-  } else {
-    Exception exc("MeasurementFactory: detID already in use",__LINE__,__FILE__);
-    exc.setFatal();
-    std::vector<double> numbers;
-    numbers.push_back(detID);
-    exc.setNumbers("detID",numbers);
-    throw exc;
+  public:
+    MeasurementFactory() {};
+    virtual ~MeasurementFactory() { clear(); }
+
+    /** @brief Register a producer module to the factory
+     *
+     * For each type of hit a separate producer is needed. The type of hit
+     * is identified by the detector ID (detID). This index corresponds to the
+     * detector ID that is stored in the TrackCand.
+     */
+    void addProducer(int detID, AbsMeasurementProducer<measurement_T>* hitProd);
+
+    /** @brief Clear all hit producers
+     */
+    void clear();
+
+    /** @brief Create a Measurement
+     *
+     * Measurements have to implement a Constructor which takes the cluster object
+     * from which the Measurement is built as the only parameter.
+     * @sa AbsMeasurementProducer
+     */
+    measurement_T* createOne(int detID, int index, const TrackCandHit* hit) const;
+
+    /** @brief Create a collection of Measurements
+     *
+     * This is the standard way to prepare the hit collection for a Track. The
+     * resulting collection can contain hits from several detectors. The order
+     * of the hits is the same as in the TrackCand. It is assumed that this order
+     * is already along the Track.
+     *
+     * Measurements have to implement a constructor which takes the cluster object
+     * from which the Measurement is built as the only parameter.
+     * @sa AbsMeasurementProducer
+     */
+    std::vector<measurement_T*> createMany(const TrackCand& cand) const;
+
+  };
+
+
+  template <class measurement_T>
+  void MeasurementFactory<measurement_T>::addProducer(int detID, AbsMeasurementProducer<measurement_T>* hitProd)
+  {
+    typename std::map<int, AbsMeasurementProducer<measurement_T>*>::iterator it = hitProdMap_.find(detID);
+    if (it == hitProdMap_.end()) {
+      hitProdMap_[detID] = hitProd;
+    } else {
+      Exception exc("MeasurementFactory: detID already in use", __LINE__, __FILE__);
+      exc.setFatal();
+      std::vector<double> numbers;
+      numbers.push_back(detID);
+      exc.setNumbers("detID", numbers);
+      throw exc;
+    }
   }
-}
 
-template <class measurement_T>
-void MeasurementFactory<measurement_T>::clear(){
-  typename std::map<int, AbsMeasurementProducer<measurement_T>*>::iterator it=hitProdMap_.begin();
-  while(it!=hitProdMap_.end()){
-    delete it->second;
-    ++it;
+  template <class measurement_T>
+  void MeasurementFactory<measurement_T>::clear()
+  {
+    typename std::map<int, AbsMeasurementProducer<measurement_T>*>::iterator it = hitProdMap_.begin();
+    while (it != hitProdMap_.end()) {
+      delete it->second;
+      ++it;
+    }
+    hitProdMap_.clear();
   }
-  hitProdMap_.clear();
-}
 
-template <class measurement_T>
-measurement_T* MeasurementFactory<measurement_T>::createOne(int detID, int index, const TrackCandHit* hit) const {
-  typename std::map<int, AbsMeasurementProducer<measurement_T>*>::const_iterator it = hitProdMap_.find(detID);
+  template <class measurement_T>
+  measurement_T* MeasurementFactory<measurement_T>::createOne(int detID, int index, const TrackCandHit* hit) const
+  {
+    typename std::map<int, AbsMeasurementProducer<measurement_T>*>::const_iterator it = hitProdMap_.find(detID);
 
-  if(it != hitProdMap_.end()) {
-    return it->second->produce(index, hit);
-  } else {
-    Exception exc("MeasurementFactory: no hitProducer for this detID available",__LINE__,__FILE__);
-    exc.setFatal();
-    std::vector<double> numbers;
-    numbers.push_back(detID);
-    exc.setNumbers("detID", numbers);
-    throw exc;
+    if (it != hitProdMap_.end()) {
+      return it->second->produce(index, hit);
+    } else {
+      Exception exc("MeasurementFactory: no hitProducer for this detID available", __LINE__, __FILE__);
+      exc.setFatal();
+      std::vector<double> numbers;
+      numbers.push_back(detID);
+      exc.setNumbers("detID", numbers);
+      throw exc;
+    }
   }
-}
 
-template <class measurement_T>
-typename std::vector<measurement_T*> MeasurementFactory<measurement_T>::createMany(const TrackCand& cand) const {
-  typename std::vector<measurement_T*> hitVec;
-  unsigned int nHits=cand.getNHits();
-  for(unsigned int i=0;i<nHits;i++) {
-    int detID, index;
-    const TrackCandHit* hit = cand.getHit(i);
-    cand.getHit(i, detID, index);
-    hitVec.push_back( MeasurementFactory<measurement_T>::createOne(hit->getDetId(), hit->getHitId(), hit) );
+  template <class measurement_T>
+  typename std::vector<measurement_T*> MeasurementFactory<measurement_T>::createMany(const TrackCand& cand) const
+  {
+    typename std::vector<measurement_T*> hitVec;
+    unsigned int nHits = cand.getNHits();
+    for (unsigned int i = 0; i < nHits; i++) {
+      int detID, index;
+      const TrackCandHit* hit = cand.getHit(i);
+      cand.getHit(i, detID, index);
+      hitVec.push_back(MeasurementFactory<measurement_T>::createOne(hit->getDetId(), hit->getHitId(), hit));
+    }
+    return hitVec;
   }
-  return hitVec;
-}
 
 
 } /* End of namespace genfit */

--- a/core/include/MeasurementOnPlane.h
+++ b/core/include/MeasurementOnPlane.h
@@ -35,71 +35,72 @@
 
 namespace genfit {
 
-/**
- * @brief Measured coordinates on a plane.
- *
- * The dimensionality will usually be 1 or 2.
- * The HMatrix corresponds to a projection matrix, which is used to
- * project the track parameters with the original dimensionality down
- * to the measured dimensionality.
- */
-class MeasurementOnPlane : public MeasuredStateOnPlane {
+  /**
+   * @brief Measured coordinates on a plane.
+   *
+   * The dimensionality will usually be 1 or 2.
+   * The HMatrix corresponds to a projection matrix, which is used to
+   * project the track parameters with the original dimensionality down
+   * to the measured dimensionality.
+   */
+  class MeasurementOnPlane : public MeasuredStateOnPlane {
 
- public:
+  public:
 
-  MeasurementOnPlane(const AbsTrackRep* rep = nullptr) :
-    MeasuredStateOnPlane(rep), hMatrix_(nullptr), weight_(0) {}
-  MeasurementOnPlane(const TVectorD& state, const TMatrixDSym& cov, SharedPlanePtr plane, const AbsTrackRep* rep, const AbsHMatrix* hMatrix, double weight = 1.) :
-    MeasuredStateOnPlane(state, cov, plane, rep), hMatrix_(hMatrix), weight_(weight) {}
+    MeasurementOnPlane(const AbsTrackRep* rep = nullptr) :
+      MeasuredStateOnPlane(rep), hMatrix_(nullptr), weight_(0) {}
+    MeasurementOnPlane(const TVectorD& state, const TMatrixDSym& cov, SharedPlanePtr plane, const AbsTrackRep* rep,
+                       const AbsHMatrix* hMatrix, double weight = 1.) :
+      MeasuredStateOnPlane(state, cov, plane, rep), hMatrix_(hMatrix), weight_(weight) {}
 
-  //! copy constructor
-  MeasurementOnPlane(const MeasurementOnPlane& other);
-  //! assignment operator
-  MeasurementOnPlane& operator=(MeasurementOnPlane other);
-  void swap(MeasurementOnPlane& other);
+    //! copy constructor
+    MeasurementOnPlane(const MeasurementOnPlane& other);
+    //! assignment operator
+    MeasurementOnPlane& operator=(MeasurementOnPlane other);
+    void swap(MeasurementOnPlane& other);
 
-  virtual ~MeasurementOnPlane() {}
+    virtual ~MeasurementOnPlane() {}
 
-  const AbsHMatrix* getHMatrix() const {return hMatrix_.get();}
-  double getWeight() const {return weight_;}
+    const AbsHMatrix* getHMatrix() const {return hMatrix_.get();}
+    double getWeight() const {return weight_;}
 
-  TMatrixDSym getWeightedCov() {return weight_*cov_;}
+    TMatrixDSym getWeightedCov() {return weight_ * cov_;}
 
-  void setHMatrix(const AbsHMatrix* hMatrix) {hMatrix_.reset(hMatrix);}
-  void setWeight(double weight) {weight_ = fmax(weight, 1.E-10);}
+    void setHMatrix(const AbsHMatrix* hMatrix) {hMatrix_.reset(hMatrix);}
+    void setWeight(double weight) {weight_ = fmax(weight, 1.E-10);}
 
-  void Print(Option_t* option = "") const override ;
+    void Print(Option_t* option = "") const override ;
 
- private:
-  TVector3 getPos() const;
-  TVector3 getMom() const;
-  TVector3 getDir() const;
-  void getPosMom(TVector3& pos, TVector3& mom) const;
-  void getPosDir(TVector3& pos, TVector3& dir) const;
-  TVectorD get6DState() const;
-  double getMomMag() const;
-  int getPDG() const;
-  double getCharge() const;
-  double getQop() const;
-  double getMass() const;
-  double getTime() const;
+  private:
+    TVector3 getPos() const;
+    TVector3 getMom() const;
+    TVector3 getDir() const;
+    void getPosMom(TVector3& pos, TVector3& mom) const;
+    void getPosDir(TVector3& pos, TVector3& dir) const;
+    TVectorD get6DState() const;
+    double getMomMag() const;
+    int getPDG() const;
+    double getCharge() const;
+    double getQop() const;
+    double getMass() const;
+    double getTime() const;
 
-  void setPosMom(const TVector3& pos, const TVector3& mom);
-  void setPosMom(const TVectorD& state6);
-  void setChargeSign(double charge);
-  void setQop(double qop);
-  void setTime(double time);
+    void setPosMom(const TVector3& pos, const TVector3& mom);
+    void setPosMom(const TVectorD& state6);
+    void setChargeSign(double charge);
+    void setQop(double qop);
+    void setTime(double time);
 
 
- protected:
+  protected:
 
-  std::unique_ptr<const AbsHMatrix> hMatrix_; // Ownership
-  double weight_;
+    std::unique_ptr<const AbsHMatrix> hMatrix_; // Ownership
+    double weight_;
 
- public:
-  ClassDefOverride(MeasurementOnPlane,1)
+  public:
+    ClassDefOverride(MeasurementOnPlane, 1)
 
-};
+  };
 
 } /* End of namespace   */
 /** @} */

--- a/core/include/MeasurementProducer.h
+++ b/core/include/MeasurementProducer.h
@@ -33,85 +33,88 @@
 
 namespace genfit {
 
-class AbsMeasurement;
+  class AbsMeasurement;
 
-/** @brief Abstract interface class for MeasurementProducer
- *
- * Defines the very basic interface of a producer.
- */
-template <class measurement_T>
-class AbsMeasurementProducer {
-public:
-  /** @brief Virtual abstract method to produce a Measurement.
-   * Implemented in MeasurementProducer
+  /** @brief Abstract interface class for MeasurementProducer
+   *
+   * Defines the very basic interface of a producer.
    */
-  virtual measurement_T* produce(int index, const TrackCandHit* hit) = 0;
-  virtual ~AbsMeasurementProducer() {};
-};
+  template <class measurement_T>
+  class AbsMeasurementProducer {
+  public:
+    /** @brief Virtual abstract method to produce a Measurement.
+     * Implemented in MeasurementProducer
+     */
+    virtual measurement_T* produce(int index, const TrackCandHit* hit) = 0;
+    virtual ~AbsMeasurementProducer() {};
+  };
 
 
-/** @brief Template class for a measurement producer module
- *
- * A MeasurementProducer module is used by MeasurementFactory to create Measurements for
- * one specific detector type.
- *
- * It is assumed that each detector has as output of its digitization /
- * clustering some sort of hit or cluster class which stores all information that
- * corresponds to a measured hit in that detector. The MeasurementProducer
- * converts this information into a class that can be handled by genfit.
- * This class is realized as a Measurement (a class inheriting from AbsMeasurement).
- *
- * In order to use the MeasurementProducer facility, a
- * Measurement has to implement a constructor which takes as an argument
- * a pointer to the cluster class and a TrackCandHit. This constructor serves as the initializing
- * constructor for the Measurement.
- *
- * The MeasurementProducer will fetch the cluster objects from a TClonesArray and
- * use the initializing constructor to build the corresponding Measurement.
- *
- * @param hit_t template parameter specifying hit/cluster class
- * @param measurement_T template parameter specifying Measurement
- */
-template <class hit_T, class measurement_T>
-class MeasurementProducer : public AbsMeasurementProducer<genfit::AbsMeasurement> {
- private:
-  /** @brief pointer to array with cluster data */
-  TClonesArray* hitArrayTClones_;
-
- public:
-  /** @brief Constructor takes pointer to the hit array */
-  explicit MeasurementProducer(TClonesArray*);
-  virtual ~MeasurementProducer();
-
-  /** @brief Create a Measurement from the cluster at position index
-   * in TClonesArray
+  /** @brief Template class for a measurement producer module
+   *
+   * A MeasurementProducer module is used by MeasurementFactory to create Measurements for
+   * one specific detector type.
+   *
+   * It is assumed that each detector has as output of its digitization /
+   * clustering some sort of hit or cluster class which stores all information that
+   * corresponds to a measured hit in that detector. The MeasurementProducer
+   * converts this information into a class that can be handled by genfit.
+   * This class is realized as a Measurement (a class inheriting from AbsMeasurement).
+   *
+   * In order to use the MeasurementProducer facility, a
+   * Measurement has to implement a constructor which takes as an argument
+   * a pointer to the cluster class and a TrackCandHit. This constructor serves as the initializing
+   * constructor for the Measurement.
+   *
+   * The MeasurementProducer will fetch the cluster objects from a TClonesArray and
+   * use the initializing constructor to build the corresponding Measurement.
+   *
+   * @param hit_t template parameter specifying hit/cluster class
+   * @param measurement_T template parameter specifying Measurement
    */
-  virtual AbsMeasurement* produce(int index, const TrackCandHit* hit);
-};
+  template <class hit_T, class measurement_T>
+  class MeasurementProducer : public AbsMeasurementProducer<genfit::AbsMeasurement> {
+  private:
+    /** @brief pointer to array with cluster data */
+    TClonesArray* hitArrayTClones_;
+
+  public:
+    /** @brief Constructor takes pointer to the hit array */
+    explicit MeasurementProducer(TClonesArray*);
+    virtual ~MeasurementProducer();
+
+    /** @brief Create a Measurement from the cluster at position index
+     * in TClonesArray
+     */
+    virtual AbsMeasurement* produce(int index, const TrackCandHit* hit);
+  };
 
 
-template <class hit_T, class measurement_T>
-  MeasurementProducer<hit_T, measurement_T>::MeasurementProducer(TClonesArray* theArr) {
-  hitArrayTClones_ = theArr;
-  //std::cout << "hit array with " << hitArrayTClones_->GetEntries() << " entries." << std::endl;
-}
-
-template <class hit_T, class measurement_T>
-MeasurementProducer<hit_T, measurement_T>::~MeasurementProducer() {
-  // we don't assume ownership over the hit arrays
-}
-
-template <class hit_T, class measurement_T>
-AbsMeasurement* MeasurementProducer<hit_T, measurement_T>::produce(int index, const TrackCandHit* hit) {
-  assert(hitArrayTClones_ != nullptr);
-  //std::cout << "hit array with " << hitArrayTClones_->GetEntries() << " entries, looking for entry " << index << "." << std::endl;
-  if(hitArrayTClones_->At(index) == 0) {
-    Exception e("In MeasurementProducer: index for hit in TClonesArray out of bounds",__LINE__,__FILE__);
-    e.setFatal();
-    throw e;
+  template <class hit_T, class measurement_T>
+  MeasurementProducer<hit_T, measurement_T>::MeasurementProducer(TClonesArray* theArr)
+  {
+    hitArrayTClones_ = theArr;
+    //std::cout << "hit array with " << hitArrayTClones_->GetEntries() << " entries." << std::endl;
   }
-  return ( new measurement_T( (hit_T*) hitArrayTClones_->At(index), hit ) );
-}
+
+  template <class hit_T, class measurement_T>
+  MeasurementProducer<hit_T, measurement_T>::~MeasurementProducer()
+  {
+    // we don't assume ownership over the hit arrays
+  }
+
+  template <class hit_T, class measurement_T>
+  AbsMeasurement* MeasurementProducer<hit_T, measurement_T>::produce(int index, const TrackCandHit* hit)
+  {
+    assert(hitArrayTClones_ != nullptr);
+    //std::cout << "hit array with " << hitArrayTClones_->GetEntries() << " entries, looking for entry " << index << "." << std::endl;
+    if (hitArrayTClones_->At(index) == 0) {
+      Exception e("In MeasurementProducer: index for hit in TClonesArray out of bounds", __LINE__, __FILE__);
+      e.setFatal();
+      throw e;
+    }
+    return (new measurement_T((hit_T*) hitArrayTClones_->At(index), hit));
+  }
 
 
 } /* End of namespace genfit */

--- a/core/include/SharedPlanePtr.h
+++ b/core/include/SharedPlanePtr.h
@@ -31,28 +31,29 @@
 
 namespace genfit {
 
-/**
- * @brief Shared Pointer to a DetPlane.
- *
- * Ownership can be shared, e.g between multiple StateOnPlane objects.
- * The DetPlane will automatically be deleted, if no owner remains.
- */
-    typedef std::shared_ptr< genfit::DetPlane > SharedPlanePtr;
+  /**
+   * @brief Shared Pointer to a DetPlane.
+   *
+   * Ownership can be shared, e.g between multiple StateOnPlane objects.
+   * The DetPlane will automatically be deleted, if no owner remains.
+   */
+  typedef std::shared_ptr< genfit::DetPlane > SharedPlanePtr;
 
+  /**
+   * Class allowing to create a SharedPlanePtr from a DetPlane from Python.
+   */
+  class SharedPlanePtrCreator {
+  public:
     /**
-     * Class allowing to create a SharedPlanePtr from a DetPlane from Python.
+     * Function which allows to create a shared plane pointer from a DetPlane.
+     * @param plane : A DetPlane.
+     * @return SharedPlanePtr : A shared plane pointer to the provided plane.
      */
-    class SharedPlanePtrCreator {
-    public:
-      /**
-       * Function which allows to create a shared plane pointer from a DetPlane.
-       * @param plane : A DetPlane.
-       * @return SharedPlanePtr : A shared plane pointer to the provided plane.
-       */
-      static SharedPlanePtr getPlanePtr(DetPlane *plane) {
-          return SharedPlanePtr(plane);
-      }
-    };
+    static SharedPlanePtr getPlanePtr(DetPlane* plane)
+    {
+      return SharedPlanePtr(plane);
+    }
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/core/include/StateOnPlane.h
+++ b/core/include/StateOnPlane.h
@@ -35,159 +35,162 @@
 
 namespace genfit {
 
-/**
- * @brief A state with arbitrary dimension defined in a DetPlane.
- *
- * The dimension and meaning of the #state_ vector are defined by the track parameterization of the #rep_.
- * #sharedPlane_ is a shared_pointer, the ownership over that plane is shared between all StateOnPlane objects defined in that plane.
- * The definition of the state is bound to the TrackRep #rep_. Therefore, the StateOnPlane contains a pointer to a AbsTrackRep.
- * It will provide functionality to extrapolate it and translate the state it into cartesian coordinates.
- * Shortcuts to all functions of the AbsTrackRep which use this StateOnPlane are also provided here.
- */
-class StateOnPlane {
-
- public:
-
-  StateOnPlane(const genfit::StateOnPlane&) = default;
-
-  StateOnPlane(const AbsTrackRep* rep = nullptr);
-  //! state is defined by the TrackReps parameterization
-  StateOnPlane(const TVectorD& state, const SharedPlanePtr& plane, const AbsTrackRep* rep);
-  StateOnPlane(const TVectorD& state, const SharedPlanePtr& plane, const AbsTrackRep* rep, const TVectorD& auxInfo);
-
-  StateOnPlane& operator=(StateOnPlane other);
-  void swap(StateOnPlane& other); // nothrow
-
-  virtual ~StateOnPlane() {}
-  virtual StateOnPlane* clone() const {return new StateOnPlane(*this);}
-
-  const TVectorD& getState() const {return state_;}
-  TVectorD& getState() {return state_;}
-  const TVectorD& getAuxInfo() const {return auxInfo_;}
-  TVectorD& getAuxInfo() {return auxInfo_;}
-  const SharedPlanePtr& getPlane() const {return sharedPlane_;}
-  const AbsTrackRep* getRep() const {return rep_;}
-
-  void setState(const TVectorD& state) {if(state_.GetNrows() == 0) state_.ResizeTo(state); state_ = state;}
-  void setPlane(const SharedPlanePtr& plane) {sharedPlane_ = plane;}
-  void setStatePlane(const TVectorD& state, const SharedPlanePtr& plane) {state_ = state; sharedPlane_ = plane;}
-  void setAuxInfo(const TVectorD& auxInfo) {if(auxInfo_.GetNrows() == 0) auxInfo_.ResizeTo(auxInfo); auxInfo_ = auxInfo;}
-  void setRep(const AbsTrackRep* rep) {rep_ = rep;}
-
-  // Shortcuts to TrackRep functions
-  double extrapolateToPlane(const SharedPlanePtr& plane,
-        bool stopAtBoundary = false,
-        bool calcJacobianNoise = false) {return rep_->extrapolateToPlane(*this, plane, stopAtBoundary, calcJacobianNoise);}
-  double extrapolateToLine(const TVector3& linePoint,
-        const TVector3& lineDirection,
-        bool stopAtBoundary = false,
-        bool calcJacobianNoise = false) {return rep_->extrapolateToLine(*this, linePoint, lineDirection, stopAtBoundary, calcJacobianNoise);}
-  double extrapolateToPoint(const TVector3& point,
-        bool stopAtBoundary = false,
-        bool calcJacobianNoise = false) {return rep_->extrapolateToPoint(*this, point, stopAtBoundary, calcJacobianNoise);}
-  double extrapolateToPoint(const TVector3& point,
-        const TMatrixDSym& G, // weight matrix (metric)
-        bool stopAtBoundary = false,
-        bool calcJacobianNoise = false) {return rep_->extrapolateToPoint(*this, point, G, stopAtBoundary, calcJacobianNoise);}
-  double extrapolateToCylinder(double radius,
-        const TVector3& linePoint = TVector3(0.,0.,0.),
-        const TVector3& lineDirection = TVector3(0.,0.,1.),
-        bool stopAtBoundary = false,
-        bool calcJacobianNoise = false) {return rep_->extrapolateToCylinder(*this, radius, linePoint, lineDirection, stopAtBoundary, calcJacobianNoise);}
-  double extrapolateToCone(double openingAngle,
-        const TVector3& conePoint = TVector3(0.,0.,0.),
-        const TVector3& coneDirection = TVector3(0.,0.,1.),
-        bool stopAtBoundary = false,
-        bool calcJacobianNoise = false) {return rep_->extrapolateToCone(*this, openingAngle, conePoint, coneDirection, stopAtBoundary, calcJacobianNoise);}
-  double extrapolateToSphere(double radius,
-        const TVector3& point = TVector3(0.,0.,0.),
-        bool stopAtBoundary = false,
-        bool calcJacobianNoise = false) {return rep_->extrapolateToSphere(*this, radius, point, stopAtBoundary, calcJacobianNoise);}
-  double extrapolateBy(double step,
-        bool stopAtBoundary = false,
-        bool calcJacobianNoise = false) {return rep_->extrapolateBy(*this, step, stopAtBoundary, calcJacobianNoise);}
-  double extrapolateToMeasurement(const AbsMeasurement* measurement,
-        bool stopAtBoundary = false,
-        bool calcJacobianNoise = false) {return rep_->extrapolateToMeasurement(*this, measurement, stopAtBoundary, calcJacobianNoise);}
-
-
-  TVector3 getPos() const {return rep_->getPos(*this);}
-  TVector3 getMom() const {return rep_->getMom(*this);}
-  TVector3 getDir() const {return rep_->getDir(*this);}
-  void getPosMom(TVector3& pos, TVector3& mom) const {rep_->getPosMom(*this, pos, mom);}
-  void getPosDir(TVector3& pos, TVector3& dir) const {rep_->getPosDir(*this, pos, dir);}
-  TVectorD get6DState() const {return rep_->get6DState(*this);}
-  double getMomMag() const {return rep_->getMomMag(*this);}
-  int getPDG() const {return rep_->getPDG();}
-  double getCharge() const {return rep_->getCharge(*this);}
-  double getQop() const {return rep_->getQop(*this);}
-  double getMass() const {return rep_->getMass(*this);}
-  double getTime() const {return rep_->getTime(*this);}
-
-  void setPosMom(const TVector3& pos, const TVector3& mom) {rep_->setPosMom(*this, pos, mom);}
-  void setPosMom(const TVectorD& state6) {rep_->setPosMom(*this, state6);}
-  void setChargeSign(double charge) {rep_->setChargeSign(*this, charge);}
-  void setQop(double qop) {rep_->setQop(*this, qop);}
-  void setTime(double time) {rep_->setTime(*this, time);}
-
-
-  virtual void Print(Option_t* option = "") const;
-
- protected:
-
-  TVectorD state_; // state vector
-  TVectorD auxInfo_; // auxiliary information (e.g. charge, flight direction etc.)
-  SharedPlanePtr sharedPlane_; //! Shared ownership.  '!' in order to silence ROOT, custom streamer writes and reads this.
-
- private:
-
-  /** Pointer to TrackRep with respect to which StateOnPlane is defined
+  /**
+   * @brief A state with arbitrary dimension defined in a DetPlane.
+   *
+   * The dimension and meaning of the #state_ vector are defined by the track parameterization of the #rep_.
+   * #sharedPlane_ is a shared_pointer, the ownership over that plane is shared between all StateOnPlane objects defined in that plane.
+   * The definition of the state is bound to the TrackRep #rep_. Therefore, the StateOnPlane contains a pointer to a AbsTrackRep.
+   * It will provide functionality to extrapolate it and translate the state it into cartesian coordinates.
+   * Shortcuts to all functions of the AbsTrackRep which use this StateOnPlane are also provided here.
    */
-  const AbsTrackRep* rep_; //! No ownership
+  class StateOnPlane {
 
- public:
-  ClassDef(StateOnPlane,2)
-  // Version history:
-  // ver 2: no longer derives from TObject (the TObject parts were not 
-  //        streamed, so no compatibility issues arise.)
-};
+  public:
+
+    StateOnPlane(const genfit::StateOnPlane&) = default;
+
+    StateOnPlane(const AbsTrackRep* rep = nullptr);
+    //! state is defined by the TrackReps parameterization
+    StateOnPlane(const TVectorD& state, const SharedPlanePtr& plane, const AbsTrackRep* rep);
+    StateOnPlane(const TVectorD& state, const SharedPlanePtr& plane, const AbsTrackRep* rep, const TVectorD& auxInfo);
+
+    StateOnPlane& operator=(StateOnPlane other);
+    void swap(StateOnPlane& other); // nothrow
+
+    virtual ~StateOnPlane() {}
+    virtual StateOnPlane* clone() const {return new StateOnPlane(*this);}
+
+    const TVectorD& getState() const {return state_;}
+    TVectorD& getState() {return state_;}
+    const TVectorD& getAuxInfo() const {return auxInfo_;}
+    TVectorD& getAuxInfo() {return auxInfo_;}
+    const SharedPlanePtr& getPlane() const {return sharedPlane_;}
+    const AbsTrackRep* getRep() const {return rep_;}
+
+    void setState(const TVectorD& state) {if (state_.GetNrows() == 0) state_.ResizeTo(state); state_ = state;}
+    void setPlane(const SharedPlanePtr& plane) {sharedPlane_ = plane;}
+    void setStatePlane(const TVectorD& state, const SharedPlanePtr& plane) {state_ = state; sharedPlane_ = plane;}
+    void setAuxInfo(const TVectorD& auxInfo) {if (auxInfo_.GetNrows() == 0) auxInfo_.ResizeTo(auxInfo); auxInfo_ = auxInfo;}
+    void setRep(const AbsTrackRep* rep) {rep_ = rep;}
+
+    // Shortcuts to TrackRep functions
+    double extrapolateToPlane(const SharedPlanePtr& plane,
+                              bool stopAtBoundary = false,
+                              bool calcJacobianNoise = false) {return rep_->extrapolateToPlane(*this, plane, stopAtBoundary, calcJacobianNoise);}
+    double extrapolateToLine(const TVector3& linePoint,
+                             const TVector3& lineDirection,
+                             bool stopAtBoundary = false,
+                             bool calcJacobianNoise = false) {return rep_->extrapolateToLine(*this, linePoint, lineDirection, stopAtBoundary, calcJacobianNoise);}
+    double extrapolateToPoint(const TVector3& point,
+                              bool stopAtBoundary = false,
+                              bool calcJacobianNoise = false) {return rep_->extrapolateToPoint(*this, point, stopAtBoundary, calcJacobianNoise);}
+    double extrapolateToPoint(const TVector3& point,
+                              const TMatrixDSym& G, // weight matrix (metric)
+                              bool stopAtBoundary = false,
+                              bool calcJacobianNoise = false) {return rep_->extrapolateToPoint(*this, point, G, stopAtBoundary, calcJacobianNoise);}
+    double extrapolateToCylinder(double radius,
+                                 const TVector3& linePoint = TVector3(0., 0., 0.),
+                                 const TVector3& lineDirection = TVector3(0., 0., 1.),
+                                 bool stopAtBoundary = false,
+                                 bool calcJacobianNoise = false) {return rep_->extrapolateToCylinder(*this, radius, linePoint, lineDirection, stopAtBoundary, calcJacobianNoise);}
+    double extrapolateToCone(double openingAngle,
+                             const TVector3& conePoint = TVector3(0., 0., 0.),
+                             const TVector3& coneDirection = TVector3(0., 0., 1.),
+                             bool stopAtBoundary = false,
+                             bool calcJacobianNoise = false) {return rep_->extrapolateToCone(*this, openingAngle, conePoint, coneDirection, stopAtBoundary, calcJacobianNoise);}
+    double extrapolateToSphere(double radius,
+                               const TVector3& point = TVector3(0., 0., 0.),
+                               bool stopAtBoundary = false,
+                               bool calcJacobianNoise = false) {return rep_->extrapolateToSphere(*this, radius, point, stopAtBoundary, calcJacobianNoise);}
+    double extrapolateBy(double step,
+                         bool stopAtBoundary = false,
+                         bool calcJacobianNoise = false) {return rep_->extrapolateBy(*this, step, stopAtBoundary, calcJacobianNoise);}
+    double extrapolateToMeasurement(const AbsMeasurement* measurement,
+                                    bool stopAtBoundary = false,
+                                    bool calcJacobianNoise = false) {return rep_->extrapolateToMeasurement(*this, measurement, stopAtBoundary, calcJacobianNoise);}
 
 
-inline StateOnPlane::StateOnPlane(const AbsTrackRep* rep) :
-  state_(0), auxInfo_(0), sharedPlane_(), rep_(rep)
-{
-  if (rep != nullptr) {
-    state_.ResizeTo(rep->getDim());
+    TVector3 getPos() const {return rep_->getPos(*this);}
+    TVector3 getMom() const {return rep_->getMom(*this);}
+    TVector3 getDir() const {return rep_->getDir(*this);}
+    void getPosMom(TVector3& pos, TVector3& mom) const {rep_->getPosMom(*this, pos, mom);}
+    void getPosDir(TVector3& pos, TVector3& dir) const {rep_->getPosDir(*this, pos, dir);}
+    TVectorD get6DState() const {return rep_->get6DState(*this);}
+    double getMomMag() const {return rep_->getMomMag(*this);}
+    int getPDG() const {return rep_->getPDG();}
+    double getCharge() const {return rep_->getCharge(*this);}
+    double getQop() const {return rep_->getQop(*this);}
+    double getMass() const {return rep_->getMass(*this);}
+    double getTime() const {return rep_->getTime(*this);}
+
+    void setPosMom(const TVector3& pos, const TVector3& mom) {rep_->setPosMom(*this, pos, mom);}
+    void setPosMom(const TVectorD& state6) {rep_->setPosMom(*this, state6);}
+    void setChargeSign(double charge) {rep_->setChargeSign(*this, charge);}
+    void setQop(double qop) {rep_->setQop(*this, qop);}
+    void setTime(double time) {rep_->setTime(*this, time);}
+
+
+    virtual void Print(Option_t* option = "") const;
+
+  protected:
+
+    TVectorD state_; // state vector
+    TVectorD auxInfo_; // auxiliary information (e.g. charge, flight direction etc.)
+    SharedPlanePtr sharedPlane_; //! Shared ownership.  '!' in order to silence ROOT, custom streamer writes and reads this.
+
+  private:
+
+    /** Pointer to TrackRep with respect to which StateOnPlane is defined
+     */
+    const AbsTrackRep* rep_; //! No ownership
+
+  public:
+    ClassDef(StateOnPlane, 2)
+    // Version history:
+    // ver 2: no longer derives from TObject (the TObject parts were not
+    //        streamed, so no compatibility issues arise.)
+  };
+
+
+  inline StateOnPlane::StateOnPlane(const AbsTrackRep* rep) :
+    state_(0), auxInfo_(0), sharedPlane_(), rep_(rep)
+  {
+    if (rep != nullptr) {
+      state_.ResizeTo(rep->getDim());
+    }
   }
-}
 
-inline StateOnPlane::StateOnPlane(const TVectorD& state, const SharedPlanePtr& plane, const AbsTrackRep* rep) :
-  state_(state), auxInfo_(0), sharedPlane_(plane), rep_(rep)
-{
-  assert(rep != nullptr);
-  assert(sharedPlane_.get() != nullptr);
-}
+  inline StateOnPlane::StateOnPlane(const TVectorD& state, const SharedPlanePtr& plane, const AbsTrackRep* rep) :
+    state_(state), auxInfo_(0), sharedPlane_(plane), rep_(rep)
+  {
+    assert(rep != nullptr);
+    assert(sharedPlane_.get() != nullptr);
+  }
 
-inline StateOnPlane::StateOnPlane(const TVectorD& state, const SharedPlanePtr& plane, const AbsTrackRep* rep, const TVectorD& auxInfo) :
-  state_(state), auxInfo_(auxInfo), sharedPlane_(plane), rep_(rep)
-{
-  assert(rep != nullptr);
-  assert(sharedPlane_.get() != nullptr);
-}
+  inline StateOnPlane::StateOnPlane(const TVectorD& state, const SharedPlanePtr& plane, const AbsTrackRep* rep,
+                                    const TVectorD& auxInfo) :
+    state_(state), auxInfo_(auxInfo), sharedPlane_(plane), rep_(rep)
+  {
+    assert(rep != nullptr);
+    assert(sharedPlane_.get() != nullptr);
+  }
 
-inline StateOnPlane& StateOnPlane::operator=(StateOnPlane other) {
-  swap(other);
-  return *this;
-}
+  inline StateOnPlane& StateOnPlane::operator=(StateOnPlane other)
+  {
+    swap(other);
+    return *this;
+  }
 
-inline void StateOnPlane::swap(StateOnPlane& other) {
-  this->state_.ResizeTo(other.state_);
-  std::swap(this->state_, other.state_);
-  this->auxInfo_.ResizeTo(other.auxInfo_);
-  std::swap(this->auxInfo_, other.auxInfo_);
-  this->sharedPlane_.swap(other.sharedPlane_);
-  std::swap(this->rep_, other.rep_);
-}
+  inline void StateOnPlane::swap(StateOnPlane& other)
+  {
+    this->state_.ResizeTo(other.state_);
+    std::swap(this->state_, other.state_);
+    this->auxInfo_.ResizeTo(other.auxInfo_);
+    std::swap(this->auxInfo_, other.auxInfo_);
+    this->sharedPlane_.swap(other.sharedPlane_);
+    std::swap(this->rep_, other.rep_);
+  }
 
 } /* End of namespace genfit */
 /** @} */

--- a/core/include/ThinScatterer.h
+++ b/core/include/ThinScatterer.h
@@ -32,33 +32,33 @@
 
 namespace genfit {
 
-/**
- * @brief Thin or thick scatterer
- */
-class ThinScatterer : public TObject {
+  /**
+   * @brief Thin or thick scatterer
+   */
+  class ThinScatterer : public TObject {
 
- public:
+  public:
 
-  ThinScatterer() :
-    TObject(), sharedPlane_(), material_() {;}
-  ThinScatterer(const SharedPlanePtr& sharedPlane, const Material& material) :
-    TObject(), sharedPlane_(sharedPlane), material_(material) {;}
+    ThinScatterer() :
+      TObject(), sharedPlane_(), material_() {;}
+    ThinScatterer(const SharedPlanePtr& sharedPlane, const Material& material) :
+      TObject(), sharedPlane_(sharedPlane), material_(material) {;}
 
-  SharedPlanePtr getPlane() const {return sharedPlane_;}
-  const Material& getMaterial() const {return material_;}
+    SharedPlanePtr getPlane() const {return sharedPlane_;}
+    const Material& getMaterial() const {return material_;}
 
-  void Print(const Option_t* = "") const;
+    void Print(const Option_t* = "") const;
 
- private:
+  private:
 
-  SharedPlanePtr sharedPlane_; //! Material boundary.  '!' shuts up ROOT.
-  Material material_; // Material properties
+    SharedPlanePtr sharedPlane_; //! Material boundary.  '!' shuts up ROOT.
+    Material material_; // Material properties
 
 
- public:
-  ClassDef(ThinScatterer, 2)
+  public:
+    ClassDef(ThinScatterer, 2)
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/core/include/Tools.h
+++ b/core/include/Tools.h
@@ -33,68 +33,68 @@
  */
 namespace genfit {
 
-class AbsHMatrix;
+  class AbsHMatrix;
 
-namespace tools {
+  namespace tools {
 
-/** @brief Invert a matrix, throwing an Exception when inversion fails.
- * Optional calculation of determinant.
- */
-void invertMatrix(const TMatrixDSym& mat, TMatrixDSym& inv, double* determinant = nullptr);
-/** @brief Same, replacing its argument.
- */
-void invertMatrix(TMatrixDSym& mat, double* determinant = nullptr);
+    /** @brief Invert a matrix, throwing an Exception when inversion fails.
+     * Optional calculation of determinant.
+     */
+    void invertMatrix(const TMatrixDSym& mat, TMatrixDSym& inv, double* determinant = nullptr);
+    /** @brief Same, replacing its argument.
+     */
+    void invertMatrix(TMatrixDSym& mat, double* determinant = nullptr);
 
-/** @brief Solves R^t x = b, replacing b with the solution for x.  R is
- *  assumed to be upper diagonal.
- */
-bool transposedForwardSubstitution(const TMatrixD& R, TVectorD& b);
-/** @brief Same, for a column of the matrix b.  */
-bool transposedForwardSubstitution(const TMatrixD& R, TMatrixD& b, int nCol);
-/** @brief Inverts the transpose of the upper right matrix R into inv.  */
-bool transposedInvert(const TMatrixD& R, TMatrixD& inv);
+    /** @brief Solves R^t x = b, replacing b with the solution for x.  R is
+     *  assumed to be upper diagonal.
+     */
+    bool transposedForwardSubstitution(const TMatrixD& R, TVectorD& b);
+    /** @brief Same, for a column of the matrix b.  */
+    bool transposedForwardSubstitution(const TMatrixD& R, TMatrixD& b, int nCol);
+    /** @brief Inverts the transpose of the upper right matrix R into inv.  */
+    bool transposedInvert(const TMatrixD& R, TMatrixD& inv);
 
-/** @brief Replaces A with an upper right matrix connected to A by
- *  an orthongonal transformation.  I.e., it computes R from a QR
- *  decomposition of A = QR, replacing A.
- */
-void QR(TMatrixD& A);
+    /** @brief Replaces A with an upper right matrix connected to A by
+     *  an orthongonal transformation.  I.e., it computes R from a QR
+     *  decomposition of A = QR, replacing A.
+     */
+    void QR(TMatrixD& A);
 
-/** @brief Replaces A with an upper right matrix connected to A by
- *  an orthongonal transformation.  I.e., it computes R from a QR
- *  decomposition of A = QR, replacing A.  Also replaces b by Q'b
- *  where Q' is the transposed of Q.
- */
-void QR(TMatrixD& A, TVectorD& b);
+    /** @brief Replaces A with an upper right matrix connected to A by
+     *  an orthongonal transformation.  I.e., it computes R from a QR
+     *  decomposition of A = QR, replacing A.  Also replaces b by Q'b
+     *  where Q' is the transposed of Q.
+     */
+    void QR(TMatrixD& A, TVectorD& b);
 
-/** @brief Calculate a sqrt for the positive semidefinite noise
- *  matrix.  Rows corresponding to zero eigenvalues are omitted.
- *  This gives the transposed of the square root, i.e.
- *    noise = noiseSqrt * noiseSqrt'
- */    
-void
-noiseMatrixSqrt(const TMatrixDSym& noise,
-		TMatrixD& noiseSqrt);
+    /** @brief Calculate a sqrt for the positive semidefinite noise
+     *  matrix.  Rows corresponding to zero eigenvalues are omitted.
+     *  This gives the transposed of the square root, i.e.
+     *    noise = noiseSqrt * noiseSqrt'
+     */
+    void
+    noiseMatrixSqrt(const TMatrixDSym& noise,
+                    TMatrixD& noiseSqrt);
 
-/** @brief Calculates the square root of the covariance matrix after
- *  the Kalman prediction (i.e. extrapolation) with transport matrix F
- *  and the noise square root Q.  Gives the new covariance square
- *  root.  */
-void
-kalmanPredictionCovSqrt(const TMatrixD& S,
-			const TMatrixD& F, const TMatrixD& Q,
-			TMatrixD& Snew);
+    /** @brief Calculates the square root of the covariance matrix after
+     *  the Kalman prediction (i.e. extrapolation) with transport matrix F
+     *  and the noise square root Q.  Gives the new covariance square
+     *  root.  */
+    void
+    kalmanPredictionCovSqrt(const TMatrixD& S,
+                            const TMatrixD& F, const TMatrixD& Q,
+                            TMatrixD& Snew);
 
-/** @brief Calculate the Kalman measurement update with no transport.
- *  x, S : state prediction, covariance square root
- *  res, R, H : residual, measurement covariance square root, H matrix of the measurement
- */
-void
-kalmanUpdateSqrt(const TMatrixD& S,
-		 const TVectorD& res, const TMatrixD& R, const AbsHMatrix* H,
-		 TVectorD& update, TMatrixD& SNew);
+    /** @brief Calculate the Kalman measurement update with no transport.
+     *  x, S : state prediction, covariance square root
+     *  res, R, H : residual, measurement covariance square root, H matrix of the measurement
+     */
+    void
+    kalmanUpdateSqrt(const TMatrixD& S,
+                     const TVectorD& res, const TMatrixD& R, const AbsHMatrix* H,
+                     TVectorD& update, TMatrixD& SNew);
 
-} /* End of namespace tools */
+  } /* End of namespace tools */
 } /* End of namespace genfit */
 /** @} */
 

--- a/core/include/Track.h
+++ b/core/include/Track.h
@@ -37,295 +37,302 @@
 
 namespace genfit {
 
-class KalmanFitStatus;
+  class KalmanFitStatus;
 
-/**
- * @brief Helper class for TrackPoint sorting, used in Track::sort().
- */
-class TrackPointComparator {
- public:
   /**
-   * Comparison operator used in Track::sort(). Compares sorting parameter.
+   * @brief Helper class for TrackPoint sorting, used in Track::sort().
    */
-  bool operator() (const TrackPoint* lhs, const TrackPoint* rhs) const {
-    return lhs->getSortingParameter() < rhs->getSortingParameter();
-  }
-};
+  class TrackPointComparator {
+  public:
+    /**
+     * Comparison operator used in Track::sort(). Compares sorting parameter.
+     */
+    bool operator()(const TrackPoint* lhs, const TrackPoint* rhs) const
+    {
+      return lhs->getSortingParameter() < rhs->getSortingParameter();
+    }
+  };
 
-
-/**
- * @brief Collection of TrackPoint objects, AbsTrackRep objects and FitStatus objects
- *
- *  Holds a number of AbsTrackRep objects, which correspond to the
- *  different particle hypotheses or track models which should be fitted.
- *  A 6D seed #stateSeed_ (x,y,z,p_x,p_y,p_z) and 6x6 #covSeed_ should be provided as start values for fitting.
- *  When fitting the Track with a AbsFitter,
- *  a FitStatus object will be created, containing information about the fit.
- *  The fitted states will be stored in AbsFitterInfo objects in every TrackPoints.
- *
- *  The fit will be performed for every AbsTrackRep,
- *  so after the fit there will be one AbsFitterInfo for each AbsTrackRep
- *  in every TrackPoint, as well as one FitStatus for every AbsTrackRep.
- *
- */
-class Track : public TObject {
-
- public:
-
-  Track();
 
   /**
-   * @ brief Construct Track from TrackCand, using a MeasurementFactory
+   * @brief Collection of TrackPoint objects, AbsTrackRep objects and FitStatus objects
    *
-   * The MeasurementFactory will be used to create AbsMeasuremen objects.
-   * TrackPoints will be created.
-   * If two or more consecutive PlanarMeasurement objects with the same detector- and planeId
-   * are created by the factory, they will be put into the same TrackPoint.
+   *  Holds a number of AbsTrackRep objects, which correspond to the
+   *  different particle hypotheses or track models which should be fitted.
+   *  A 6D seed #stateSeed_ (x,y,z,p_x,p_y,p_z) and 6x6 #covSeed_ should be provided as start values for fitting.
+   *  When fitting the Track with a AbsFitter,
+   *  a FitStatus object will be created, containing information about the fit.
+   *  The fitted states will be stored in AbsFitterInfo objects in every TrackPoints.
    *
-   * Optionally, a AbsTrackRep can be provided.
+   *  The fit will be performed for every AbsTrackRep,
+   *  so after the fit there will be one AbsFitterInfo for each AbsTrackRep
+   *  in every TrackPoint, as well as one FitStatus for every AbsTrackRep.
    *
-   * The stateSeed_ of the Track will be filled with the seed of the TrackCand.
-   * A guess for covSeed_ will be made using the largest entry of the cov of the first measurement
-   * and the number of measurements (For the covSeed_, it is just important that it will be
-   * big enough not to bias the fit too much, but not too big in order to avoid
-   * numerical problems).
    */
-  Track(const TrackCand& trackCand, const MeasurementFactory<genfit::AbsMeasurement>& factory, AbsTrackRep* rep = nullptr);
+  class Track : public TObject {
 
-  Track(AbsTrackRep* trackRep, const TVectorD& stateSeed);
-  Track(AbsTrackRep* trackRep, const TVector3& posSeed, const TVector3& momSeed);
-  Track(AbsTrackRep* trackRep, const TVectorD& stateSeed, const TMatrixDSym& covSeed);
+  public:
 
-  Track(const Track&); // copy constructor
-  Track& operator=(Track); // assignment operator
-  void swap(Track& other); // nothrow
+    Track();
 
-  virtual ~Track();
-  virtual void Clear(Option_t* = "");
+    /**
+     * @ brief Construct Track from TrackCand, using a MeasurementFactory
+     *
+     * The MeasurementFactory will be used to create AbsMeasuremen objects.
+     * TrackPoints will be created.
+     * If two or more consecutive PlanarMeasurement objects with the same detector- and planeId
+     * are created by the factory, they will be put into the same TrackPoint.
+     *
+     * Optionally, a AbsTrackRep can be provided.
+     *
+     * The stateSeed_ of the Track will be filled with the seed of the TrackCand.
+     * A guess for covSeed_ will be made using the largest entry of the cov of the first measurement
+     * and the number of measurements (For the covSeed_, it is just important that it will be
+     * big enough not to bias the fit too much, but not too big in order to avoid
+     * numerical problems).
+     */
+    Track(const TrackCand& trackCand, const MeasurementFactory<genfit::AbsMeasurement>& factory, AbsTrackRep* rep = nullptr);
 
-  void createMeasurements(const TrackCand& trackCand, const MeasurementFactory<genfit::AbsMeasurement>& factory);
+    Track(AbsTrackRep* trackRep, const TVectorD& stateSeed);
+    Track(AbsTrackRep* trackRep, const TVector3& posSeed, const TVector3& momSeed);
+    Track(AbsTrackRep* trackRep, const TVectorD& stateSeed, const TMatrixDSym& covSeed);
 
-  TrackPoint* getPoint(int id) const;
-  const std::vector< genfit::TrackPoint* > & getPoints() const {return trackPoints_;}
-  unsigned int getNumPoints() const {return trackPoints_.size();}
+    Track(const Track&); // copy constructor
+    Track& operator=(Track); // assignment operator
+    void swap(Track& other); // nothrow
 
-  TrackPoint* getPointWithMeasurement(int id) const;
-  const std::vector< genfit::TrackPoint* > & getPointsWithMeasurement() const  {return trackPointsWithMeasurement_;}
-  unsigned int getNumPointsWithMeasurement() const {return trackPointsWithMeasurement_.size();}
+    virtual ~Track();
+    virtual void Clear(Option_t* = "");
 
-  TrackPoint* getPointWithMeasurementAndFitterInfo(int id, const AbsTrackRep* rep = nullptr) const;
-  TrackPoint* getPointWithFitterInfo(int id, const AbsTrackRep* rep = nullptr) const;
+    void createMeasurements(const TrackCand& trackCand, const MeasurementFactory<genfit::AbsMeasurement>& factory);
 
-  /**
-   * @brief Shortcut to get FittedStates.
-   *
-   * Uses getPointWithFitterInfo(id, rep).
-   * Gets the fitted state at trackpoint id for the track representation rep.
-   * Per default, the fitted state of the fitterInfo of the first TrackPoint
-   * with one or more AbsFitterInfo objects
-   * is returned. If no AbsTrackRep is specified, the AbsFitterInfo of the cardinal rep will be used.
-   */
-  const MeasuredStateOnPlane& getFittedState(int id = 0, const AbsTrackRep* rep = nullptr, bool biased = true) const;
+    TrackPoint* getPoint(int id) const;
+    const std::vector< genfit::TrackPoint* >& getPoints() const {return trackPoints_;}
+    unsigned int getNumPoints() const {return trackPoints_.size();}
 
-  AbsTrackRep* getTrackRep(int id) const {return trackReps_.at(id);}
-  /// Return the track representations as a list of pointers.
-  const std::vector<genfit::AbsTrackRep*>& getTrackReps() const {return trackReps_;}
-  unsigned int getNumReps() const {return trackReps_.size();}
+    TrackPoint* getPointWithMeasurement(int id) const;
+    const std::vector< genfit::TrackPoint* >& getPointsWithMeasurement() const  {return trackPointsWithMeasurement_;}
+    unsigned int getNumPointsWithMeasurement() const {return trackPointsWithMeasurement_.size();}
 
-  //! This is used when streaming TrackPoints.
-  int getIdForRep(const AbsTrackRep* rep) const;
+    TrackPoint* getPointWithMeasurementAndFitterInfo(int id, const AbsTrackRep* rep = nullptr) const;
+    TrackPoint* getPointWithFitterInfo(int id, const AbsTrackRep* rep = nullptr) const;
 
-  /** @brief Get cardinal track representation
-   *
-   * The user has to choose which AbsTrackRep should be considered the
-   * best one after the fit. E.g. the track representation giving the
-   * smallest chi2 could be chosen. By default the first in the list is returned.
-   * @sa #determineCardinalRep()
-   */
-  AbsTrackRep* getCardinalRep() const {return trackReps_.at(cardinalRep_);}
-  unsigned int getCardinalRepId() const {return cardinalRep_;}
+    /**
+     * @brief Shortcut to get FittedStates.
+     *
+     * Uses getPointWithFitterInfo(id, rep).
+     * Gets the fitted state at trackpoint id for the track representation rep.
+     * Per default, the fitted state of the fitterInfo of the first TrackPoint
+     * with one or more AbsFitterInfo objects
+     * is returned. If no AbsTrackRep is specified, the AbsFitterInfo of the cardinal rep will be used.
+     */
+    const MeasuredStateOnPlane& getFittedState(int id = 0, const AbsTrackRep* rep = nullptr, bool biased = true) const;
 
-  //! Get the MCT track id, for MC simulations - default value = -1
-  int getMcTrackId() const {return mcTrackId_;}
+    AbsTrackRep* getTrackRep(int id) const {return trackReps_.at(id);}
+    /// Return the track representations as a list of pointers.
+    const std::vector<genfit::AbsTrackRep*>& getTrackReps() const {return trackReps_;}
+    unsigned int getNumReps() const {return trackReps_.size();}
 
-  //! Check if track has a FitStatus for given AbsTrackRep. Per default, check for cardinal rep.
-  bool hasFitStatus(const AbsTrackRep* rep = nullptr) const;
-  //! Get FitStatus for a AbsTrackRep. Per default, return FitStatus for cardinalRep.
-  FitStatus* getFitStatus(const AbsTrackRep* rep = nullptr) const {if (rep == nullptr) rep = getCardinalRep(); return fitStatuses_.at(rep);}
+    //! This is used when streaming TrackPoints.
+    int getIdForRep(const AbsTrackRep* rep) const;
 
-  //! Check if track has a KalmanFitStatus for given AbsTrackRep. Per default, check for cardinal rep.
-  bool hasKalmanFitStatus(const AbsTrackRep* rep = nullptr) const;
-  //! If FitStatus is a KalmanFitStatus, return it. Otherwise return nullptr
-  KalmanFitStatus* getKalmanFitStatus(const AbsTrackRep* rep = nullptr) const;
+    /** @brief Get cardinal track representation
+     *
+     * The user has to choose which AbsTrackRep should be considered the
+     * best one after the fit. E.g. the track representation giving the
+     * smallest chi2 could be chosen. By default the first in the list is returned.
+     * @sa #determineCardinalRep()
+     */
+    AbsTrackRep* getCardinalRep() const {return trackReps_.at(cardinalRep_);}
+    unsigned int getCardinalRepId() const {return cardinalRep_;}
 
-  void setFitStatus(FitStatus* fitStatus, const AbsTrackRep* rep);
+    //! Get the MCT track id, for MC simulations - default value = -1
+    int getMcTrackId() const {return mcTrackId_;}
 
-  double getTimeSeed() const {return timeSeed_;}
-  void setTimeSeed(double time) {timeSeed_ = time;}
+    //! Check if track has a FitStatus for given AbsTrackRep. Per default, check for cardinal rep.
+    bool hasFitStatus(const AbsTrackRep* rep = nullptr) const;
+    //! Get FitStatus for a AbsTrackRep. Per default, return FitStatus for cardinalRep.
+    FitStatus* getFitStatus(const AbsTrackRep* rep = nullptr) const {if (rep == nullptr) rep = getCardinalRep(); return fitStatuses_.at(rep);}
 
-  const TVectorD& getStateSeed() const {return stateSeed_;}
-  void setStateSeed(const TVectorD& s) {stateSeed_.ResizeTo(s); stateSeed_ = s;}
-  void setStateSeed(const TVector3& pos, const TVector3& mom);
+    //! Check if track has a KalmanFitStatus for given AbsTrackRep. Per default, check for cardinal rep.
+    bool hasKalmanFitStatus(const AbsTrackRep* rep = nullptr) const;
+    //! If FitStatus is a KalmanFitStatus, return it. Otherwise return nullptr
+    KalmanFitStatus* getKalmanFitStatus(const AbsTrackRep* rep = nullptr) const;
 
-  const TMatrixDSym& getCovSeed() const {return covSeed_;}
-  void setCovSeed(const TMatrixDSym& c) {covSeed_.ResizeTo(c); covSeed_ = c;}
+    void setFitStatus(FitStatus* fitStatus, const AbsTrackRep* rep);
 
-  //! Set the MCT track id, for MC simulations
-  void setMcTrackId(int i) {mcTrackId_ = i;}
+    double getTimeSeed() const {return timeSeed_;}
+    void setTimeSeed(double time) {timeSeed_ = time;}
 
-  /**
-   * @brief Insert TrackPoint BEFORE TrackPoint with position id, if id >= 0.
-   *
-   * Id -1 means after last TrackPoint. Id -2 means before last TrackPoint. ...
-   * Also deletes backwardInfos before new point and forwardInfos after new point.
-   * Also sets Track backpointer of point accordingly.
-   */
-  void insertPoint(TrackPoint* point, int id = -1);
+    const TVectorD& getStateSeed() const {return stateSeed_;}
+    void setStateSeed(const TVectorD& s) {stateSeed_.ResizeTo(s); stateSeed_ = s;}
+    void setStateSeed(const TVector3& pos, const TVector3& mom);
 
-  /**
-   * @brief Insert TrackPoints BEFORE TrackPoint with position id, if id >= 0.
-   *
-   * Id -1 means after last TrackPoint. Id -2 means before last TrackPoint. ...
-   * Also deletes backwardInfos before and for new points and forwardInfos after and for new points.
-   * Also sets Track backpointers of points accordingly.
-   */
-  void insertPoints(std::vector<genfit::TrackPoint*> points, int id = -1);
+    const TMatrixDSym& getCovSeed() const {return covSeed_;}
+    void setCovSeed(const TMatrixDSym& c) {covSeed_.ResizeTo(c); covSeed_ = c;}
 
-  void deletePoint(int id);
+    //! Set the MCT track id, for MC simulations
+    void setMcTrackId(int i) {mcTrackId_ = i;}
 
-  //! Creates a new TrackPoint containing the measurement, and adds it to the track
-  void insertMeasurement(AbsMeasurement* measurement, int id = -1);
+    /**
+     * @brief Insert TrackPoint BEFORE TrackPoint with position id, if id >= 0.
+     *
+     * Id -1 means after last TrackPoint. Id -2 means before last TrackPoint. ...
+     * Also deletes backwardInfos before new point and forwardInfos after new point.
+     * Also sets Track backpointer of point accordingly.
+     */
+    void insertPoint(TrackPoint* point, int id = -1);
 
-  //! Delete all measurement information and the track points of the track. Does not delete track representations.
-  void deleteTrackPointsAndFitStatus();
-  /**
-   * @brief Merge two tracks.
-   *
-   * The TrackPoint objects of other will be cloned and inserted
-   * after id (per default, they will be appended at the end).
-   * The other Track will not be altered, the TrackPoint objects will be (deep) copied.
-   * Only copies the TrackPoint objects, NOT the AbsTrackRep, FitStatus, seed state and other objects of the other track.
-   */
-  void mergeTrack(const Track* other, int id = -1);
+    /**
+     * @brief Insert TrackPoints BEFORE TrackPoint with position id, if id >= 0.
+     *
+     * Id -1 means after last TrackPoint. Id -2 means before last TrackPoint. ...
+     * Also deletes backwardInfos before and for new points and forwardInfos after and for new points.
+     * Also sets Track backpointers of points accordingly.
+     */
+    void insertPoints(std::vector<genfit::TrackPoint*> points, int id = -1);
 
-  void addTrackRep(AbsTrackRep* trackRep);
+    void deletePoint(int id);
 
-  //! Delete a AbsTrackRep and all corresponding AbsFitterInfo objects in every TrackPoint.
-  void deleteTrackRep(int id);
+    //! Creates a new TrackPoint containing the measurement, and adds it to the track
+    void insertMeasurement(AbsMeasurement* measurement, int id = -1);
 
-  void setCardinalRep(int id);
-  //! See with which AbsTrackRep the track was fitted best (converged fit w/ smallest chi2) and set the cardinal rep accordingly.
-  void determineCardinalRep();
+    //! Delete all measurement information and the track points of the track. Does not delete track representations.
+    void deleteTrackPointsAndFitStatus();
+    /**
+     * @brief Merge two tracks.
+     *
+     * The TrackPoint objects of other will be cloned and inserted
+     * after id (per default, they will be appended at the end).
+     * The other Track will not be altered, the TrackPoint objects will be (deep) copied.
+     * Only copies the TrackPoint objects, NOT the AbsTrackRep, FitStatus, seed state and other objects of the other track.
+     */
+    void mergeTrack(const Track* other, int id = -1);
 
-  /**
-   * @brief Sort TrackPoint and according to their sorting parameters.
-   *
-   * Returns if the order of the TrackPoint has actually changed.
-   */
-  bool sort();
+    void addTrackRep(AbsTrackRep* trackRep);
 
-  //! Try to set the fitted state as seed. Return if it was successfull.
-  //! Adapt the sign of all TrackReps' pdg to the actual fitted charge.
-  bool udpateSeed(int id = 0, AbsTrackRep* rep = nullptr, bool biased = true);
+    //! Delete a AbsTrackRep and all corresponding AbsFitterInfo objects in every TrackPoint.
+    void deleteTrackRep(int id);
 
-  //! Flip the ordering of the TrackPoints
-  void reverseTrackPoints();
+    void setCardinalRep(int id);
+    //! See with which AbsTrackRep the track was fitted best (converged fit w/ smallest chi2) and set the cardinal rep accordingly.
+    void determineCardinalRep();
 
-  //! Flip direction of momentum seed
-  void reverseMomSeed() {
-    stateSeed_(3) *= -1; stateSeed_(4) *= -1; stateSeed_(5) *= -1;
-  }
+    /**
+     * @brief Sort TrackPoint and according to their sorting parameters.
+     *
+     * Returns if the order of the TrackPoint has actually changed.
+     */
+    bool sort();
 
-  //! Switch the pdg signs of specified rep (of all reps if rep == nullptr).
-  void switchPDGSigns(AbsTrackRep* rep = nullptr);
+    //! Try to set the fitted state as seed. Return if it was successfull.
+    //! Adapt the sign of all TrackReps' pdg to the actual fitted charge.
+    bool udpateSeed(int id = 0, AbsTrackRep* rep = nullptr, bool biased = true);
 
-  //! Make track ready to be fitted in reverse direction
-  /**
-   * Flip the order of TrackPoints and the momentum direction of the seed state.
-   * If possible, take the smoothed state of the last hit as new seed state.
-   * Flip charge of the TrackReps.
-   */
-  void reverseTrack();
+    //! Flip the ordering of the TrackPoints
+    void reverseTrackPoints();
 
+    //! Flip direction of momentum seed
+    void reverseMomSeed()
+    {
+      stateSeed_(3) *= -1; stateSeed_(4) *= -1; stateSeed_(5) *= -1;
+    }
 
-  void deleteForwardInfo(int startId = 0, int endId = -1, const AbsTrackRep* rep = nullptr); // delete in range [startId, endId]. If rep == nullptr, delete for ALL reps, otherwise only for rep.
-  void deleteBackwardInfo(int startId = 0, int endId = -1, const AbsTrackRep* rep = nullptr); // delete in range [startId, endId]. If rep == nullptr, delete for ALL reps, otherwise only for rep.
-  void deleteReferenceInfo(int startId = 0, int endId = -1, const AbsTrackRep* rep = nullptr); // delete in range [startId, endId]. If rep == nullptr, delete for ALL reps, otherwise only for rep.
-  void deleteMeasurementInfo(int startId = 0, int endId = -1, const AbsTrackRep* rep = nullptr); // delete in range [startId, endId]. If rep == nullptr, delete for ALL reps, otherwise only for rep.
-  void deleteFitterInfo(int startId = 0, int endId = -1, const AbsTrackRep* rep = nullptr); // delete in range [startId, endId]. If rep == nullptr, delete for ALL reps, otherwise only for rep.
+    //! Switch the pdg signs of specified rep (of all reps if rep == nullptr).
+    void switchPDGSigns(AbsTrackRep* rep = nullptr);
 
-  //! get TrackLength between to trackPoints (if nullptr, for cardinal rep)
-  double getTrackLen(AbsTrackRep* rep = nullptr, int startId = 0, int endId = -1) const;
-  //! get time of flight in ns between to trackPoints (if nullptr, for cardinal rep)
-  double getTOF(AbsTrackRep* rep = nullptr, int startId = 0, int endId = -1) const;
-
-  /**
-   * Delete the fit status and all the FitStates of the TrackPoints
-   * for the given hypothesis.
-   * This is equal to resetting the track for the rep, so another fit
-   * can start from scratch.
-   * Useful if you have changed some seeds.
-   */
-  void deleteFittedState(const genfit::AbsTrackRep* rep); 
-
-  //! Construct a new TrackCand containing the hit IDs of the measurements
-  /**
-   * The idea is hat you can get a TrackCand for storing the hit IDs after a track has been fitted.
-   * His could have been reordered, added or removed, so that the original TackCand no longer
-   * represents the Track correctly.
-   * You might want to call determineCardinalRep() and/or udpateSeed() before.
-   */
-  TrackCand* constructTrackCand() const;
-
-  //! Helper function: For all KalmanFitterInfos belonging to rep (if nullptr, for all reps),
-  //! call the fixWeights() function, so that e.g. the DAF will not alter weights anymore.
-  void fixWeights(AbsTrackRep* rep = nullptr, int startId = 0, int endId = -1);
-
-  /**
-   * @brief Delete unneeded information from the Track.
-   *
-   * Possible options: (see also PruneFlags defined in FitStatus.h)
-   * C:  prune all reps except cardinalRep
-   * F:  prune all points except first point (also prune referenceInfo from fitterInfos)
-   * L:  prune all points except last point (also prune referenceInfo from fitterInfos)
-   * FL: prune all points except first and last point (also prune referenceInfo from fitterInfos)
-   * W:  prune rawMeasurements from TrackPoints
-   * R:  prune referenceInfo from fitterInfos
-   * M:  prune measurementInfo from fitterInfos
-   * I:  if F, L, or FL is set, prune forward (backward) info of first (last) point
-   * U:  if fitterInfo is a KalmanFitterInfo, prune predictions and keep updates
-   */
-  void prune(const Option_t* = "CFLWRMIU");
-
-  void Print(const Option_t* = "") const;
-
-  void checkConsistency() const;
-
- private:
-
-  void trackHasChanged();
-
-  void fillPointsWithMeasurement();
-
-  std::vector<AbsTrackRep*> trackReps_; // Ownership
-  unsigned int cardinalRep_; // THE selected rep, default = 0;
-
-  std::vector<TrackPoint*> trackPoints_; // Ownership
-  std::vector<TrackPoint*> trackPointsWithMeasurement_; //! helper
-
-  std::map< const AbsTrackRep*, FitStatus* > fitStatuses_; // Ownership over FitStatus*
-
-  int mcTrackId_; /**< if MC simulation, store the mc track id here */
-  double timeSeed_;
-  TVectorD stateSeed_; // 6D: position, momentum
-  TMatrixDSym covSeed_; // 6D
+    //! Make track ready to be fitted in reverse direction
+    /**
+     * Flip the order of TrackPoints and the momentum direction of the seed state.
+     * If possible, take the smoothed state of the last hit as new seed state.
+     * Flip charge of the TrackReps.
+     */
+    void reverseTrack();
 
 
- public:
-  ClassDef(Track,3)
-  // Class version history:
-  //  ver 3: introduces timeSeed_
-};
+    void deleteForwardInfo(int startId = 0, int endId = -1,
+                           const AbsTrackRep* rep = nullptr); // delete in range [startId, endId]. If rep == nullptr, delete for ALL reps, otherwise only for rep.
+    void deleteBackwardInfo(int startId = 0, int endId = -1,
+                            const AbsTrackRep* rep = nullptr); // delete in range [startId, endId]. If rep == nullptr, delete for ALL reps, otherwise only for rep.
+    void deleteReferenceInfo(int startId = 0, int endId = -1,
+                             const AbsTrackRep* rep = nullptr); // delete in range [startId, endId]. If rep == nullptr, delete for ALL reps, otherwise only for rep.
+    void deleteMeasurementInfo(int startId = 0, int endId = -1,
+                               const AbsTrackRep* rep = nullptr); // delete in range [startId, endId]. If rep == nullptr, delete for ALL reps, otherwise only for rep.
+    void deleteFitterInfo(int startId = 0, int endId = -1,
+                          const AbsTrackRep* rep = nullptr); // delete in range [startId, endId]. If rep == nullptr, delete for ALL reps, otherwise only for rep.
+
+    //! get TrackLength between to trackPoints (if nullptr, for cardinal rep)
+    double getTrackLen(AbsTrackRep* rep = nullptr, int startId = 0, int endId = -1) const;
+    //! get time of flight in ns between to trackPoints (if nullptr, for cardinal rep)
+    double getTOF(AbsTrackRep* rep = nullptr, int startId = 0, int endId = -1) const;
+
+    /**
+     * Delete the fit status and all the FitStates of the TrackPoints
+     * for the given hypothesis.
+     * This is equal to resetting the track for the rep, so another fit
+     * can start from scratch.
+     * Useful if you have changed some seeds.
+     */
+    void deleteFittedState(const genfit::AbsTrackRep* rep);
+
+    //! Construct a new TrackCand containing the hit IDs of the measurements
+    /**
+     * The idea is hat you can get a TrackCand for storing the hit IDs after a track has been fitted.
+     * His could have been reordered, added or removed, so that the original TackCand no longer
+     * represents the Track correctly.
+     * You might want to call determineCardinalRep() and/or udpateSeed() before.
+     */
+    TrackCand* constructTrackCand() const;
+
+    //! Helper function: For all KalmanFitterInfos belonging to rep (if nullptr, for all reps),
+    //! call the fixWeights() function, so that e.g. the DAF will not alter weights anymore.
+    void fixWeights(AbsTrackRep* rep = nullptr, int startId = 0, int endId = -1);
+
+    /**
+     * @brief Delete unneeded information from the Track.
+     *
+     * Possible options: (see also PruneFlags defined in FitStatus.h)
+     * C:  prune all reps except cardinalRep
+     * F:  prune all points except first point (also prune referenceInfo from fitterInfos)
+     * L:  prune all points except last point (also prune referenceInfo from fitterInfos)
+     * FL: prune all points except first and last point (also prune referenceInfo from fitterInfos)
+     * W:  prune rawMeasurements from TrackPoints
+     * R:  prune referenceInfo from fitterInfos
+     * M:  prune measurementInfo from fitterInfos
+     * I:  if F, L, or FL is set, prune forward (backward) info of first (last) point
+     * U:  if fitterInfo is a KalmanFitterInfo, prune predictions and keep updates
+     */
+    void prune(const Option_t* = "CFLWRMIU");
+
+    void Print(const Option_t* = "") const;
+
+    void checkConsistency() const;
+
+  private:
+
+    void trackHasChanged();
+
+    void fillPointsWithMeasurement();
+
+    std::vector<AbsTrackRep*> trackReps_; // Ownership
+    unsigned int cardinalRep_; // THE selected rep, default = 0;
+
+    std::vector<TrackPoint*> trackPoints_; // Ownership
+    std::vector<TrackPoint*> trackPointsWithMeasurement_; //! helper
+
+    std::map< const AbsTrackRep*, FitStatus* > fitStatuses_; // Ownership over FitStatus*
+
+    int mcTrackId_; /**< if MC simulation, store the mc track id here */
+    double timeSeed_;
+    TVectorD stateSeed_; // 6D: position, momentum
+    TMatrixDSym covSeed_; // 6D
+
+
+  public:
+    ClassDef(Track, 3)
+    // Class version history:
+    //  ver 3: introduces timeSeed_
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/core/include/TrackCand.h
+++ b/core/include/TrackCand.h
@@ -40,208 +40,208 @@
 
 namespace genfit {
 
-/** @brief Track candidate -- seed values and indices
- *
- *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
- *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
- *  @author Moritz Nadler (maintainer during 2012)
- *
- * The main task of the TrackCand object is to store a list of indices to
- * cluster objects. Each cluster in the Track is identified by it's
- * detector ID and it's index in the corresponding TClonesArray.
- * Also there is a ordering parameter to order hits.
- * Optionally, plane indices for the hits can be stored (most importantly
- * for fitting with the Daf).
- * This information is used by the RecoHitFactory to automatically load
- * RecoHits into a Track. Through this it is possible to define Tracks over
- * an arbitrary number of different detectors.
- *
- * In addition TrackCand offers members to store starting values for the fit.
- * The starting values (seeds) for the fit are stored as a 6D state (x,y,z,px,py,pz) and its
- * corresponding 6x6 covariance matrix. All seed getter and setter manipulate these two members
- * but the user can chose using TVector3 or TMatrixD to get/set the seed state.
- * However this information is not automatically used in genfit.
- * But a pointer to a TrackCand can be passed to the a RKTrackRep constructor
- * to make use of this information without manually extracting it from the TrackCand object.
- *
- * @sa RecoHitFactory
- */
-class TrackCand : public TObject {
-
-
- public:
-
-
-  // Constructors/Destructors ---------
-  TrackCand();
-  ~TrackCand();
-
-  //! copy constructor
-  TrackCand( const TrackCand& other );
-  //! assignment operator
-  TrackCand& operator=(TrackCand other);
-  void swap(TrackCand& other); // nothrow
-
-  //! == operator checks equality of TrackCandHits. Does not check for sorting parameters.
-  friend bool operator== (const TrackCand& lhs, const TrackCand& rhs);
-  friend bool operator!= (const TrackCand& lhs, const TrackCand& rhs) {return !(lhs == rhs);}
-
-  static bool compareTrackCandHits(const TrackCandHit* lhs, const TrackCandHit* rhs) {return (*lhs < *rhs);} // operator< defined in TrackCandHit.h
-
-  // Accessors -----------------------
-  TrackCandHit* getHit(int i) const;
-
-  //!Get detector Id and hit Id for hit number i
-  void getHit(int i, int& detId, int& hitId) const;
-
-  //! Get detector Id, hit Id and sorting parameter for hit number i
-  void getHit(int i, int& detId, int& hitId, double& sortingParameter) const;
-
-  //! Get detector Id, hit Id and plane id for hit number i
-  void getHitWithPlane(int i, int& detId, int& hitId, int& planeId) const;
-
-  unsigned int getNHits() const {return hits_.size();}
-
-  /**
-   * @brief Get hit ids of from a specific detector.
+  /** @brief Track candidate -- seed values and indices
    *
-   * DetId -1 gives hitIds of hits with default detId -1. The default argument -2 gives hit Ids of all hits.
+   *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
+   *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
+   *  @author Moritz Nadler (maintainer during 2012)
+   *
+   * The main task of the TrackCand object is to store a list of indices to
+   * cluster objects. Each cluster in the Track is identified by it's
+   * detector ID and it's index in the corresponding TClonesArray.
+   * Also there is a ordering parameter to order hits.
+   * Optionally, plane indices for the hits can be stored (most importantly
+   * for fitting with the Daf).
+   * This information is used by the RecoHitFactory to automatically load
+   * RecoHits into a Track. Through this it is possible to define Tracks over
+   * an arbitrary number of different detectors.
+   *
+   * In addition TrackCand offers members to store starting values for the fit.
+   * The starting values (seeds) for the fit are stored as a 6D state (x,y,z,px,py,pz) and its
+   * corresponding 6x6 covariance matrix. All seed getter and setter manipulate these two members
+   * but the user can chose using TVector3 or TMatrixD to get/set the seed state.
+   * However this information is not automatically used in genfit.
+   * But a pointer to a TrackCand can be passed to the a RKTrackRep constructor
+   * to make use of this information without manually extracting it from the TrackCand object.
+   *
+   * @sa RecoHitFactory
    */
-  std::vector<int>    getHitIDs(int detId = -2) const;
-
-  //! Get detector IDs of all hits
-  std::vector<int>    getDetIDs() const;
-  //! Get sorting parameterts of all hits
-  std::vector<double> getSortingParameters() const;
-  std::set<int>       getUniqueDetIDs() const;
-
-  //! Get the MCT track id, for MC simulations - default value = -1
-  int getMcTrackId() const {return mcTrackId_;}
-
-  //! Get the time at which the seed state is defined
-  double getTimeSeed() const { return time_; }
-
-  /** @brief get the seed value for track: pos. Identical to the first 3 components of getStateSeed*/
-  TVector3 getPosSeed() const {return TVector3(state6D_(0), state6D_(1), state6D_(2));}
-
-  /** @brief get the seed value for track: mom. Identical to the last 3 components of getStateSeed*/
-  TVector3 getMomSeed() const {return TVector3(state6D_(3), state6D_(4), state6D_(5));}
-
-  /** @brief get the covariance matrix seed (6D).  */
-  const TMatrixDSym& getCovSeed() const {return cov6D_;}
-
-  //! Returns the 6D seed state; should be in global coordinates.
-  const TVectorD& getStateSeed() const {return state6D_;}
-
-  double getChargeSeed() const {return q_;}
-
-  //! Get the PDG code
-  int getPdgCode() const {return pdg_;}
-
-  //! Is there a hit with detId and hitId in the TrackCand?
-  bool hitInTrack(int detId, int hitId) const;
-
-  // Modifiers -----------------------
-
-  void addHit(int detId, int hitId, int planeId = -1, double sortingParameter = 0);
-
-  void addHit(TrackCandHit* hit) {hits_.push_back(hit);}
-
-  //! Set the MCT track id, for MC simulations
-  void setMcTrackId(int i) {mcTrackId_ = i;}
-
-  //! Set a particle hypothesis in form of a PDG code. This will also set the charge attribute
-  void setPdgCode(int pdgCode);
-
-  //! Clone the TrackCandHit objects from the other TrackCand and append them to this TrackCand
-  void append(const TrackCand&);
-
-  //! Sort the hits that were already added to the trackCand using the sorting parameters.
-  void sortHits();
-
-  void sortHits(const std::vector<unsigned int>& indices);
-
-  // Operations ----------------------
-  //! Delete and clear the TrackCandHits
-  void reset();
-
-  //! Write the content of all private attributes to the terminal
-  void Print(const Option_t* = "") const ;
-
-  //! Set the time at which the seed is defined
-  void setTimeSeed(double time) { time_ = time; }
-
-  /** @brief set the covariance matrix seed (6D).  */
-  void setCovSeed(const TMatrixDSym& cov6D) {cov6D_ = cov6D; /* always 6D, no need to resize */}
-
-  /** @brief sets the state to seed the track fitting. State has to be a TVectorD(6). First 3 elements are the staring postion second 3 elements the starting momentum. Everything in global coordinates
-   * charge is the charge hypotheses of the particle charge
-   */
-  void set6DSeed(const TVectorD& state6D, const double charge);
-
-  /** @brief This function works the same as set6DSeed but instead of a charge hypothesis you can set a pdg code which will set the charge automatically
-   */
-  void set6DSeedAndPdgCode(const TVectorD& state6D, const int pdgCode);
-
-  /** @brief sets the state to seed the track fitting. State has to be a TVector3 for position and a TVector3 for momentum. Everything in global coordinates
-   * charge is the charge hypotheses of the particle charge
-   */
-  void setPosMomSeed(const TVector3& pos, const TVector3& mom, const double charge);
-
-  /** @brief This function works the same as setPosMomSeed but instead of a charge hypothesis you can set a pdg code which will set the charge automatically
-   */
-  void setPosMomSeedAndPdgCode(const TVector3& pos, const TVector3& mom, const int pdgCode);
-
-  /** @brief sets the state to seed the track fitting and its
-     time. State has to be a TVectorD(6). First 3 elements are the
-     staring postion second 3 elements the starting
-     momentum. Everything in global coordinates charge is the charge
-     hypotheses of the particle charge.
-   */
-  void setTime6DSeed(double time, const TVectorD& state6D, const double charge);
-
-  /** @brief This function works the same as set6DSeed but instead of
-      a charge hypothesis you can set a pdg code which will set the
-      charge automatically.
-   */
-  void setTime6DSeedAndPdgCode(double time, const TVectorD& state6D, const int pdgCode);
-
-  /** @brief sets the state to seed the track fitting and its time. State has to be
-     a TVector3 for position and a TVector3 for momentum. Everything
-     in global coordinates charge is the charge hypotheses of the
-     particle charge.
-   */
-  void setTimePosMomSeed(double time, const TVector3& pos, const TVector3& mom,
-			 const double charge);
-
-  /** @brief This function works the same as setPosMomSeed but instead
-      of a charge hypothesis you can set a pdg code which will set the
-      charge automatically.
-   */
-  void setTimePosMomSeedAndPdgCode(double time, const TVector3& pos,
-				   const TVector3& mom, const int pdgCode);
+  class TrackCand : public TObject {
 
 
- private:
-
-  // Private Data Members ------------
-  std::vector<TrackCandHit*> hits_; //->
-
-  int mcTrackId_; /**< if MC simulation, store the mc track id here */
-  int pdg_; /**< particle data groupe's id for a particle*/
-
-  double time_; /**< Time at which the seed is given */
-  TVectorD state6D_; /**< global 6D position plus momentum state */
-  TMatrixDSym cov6D_; /**< global 6D position plus momentum state */
-  double q_; /**< the charge of the particle in units of elementary charge */
+  public:
 
 
- public:
+    // Constructors/Destructors ---------
+    TrackCand();
+    ~TrackCand();
 
-  ClassDef(TrackCand,2)
-  // Version history:
-  // ver 2: keep track of time in state (schema evolution rule added).
-};
+    //! copy constructor
+    TrackCand(const TrackCand& other);
+    //! assignment operator
+    TrackCand& operator=(TrackCand other);
+    void swap(TrackCand& other); // nothrow
+
+    //! == operator checks equality of TrackCandHits. Does not check for sorting parameters.
+    friend bool operator== (const TrackCand& lhs, const TrackCand& rhs);
+    friend bool operator!= (const TrackCand& lhs, const TrackCand& rhs) {return !(lhs == rhs);}
+
+    static bool compareTrackCandHits(const TrackCandHit* lhs, const TrackCandHit* rhs) {return (*lhs < *rhs);} // operator< defined in TrackCandHit.h
+
+    // Accessors -----------------------
+    TrackCandHit* getHit(int i) const;
+
+    //!Get detector Id and hit Id for hit number i
+    void getHit(int i, int& detId, int& hitId) const;
+
+    //! Get detector Id, hit Id and sorting parameter for hit number i
+    void getHit(int i, int& detId, int& hitId, double& sortingParameter) const;
+
+    //! Get detector Id, hit Id and plane id for hit number i
+    void getHitWithPlane(int i, int& detId, int& hitId, int& planeId) const;
+
+    unsigned int getNHits() const {return hits_.size();}
+
+    /**
+     * @brief Get hit ids of from a specific detector.
+     *
+     * DetId -1 gives hitIds of hits with default detId -1. The default argument -2 gives hit Ids of all hits.
+     */
+    std::vector<int>    getHitIDs(int detId = -2) const;
+
+    //! Get detector IDs of all hits
+    std::vector<int>    getDetIDs() const;
+    //! Get sorting parameterts of all hits
+    std::vector<double> getSortingParameters() const;
+    std::set<int>       getUniqueDetIDs() const;
+
+    //! Get the MCT track id, for MC simulations - default value = -1
+    int getMcTrackId() const {return mcTrackId_;}
+
+    //! Get the time at which the seed state is defined
+    double getTimeSeed() const { return time_; }
+
+    /** @brief get the seed value for track: pos. Identical to the first 3 components of getStateSeed*/
+    TVector3 getPosSeed() const {return TVector3(state6D_(0), state6D_(1), state6D_(2));}
+
+    /** @brief get the seed value for track: mom. Identical to the last 3 components of getStateSeed*/
+    TVector3 getMomSeed() const {return TVector3(state6D_(3), state6D_(4), state6D_(5));}
+
+    /** @brief get the covariance matrix seed (6D).  */
+    const TMatrixDSym& getCovSeed() const {return cov6D_;}
+
+    //! Returns the 6D seed state; should be in global coordinates.
+    const TVectorD& getStateSeed() const {return state6D_;}
+
+    double getChargeSeed() const {return q_;}
+
+    //! Get the PDG code
+    int getPdgCode() const {return pdg_;}
+
+    //! Is there a hit with detId and hitId in the TrackCand?
+    bool hitInTrack(int detId, int hitId) const;
+
+    // Modifiers -----------------------
+
+    void addHit(int detId, int hitId, int planeId = -1, double sortingParameter = 0);
+
+    void addHit(TrackCandHit* hit) {hits_.push_back(hit);}
+
+    //! Set the MCT track id, for MC simulations
+    void setMcTrackId(int i) {mcTrackId_ = i;}
+
+    //! Set a particle hypothesis in form of a PDG code. This will also set the charge attribute
+    void setPdgCode(int pdgCode);
+
+    //! Clone the TrackCandHit objects from the other TrackCand and append them to this TrackCand
+    void append(const TrackCand&);
+
+    //! Sort the hits that were already added to the trackCand using the sorting parameters.
+    void sortHits();
+
+    void sortHits(const std::vector<unsigned int>& indices);
+
+    // Operations ----------------------
+    //! Delete and clear the TrackCandHits
+    void reset();
+
+    //! Write the content of all private attributes to the terminal
+    void Print(const Option_t* = "") const ;
+
+    //! Set the time at which the seed is defined
+    void setTimeSeed(double time) { time_ = time; }
+
+    /** @brief set the covariance matrix seed (6D).  */
+    void setCovSeed(const TMatrixDSym& cov6D) {cov6D_ = cov6D; /* always 6D, no need to resize */}
+
+    /** @brief sets the state to seed the track fitting. State has to be a TVectorD(6). First 3 elements are the staring postion second 3 elements the starting momentum. Everything in global coordinates
+     * charge is the charge hypotheses of the particle charge
+     */
+    void set6DSeed(const TVectorD& state6D, const double charge);
+
+    /** @brief This function works the same as set6DSeed but instead of a charge hypothesis you can set a pdg code which will set the charge automatically
+     */
+    void set6DSeedAndPdgCode(const TVectorD& state6D, const int pdgCode);
+
+    /** @brief sets the state to seed the track fitting. State has to be a TVector3 for position and a TVector3 for momentum. Everything in global coordinates
+     * charge is the charge hypotheses of the particle charge
+     */
+    void setPosMomSeed(const TVector3& pos, const TVector3& mom, const double charge);
+
+    /** @brief This function works the same as setPosMomSeed but instead of a charge hypothesis you can set a pdg code which will set the charge automatically
+     */
+    void setPosMomSeedAndPdgCode(const TVector3& pos, const TVector3& mom, const int pdgCode);
+
+    /** @brief sets the state to seed the track fitting and its
+       time. State has to be a TVectorD(6). First 3 elements are the
+       staring postion second 3 elements the starting
+       momentum. Everything in global coordinates charge is the charge
+       hypotheses of the particle charge.
+     */
+    void setTime6DSeed(double time, const TVectorD& state6D, const double charge);
+
+    /** @brief This function works the same as set6DSeed but instead of
+        a charge hypothesis you can set a pdg code which will set the
+        charge automatically.
+     */
+    void setTime6DSeedAndPdgCode(double time, const TVectorD& state6D, const int pdgCode);
+
+    /** @brief sets the state to seed the track fitting and its time. State has to be
+       a TVector3 for position and a TVector3 for momentum. Everything
+       in global coordinates charge is the charge hypotheses of the
+       particle charge.
+     */
+    void setTimePosMomSeed(double time, const TVector3& pos, const TVector3& mom,
+                           const double charge);
+
+    /** @brief This function works the same as setPosMomSeed but instead
+        of a charge hypothesis you can set a pdg code which will set the
+        charge automatically.
+     */
+    void setTimePosMomSeedAndPdgCode(double time, const TVector3& pos,
+                                     const TVector3& mom, const int pdgCode);
+
+
+  private:
+
+    // Private Data Members ------------
+    std::vector<TrackCandHit*> hits_; //->
+
+    int mcTrackId_; /**< if MC simulation, store the mc track id here */
+    int pdg_; /**< particle data groupe's id for a particle*/
+
+    double time_; /**< Time at which the seed is given */
+    TVectorD state6D_; /**< global 6D position plus momentum state */
+    TMatrixDSym cov6D_; /**< global 6D position plus momentum state */
+    double q_; /**< the charge of the particle in units of elementary charge */
+
+
+  public:
+
+    ClassDef(TrackCand, 2)
+    // Version history:
+    // ver 2: keep track of time in state (schema evolution rule added).
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/core/include/TrackCandHit.h
+++ b/core/include/TrackCandHit.h
@@ -28,68 +28,70 @@
 
 namespace genfit {
 
-/**
- * @brief Hit object for use in TrackCand. Provides IDs and sorting parameters.
- */
-class TrackCandHit : public TObject {
- public:
-
-  // Constructors/Destructors ---------
-  TrackCandHit(int detId   = -1,
-               int hitId   = -1,
-               int planeId = -1,
-               double sortingParameter  =  0.);
-
-  virtual ~TrackCandHit() {;}
-
-  virtual TrackCandHit* clone() const {return new TrackCandHit(*this);}
-
-  // Accessors
-  int    getDetId() const {return detId_;}
-  int    getHitId() const {return hitId_;}
-  int    getPlaneId() const {return planeId_;}
-  double getSortingParameter() const {return sortingParameter_;}
-
-  // Modifiers
-  void setSortingParameter(double sortingParameter) {sortingParameter_ = sortingParameter;}
-
-  virtual void Print(Option_t* option = "") const;
-
-
-  /** @brief Equality operator. Does not check sortingParameter.
+  /**
+   * @brief Hit object for use in TrackCand. Provides IDs and sorting parameters.
    */
-  friend bool operator== (const TrackCandHit& lhs, const TrackCandHit& rhs);
-  friend bool operator!= (const TrackCandHit& lhs, const TrackCandHit& rhs) {
-    return !(lhs == rhs);
-  }
+  class TrackCandHit : public TObject {
+  public:
 
-  /** @brief Compare sortingParameter, needed for sorting
-   */
-  friend bool operator< (const TrackCandHit& lhs, const TrackCandHit& rhs) {
-    return (lhs.sortingParameter_ < rhs.sortingParameter_);
-  }
+    // Constructors/Destructors ---------
+    TrackCandHit(int detId   = -1,
+                 int hitId   = -1,
+                 int planeId = -1,
+                 double sortingParameter  =  0.);
 
- protected:
+    virtual ~TrackCandHit() {;}
 
-  //! protect from calling copy c'tor from outside the class. Use #clone() if you want a copy!
-  TrackCandHit(const TrackCandHit& other) :
-    TObject(other), detId_(other.detId_), hitId_(other.hitId_), planeId_(other.planeId_), sortingParameter_(other.sortingParameter_) {;}
-  //! protect from calling assignment operator from outside the class. Use #clone() instead!
-  TrackCandHit& operator=(const TrackCandHit&);
+    virtual TrackCandHit* clone() const {return new TrackCandHit(*this);}
 
+    // Accessors
+    int    getDetId() const {return detId_;}
+    int    getHitId() const {return hitId_;}
+    int    getPlaneId() const {return planeId_;}
+    double getSortingParameter() const {return sortingParameter_;}
 
-  // Data Members ------------
-  int    detId_; // detId id is -1 per default
-  int    hitId_; // hitId id is -1 per default
-  int    planeId_; // planeId id is -1 per default
-  double sortingParameter_; // sorting parameter
+    // Modifiers
+    void setSortingParameter(double sortingParameter) {sortingParameter_ = sortingParameter;}
+
+    virtual void Print(Option_t* option = "") const;
 
 
- public:
+    /** @brief Equality operator. Does not check sortingParameter.
+     */
+    friend bool operator== (const TrackCandHit& lhs, const TrackCandHit& rhs);
+    friend bool operator!= (const TrackCandHit& lhs, const TrackCandHit& rhs)
+    {
+      return !(lhs == rhs);
+    }
 
-  ClassDef(TrackCandHit,1)
+    /** @brief Compare sortingParameter, needed for sorting
+     */
+    friend bool operator< (const TrackCandHit& lhs, const TrackCandHit& rhs)
+    {
+      return (lhs.sortingParameter_ < rhs.sortingParameter_);
+    }
 
-};
+  protected:
+
+    //! protect from calling copy c'tor from outside the class. Use #clone() if you want a copy!
+    TrackCandHit(const TrackCandHit& other) :
+      TObject(other), detId_(other.detId_), hitId_(other.hitId_), planeId_(other.planeId_), sortingParameter_(other.sortingParameter_) {;}
+    //! protect from calling assignment operator from outside the class. Use #clone() instead!
+    TrackCandHit& operator=(const TrackCandHit&);
+
+
+    // Data Members ------------
+    int    detId_; // detId id is -1 per default
+    int    hitId_; // hitId id is -1 per default
+    int    planeId_; // planeId id is -1 per default
+    double sortingParameter_; // sorting parameter
+
+
+  public:
+
+    ClassDef(TrackCandHit, 1)
+
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/core/include/TrackPoint.h
+++ b/core/include/TrackPoint.h
@@ -36,121 +36,122 @@
 
 namespace genfit {
 
-class Track;
-class KalmanFitterInfo;
-
-/**
- * @brief Object containing AbsMeasurement and AbsFitterInfo objects.
- *
- */
-class TrackPoint : public TObject {
-
- public:
-
-  TrackPoint();
-  explicit TrackPoint(Track* track);
+  class Track;
+  class KalmanFitterInfo;
 
   /**
-   * @brief Contructor taking list of measurements.
+   * @brief Object containing AbsMeasurement and AbsFitterInfo objects.
    *
-   * AbsMeasurement::setTrackPoint() of each measurement will be called.
-   * TrackPoint takes ownership over rawMeasurements.
    */
-  TrackPoint(const std::vector< genfit::AbsMeasurement* >& rawMeasurements, Track* track);
+  class TrackPoint : public TObject {
 
-  /**
-   * @brief Contructor taking one measurement.
-   *
-   * AbsMeasurement::setTrackPoint() of the measurement will be called.
-   * TrackPoint takes ownership over the rawMeasurement.
-   */
-  TrackPoint(genfit::AbsMeasurement* rawMeasurement, Track* track);
+  public:
 
-  TrackPoint(const TrackPoint&); // copy constructor
-  TrackPoint& operator=(TrackPoint); // assignment operator
-  void swap(TrackPoint& other);
+    TrackPoint();
+    explicit TrackPoint(Track* track);
 
-  /**
-   * custom copy constructor where all TrackRep pointers are exchanged according to the map.
-   * FitterInfos with a rep in repsToIgnore will NOT be copied.
-   */
-  TrackPoint(const TrackPoint& rhs,
-      const std::map<const genfit::AbsTrackRep*, genfit::AbsTrackRep*>& map,
-      const std::vector<const genfit::AbsTrackRep*> * repsToIgnore = nullptr);
+    /**
+     * @brief Contructor taking list of measurements.
+     *
+     * AbsMeasurement::setTrackPoint() of each measurement will be called.
+     * TrackPoint takes ownership over rawMeasurements.
+     */
+    TrackPoint(const std::vector< genfit::AbsMeasurement* >& rawMeasurements, Track* track);
 
-  virtual ~TrackPoint();
+    /**
+     * @brief Contructor taking one measurement.
+     *
+     * AbsMeasurement::setTrackPoint() of the measurement will be called.
+     * TrackPoint takes ownership over the rawMeasurement.
+     */
+    TrackPoint(genfit::AbsMeasurement* rawMeasurement, Track* track);
 
+    TrackPoint(const TrackPoint&); // copy constructor
+    TrackPoint& operator=(TrackPoint); // assignment operator
+    void swap(TrackPoint& other);
 
-  double getSortingParameter() const {return sortingParameter_;}
+    /**
+     * custom copy constructor where all TrackRep pointers are exchanged according to the map.
+     * FitterInfos with a rep in repsToIgnore will NOT be copied.
+     */
+    TrackPoint(const TrackPoint& rhs,
+               const std::map<const genfit::AbsTrackRep*, genfit::AbsTrackRep*>& map,
+               const std::vector<const genfit::AbsTrackRep*>* repsToIgnore = nullptr);
 
-  Track* getTrack() const {return track_;}
-  void setTrack(Track* track) {track_ = track;}
-
-  const std::vector< genfit::AbsMeasurement* >& getRawMeasurements() const {return rawMeasurements_;}
-  AbsMeasurement* getRawMeasurement(int i = 0) const;
-  unsigned int getNumRawMeasurements() const {return rawMeasurements_.size();}
-  bool hasRawMeasurements() const {return (rawMeasurements_.size() != 0);}
-  //! Get list of all fitterInfos
-  std::vector< genfit::AbsFitterInfo* > getFitterInfos() const;
-  //! Get fitterInfo for rep. Per default, use cardinal rep
-  AbsFitterInfo* getFitterInfo(const AbsTrackRep* rep = nullptr) const;
-  //! Helper to avoid casting
-  KalmanFitterInfo* getKalmanFitterInfo(const AbsTrackRep* rep = nullptr) const;
-  bool hasFitterInfo(const AbsTrackRep* rep) const {
-    return (fitterInfos_.find(rep) != fitterInfos_.end());
-  }
-
-  ThinScatterer* getMaterialInfo() const {return thinScatterer_.get();}
-  bool hasThinScatterer() const {return thinScatterer_.get() != nullptr;}
+    virtual ~TrackPoint();
 
 
-  void setSortingParameter(double sortingParameter) {sortingParameter_ = sortingParameter;}
-  //! Takes ownership and sets this as measurement's trackPoint
-  void addRawMeasurement(genfit::AbsMeasurement* rawMeasurement) {assert(rawMeasurement!=nullptr); rawMeasurement->setTrackPoint(this); rawMeasurements_.push_back(rawMeasurement);}
-  void deleteRawMeasurements();
-  //! Takes Ownership
-  void setFitterInfo(genfit::AbsFitterInfo* fitterInfo);
-  void deleteFitterInfo(const AbsTrackRep* rep) {delete fitterInfos_[rep]; fitterInfos_.erase(rep);}
+    double getSortingParameter() const {return sortingParameter_;}
 
-  void setScatterer(ThinScatterer* scatterer) {thinScatterer_.reset(scatterer);}
+    Track* getTrack() const {return track_;}
+    void setTrack(Track* track) {track_ = track;}
 
-  void Print(const Option_t* = "") const;
+    const std::vector< genfit::AbsMeasurement* >& getRawMeasurements() const {return rawMeasurements_;}
+    AbsMeasurement* getRawMeasurement(int i = 0) const;
+    unsigned int getNumRawMeasurements() const {return rawMeasurements_.size();}
+    bool hasRawMeasurements() const {return (rawMeasurements_.size() != 0);}
+    //! Get list of all fitterInfos
+    std::vector< genfit::AbsFitterInfo* > getFitterInfos() const;
+    //! Get fitterInfo for rep. Per default, use cardinal rep
+    AbsFitterInfo* getFitterInfo(const AbsTrackRep* rep = nullptr) const;
+    //! Helper to avoid casting
+    KalmanFitterInfo* getKalmanFitterInfo(const AbsTrackRep* rep = nullptr) const;
+    bool hasFitterInfo(const AbsTrackRep* rep) const
+    {
+      return (fitterInfos_.find(rep) != fitterInfos_.end());
+    }
 
-  /**
-   * This function is used when reading the TrackPoint and is called
-   * by the owner in order to build fitterInfos_ from vFitterInfos_.
-   * This requires that the track_ be set.  It also empties
-   * vFitterInfos_ which has served its purpose after this function is
-   * called.
-   */
-  void fixupRepsForReading();
+    ThinScatterer* getMaterialInfo() const {return thinScatterer_.get();}
+    bool hasThinScatterer() const {return thinScatterer_.get() != nullptr;}
 
- private:
-  double sortingParameter_;
 
-  //! Pointer to Track where TrackPoint belongs to
-  Track* track_; //! No ownership
+    void setSortingParameter(double sortingParameter) {sortingParameter_ = sortingParameter;}
+    //! Takes ownership and sets this as measurement's trackPoint
+    void addRawMeasurement(genfit::AbsMeasurement* rawMeasurement) {assert(rawMeasurement != nullptr); rawMeasurement->setTrackPoint(this); rawMeasurements_.push_back(rawMeasurement);}
+    void deleteRawMeasurements();
+    //! Takes Ownership
+    void setFitterInfo(genfit::AbsFitterInfo* fitterInfo);
+    void deleteFitterInfo(const AbsTrackRep* rep) {delete fitterInfos_[rep]; fitterInfos_.erase(rep);}
 
-  //! Can be more than one, e.g. multiple measurements in the same Si detector, left and right measurements of a wire detector etc.
-  std::vector<AbsMeasurement*> rawMeasurements_; // Ownership
+    void setScatterer(ThinScatterer* scatterer) {thinScatterer_.reset(scatterer);}
 
-  std::map< const AbsTrackRep*, AbsFitterInfo* > fitterInfos_; //! Ownership over FitterInfos
+    void Print(const Option_t* = "") const;
 
-  /**
-   * The following map is read while streaming.  After reading the
-   * TrackPoint, the Track's streamer will call fixupRepsForReading,
-   * and this map will be translated into the map fitterInfos. The
-   * map is indexed by the ids of the corresponding TrackReps.
-   */
-  std::map<unsigned int, AbsFitterInfo*> vFitterInfos_; //!
+    /**
+     * This function is used when reading the TrackPoint and is called
+     * by the owner in order to build fitterInfos_ from vFitterInfos_.
+     * This requires that the track_ be set.  It also empties
+     * vFitterInfos_ which has served its purpose after this function is
+     * called.
+     */
+    void fixupRepsForReading();
 
-  std::unique_ptr<ThinScatterer> thinScatterer_; // Ownership
+  private:
+    double sortingParameter_;
 
- public:
+    //! Pointer to Track where TrackPoint belongs to
+    Track* track_; //! No ownership
 
-  ClassDef(TrackPoint,1)
+    //! Can be more than one, e.g. multiple measurements in the same Si detector, left and right measurements of a wire detector etc.
+    std::vector<AbsMeasurement*> rawMeasurements_; // Ownership
 
-};
+    std::map< const AbsTrackRep*, AbsFitterInfo* > fitterInfos_; //! Ownership over FitterInfos
+
+    /**
+     * The following map is read while streaming.  After reading the
+     * TrackPoint, the Track's streamer will call fixupRepsForReading,
+     * and this map will be translated into the map fitterInfos. The
+     * map is indexed by the ids of the corresponding TrackReps.
+     */
+    std::map<unsigned int, AbsFitterInfo*> vFitterInfos_; //!
+
+    std::unique_ptr<ThinScatterer> thinScatterer_; // Ownership
+
+  public:
+
+    ClassDef(TrackPoint, 1)
+
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/core/src/AbsFitter.cc
+++ b/core/src/AbsFitter.cc
@@ -22,18 +22,19 @@
 
 namespace genfit {
 
-void AbsFitter::processTrack(Track* tr, bool resortHits) {
-  AbsTrackRep* cardRep = tr->getCardinalRep();
-  // process cardinal rep first
-  processTrackWithRep(tr, cardRep, resortHits);
+  void AbsFitter::processTrack(Track* tr, bool resortHits)
+  {
+    AbsTrackRep* cardRep = tr->getCardinalRep();
+    // process cardinal rep first
+    processTrackWithRep(tr, cardRep, resortHits);
 
-  // now process rest of reps, but don't change sorting anymore!
-  for (unsigned int i=0; i<tr->getNumReps(); ++i) {
-    if (tr->getTrackRep(i) != cardRep)
-      processTrackWithRep(tr, tr->getTrackRep(i), false);
+    // now process rest of reps, but don't change sorting anymore!
+    for (unsigned int i = 0; i < tr->getNumReps(); ++i) {
+      if (tr->getTrackRep(i) != cardRep)
+        processTrackWithRep(tr, tr->getTrackRep(i), false);
+    }
+
+    tr->checkConsistency();
   }
-
-  tr->checkConsistency();
-}
 
 } /* End of namespace genfit */

--- a/core/src/AbsFitterInfo.cc
+++ b/core/src/AbsFitterInfo.cc
@@ -24,37 +24,38 @@
 
 namespace genfit {
 
-AbsFitterInfo::AbsFitterInfo() :
-  trackPoint_(nullptr),
-  rep_(nullptr)
-{
-  ;
-}
+  AbsFitterInfo::AbsFitterInfo() :
+    trackPoint_(nullptr),
+    rep_(nullptr)
+  {
+    ;
+  }
 
-AbsFitterInfo::AbsFitterInfo(const TrackPoint* trackPoint, const AbsTrackRep* rep) :
-  trackPoint_(trackPoint),
-  rep_(rep)
-{
-  ;
-}
+  AbsFitterInfo::AbsFitterInfo(const TrackPoint* trackPoint, const AbsTrackRep* rep) :
+    trackPoint_(trackPoint),
+    rep_(rep)
+  {
+    ;
+  }
 
-void AbsFitterInfo::Streamer(TBuffer &R__b)
-{
-   // Stream an object of class genfit::AbsFitterInfo.
-   //This works around a msvc bug and should be harmless on other platforms
-   typedef ::genfit::AbsFitterInfo thisClass;
-   UInt_t R__s, R__c;
-   if (R__b.IsReading()) {
-      Version_t R__v = R__b.ReadVersion(&R__s, &R__c); if (R__v) { }
+  void AbsFitterInfo::Streamer(TBuffer& R__b)
+  {
+    // Stream an object of class genfit::AbsFitterInfo.
+    //This works around a msvc bug and should be harmless on other platforms
+    typedef ::genfit::AbsFitterInfo thisClass;
+    UInt_t R__s, R__c;
+    if (R__b.IsReading()) {
+      Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+      if (R__v) { }
       //TObject::Streamer(R__b);
       // See the long comment in AbsFinitePlane::Streamer.  This
       // creates a duplicate of the DetPlane.
       TClass* cl = TClass::Load(R__b);
-      DetPlane *p = (DetPlane*)(cl->New());
+      DetPlane* p = (DetPlane*)(cl->New());
       cl->Streamer(p, R__b);
       sharedPlane_.reset(p);
       R__b.CheckByteCount(R__s, R__c, thisClass::IsA());
-   } else {
+    } else {
       R__c = R__b.WriteVersion(thisClass::IsA(), kTRUE);
       //TObject::Streamer(R__b);
       // See the long comment in AbsFinitePlane::Streamer.  This
@@ -63,7 +64,7 @@ void AbsFitterInfo::Streamer(TBuffer &R__b)
       sharedPlane_->IsA()->Store(R__b);
       sharedPlane_->Streamer(R__b);
       R__b.SetByteCount(R__c, kTRUE);
-   }
-}
+    }
+  }
 
 } /* End of namespace genfit */

--- a/core/src/AbsMeasurement.cc
+++ b/core/src/AbsMeasurement.cc
@@ -25,43 +25,46 @@
 
 namespace genfit {
 
-AbsMeasurement::AbsMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId, TrackPoint* trackPoint)
-  : rawHitCoords_(rawHitCoords), rawHitCov_(rawHitCov), detId_(detId), hitId_(hitId), trackPoint_(trackPoint)
-{
-  assert(rawHitCov_.GetNrows() == rawHitCoords_.GetNrows());
-}
+  AbsMeasurement::AbsMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId,
+                                 TrackPoint* trackPoint)
+    : rawHitCoords_(rawHitCoords), rawHitCov_(rawHitCov), detId_(detId), hitId_(hitId), trackPoint_(trackPoint)
+  {
+    assert(rawHitCov_.GetNrows() == rawHitCoords_.GetNrows());
+  }
 
 
-AbsMeasurement::AbsMeasurement(const AbsMeasurement& o)
-  : TObject(o),
-    rawHitCoords_(o.rawHitCoords_),
-    rawHitCov_(o.rawHitCov_),
-    detId_(o.detId_),
-    hitId_(o.hitId_),
-    trackPoint_(o.trackPoint_)
-{
-  ;
-}
+  AbsMeasurement::AbsMeasurement(const AbsMeasurement& o)
+    : TObject(o),
+      rawHitCoords_(o.rawHitCoords_),
+      rawHitCov_(o.rawHitCov_),
+      detId_(o.detId_),
+      hitId_(o.hitId_),
+      trackPoint_(o.trackPoint_)
+  {
+    ;
+  }
 
 
-AbsMeasurement::~AbsMeasurement()
-{
-  ;
-}
+  AbsMeasurement::~AbsMeasurement()
+  {
+    ;
+  }
 
 
-AbsMeasurement& AbsMeasurement::operator=(const AbsMeasurement&) {
-  fputs ("must not call AbsMeasurement::operator=\n",stderr);
-  abort();
-  return *this;
-}
+  AbsMeasurement& AbsMeasurement::operator=(const AbsMeasurement&)
+  {
+    fputs("must not call AbsMeasurement::operator=\n", stderr);
+    abort();
+    return *this;
+  }
 
 
-void AbsMeasurement::Print(const Option_t*) const {
-  printOut << "genfit::AbsMeasurement, detId = " << detId_ << ". hitId = " << hitId_ << "\n";
-  printOut << "Raw hit coordinates: "; rawHitCoords_.Print();
-  printOut << "Raw hit covariance: "; rawHitCov_.Print();
-}
+  void AbsMeasurement::Print(const Option_t*) const
+  {
+    printOut << "genfit::AbsMeasurement, detId = " << detId_ << ". hitId = " << hitId_ << "\n";
+    printOut << "Raw hit coordinates: "; rawHitCoords_.Print();
+    printOut << "Raw hit covariance: "; rawHitCov_.Print();
+  }
 
 
 } /* End of namespace genfit */

--- a/core/src/AbsTrackRep.cc
+++ b/core/src/AbsTrackRep.cc
@@ -28,172 +28,180 @@
 
 namespace genfit {
 
-AbsTrackRep::AbsTrackRep() :
-  pdgCode_(0), propDir_(0), debugLvl_(0)
-{
-  ;
-}
+  AbsTrackRep::AbsTrackRep() :
+    pdgCode_(0), propDir_(0), debugLvl_(0)
+  {
+    ;
+  }
 
-AbsTrackRep::AbsTrackRep(int pdgCode, char propDir) :
-  pdgCode_(pdgCode), propDir_(propDir), debugLvl_(0)
-{
-  ;
-}
+  AbsTrackRep::AbsTrackRep(int pdgCode, char propDir) :
+    pdgCode_(pdgCode), propDir_(propDir), debugLvl_(0)
+  {
+    ;
+  }
 
-AbsTrackRep::AbsTrackRep(const AbsTrackRep& rep) :
-  TObject(rep), pdgCode_(rep.pdgCode_), propDir_(rep.propDir_), debugLvl_(rep.debugLvl_)
-{
-  ;
-}
-
-
-double AbsTrackRep::extrapolateToMeasurement(StateOnPlane& state,
-    const AbsMeasurement* measurement,
-    bool stopAtBoundary,
-    bool calcJacobianNoise) const {
-
-  return this->extrapolateToPlane(state, measurement->constructPlane(state), stopAtBoundary, calcJacobianNoise);
-}
+  AbsTrackRep::AbsTrackRep(const AbsTrackRep& rep) :
+    TObject(rep), pdgCode_(rep.pdgCode_), propDir_(rep.propDir_), debugLvl_(rep.debugLvl_)
+  {
+    ;
+  }
 
 
-TVectorD AbsTrackRep::get6DState(const StateOnPlane& state) const {
-  TVector3 pos, mom;
-  getPosMom(state, pos, mom);
+  double AbsTrackRep::extrapolateToMeasurement(StateOnPlane& state,
+                                               const AbsMeasurement* measurement,
+                                               bool stopAtBoundary,
+                                               bool calcJacobianNoise) const
+  {
 
-  TVectorD stateVec(6);
-
-  stateVec(0) = pos.X();
-  stateVec(1) = pos.Y();
-  stateVec(2) = pos.Z();
-
-  stateVec(3) = mom.X();
-  stateVec(4) = mom.Y();
-  stateVec(5) = mom.Z();
-
-  return stateVec;
-}
+    return this->extrapolateToPlane(state, measurement->constructPlane(state), stopAtBoundary, calcJacobianNoise);
+  }
 
 
-void AbsTrackRep::get6DStateCov(const MeasuredStateOnPlane& state, TVectorD& stateVec, TMatrixDSym& cov) const {
-  TVector3 pos, mom;
-  getPosMomCov(state, pos, mom, cov);
+  TVectorD AbsTrackRep::get6DState(const StateOnPlane& state) const
+  {
+    TVector3 pos, mom;
+    getPosMom(state, pos, mom);
 
-  stateVec.ResizeTo(6);
+    TVectorD stateVec(6);
 
-  stateVec(0) = pos.X();
-  stateVec(1) = pos.Y();
-  stateVec(2) = pos.Z();
+    stateVec(0) = pos.X();
+    stateVec(1) = pos.Y();
+    stateVec(2) = pos.Z();
 
-  stateVec(3) = mom.X();
-  stateVec(4) = mom.Y();
-  stateVec(5) = mom.Z();
-}
+    stateVec(3) = mom.X();
+    stateVec(4) = mom.Y();
+    stateVec(5) = mom.Z();
 
-
-double AbsTrackRep::getPDGCharge() const {
-  TParticlePDG* particle = TDatabasePDG::Instance()->GetParticle(pdgCode_);
-  assert(particle != nullptr);
-  return particle->Charge()/(3.);
-}
+    return stateVec;
+  }
 
 
-double AbsTrackRep::getMass(const StateOnPlane& /*state*/) const {
-  return TDatabasePDG::Instance()->GetParticle(pdgCode_)->Mass();
-}
+  void AbsTrackRep::get6DStateCov(const MeasuredStateOnPlane& state, TVectorD& stateVec, TMatrixDSym& cov) const
+  {
+    TVector3 pos, mom;
+    getPosMomCov(state, pos, mom, cov);
+
+    stateVec.ResizeTo(6);
+
+    stateVec(0) = pos.X();
+    stateVec(1) = pos.Y();
+    stateVec(2) = pos.Z();
+
+    stateVec(3) = mom.X();
+    stateVec(4) = mom.Y();
+    stateVec(5) = mom.Z();
+  }
 
 
-void AbsTrackRep::calcJacobianNumerically(const genfit::StateOnPlane& origState,
-                                               const genfit::SharedPlanePtr destPlane,
-                                               TMatrixD& jacobian) const {
+  double AbsTrackRep::getPDGCharge() const
+  {
+    TParticlePDG* particle = TDatabasePDG::Instance()->GetParticle(pdgCode_);
+    assert(particle != nullptr);
+    return particle->Charge() / (3.);
+  }
 
-  // Find the transport matrix for track propagation from origState to destPlane
-  // I.e. this finds
-  //            d stateDestPlane / d origState |_origState
 
-  jacobian.ResizeTo(getDim(), getDim());
+  double AbsTrackRep::getMass(const StateOnPlane& /*state*/) const
+  {
+    return TDatabasePDG::Instance()->GetParticle(pdgCode_)->Mass();
+  }
 
-  // no science behind these values, I verified that forward and
-  // backward propagation yield inverse matrices to good
-  // approximation.  In order to avoid bad roundoff errors, the actual
-  // step taken is determined below, separately for each direction.
-  const double defaultStepX = 1.E-5;
-  double stepX;
 
-  // Calculate derivative for all three dimensions successively.
-  // The algorithm follows the one in TF1::Derivative() :
-  //   df(x) = (4 D(h/2) - D(h)) / 3
-  // with D(h) = (f(x + h) - f(x - h)) / (2 h).
-  //
-  // Could perhaps do better by also using f(x) which would be stB.
-  TVectorD rightShort(getDim()), rightFull(getDim());
-  TVectorD leftShort(getDim()), leftFull(getDim());
-  for (size_t i = 0; i < getDim(); ++i) {
-    {
-      genfit::StateOnPlane stateCopy(origState);
-      double temp = stateCopy.getState()(i) + defaultStepX / 2;
-      // Find the actual size of the step, which will differ from
-      // defaultStepX due to roundoff.  This is the step-size we will
-      // use for this direction.  Idea taken from Numerical Recipes,
-      // 3rd ed., section 5.7.
-      //
-      // Note that if a number is exactly representable, it's double
-      // will also be exact.  Outside denormals, this also holds for
-      // halving.  Unless the exponent changes (which it only will in
-      // the vicinity of zero) adding or subtracing doesn't make a
-      // difference.
-      //
-      // We determine the roundoff error for the half-step.  If this
-      // is exactly representable, the full step will also be.
-      stepX = 2 * (temp - stateCopy.getState()(i));
-      (stateCopy.getState())(i) = temp;
-      extrapolateToPlane(stateCopy, destPlane);
-      rightShort = stateCopy.getState();
-    }
-    {
-      genfit::StateOnPlane stateCopy(origState);
-      (stateCopy.getState())(i) -= stepX / 2;
-      extrapolateToPlane(stateCopy, destPlane);
-      leftShort = stateCopy.getState();
-    }
-    {
-      genfit::StateOnPlane stateCopy(origState);
-      (stateCopy.getState())(i) += stepX;
-      extrapolateToPlane(stateCopy, destPlane);
-      rightFull = stateCopy.getState();
-    }
-    {
-      genfit::StateOnPlane stateCopy(origState);
-      (stateCopy.getState())(i) -= stepX;
-      extrapolateToPlane(stateCopy, destPlane);
-      leftFull = stateCopy.getState();
-    }
+  void AbsTrackRep::calcJacobianNumerically(const genfit::StateOnPlane& origState,
+                                            const genfit::SharedPlanePtr destPlane,
+                                            TMatrixD& jacobian) const
+  {
 
-    // Calculate the derivatives for the individual components of
-    // the track parameters.
-    for (size_t j = 0; j < getDim(); ++j) {
-      double derivFull = (rightFull(j) - leftFull(j)) / 2 / stepX;
-      double derivShort = (rightShort(j) - leftShort(j)) / stepX;
+    // Find the transport matrix for track propagation from origState to destPlane
+    // I.e. this finds
+    //            d stateDestPlane / d origState |_origState
 
-      jacobian(j, i) = 1./3.*(4*derivShort - derivFull);
+    jacobian.ResizeTo(getDim(), getDim());
+
+    // no science behind these values, I verified that forward and
+    // backward propagation yield inverse matrices to good
+    // approximation.  In order to avoid bad roundoff errors, the actual
+    // step taken is determined below, separately for each direction.
+    const double defaultStepX = 1.E-5;
+    double stepX;
+
+    // Calculate derivative for all three dimensions successively.
+    // The algorithm follows the one in TF1::Derivative() :
+    //   df(x) = (4 D(h/2) - D(h)) / 3
+    // with D(h) = (f(x + h) - f(x - h)) / (2 h).
+    //
+    // Could perhaps do better by also using f(x) which would be stB.
+    TVectorD rightShort(getDim()), rightFull(getDim());
+    TVectorD leftShort(getDim()), leftFull(getDim());
+    for (size_t i = 0; i < getDim(); ++i) {
+      {
+        genfit::StateOnPlane stateCopy(origState);
+        double temp = stateCopy.getState()(i) + defaultStepX / 2;
+        // Find the actual size of the step, which will differ from
+        // defaultStepX due to roundoff.  This is the step-size we will
+        // use for this direction.  Idea taken from Numerical Recipes,
+        // 3rd ed., section 5.7.
+        //
+        // Note that if a number is exactly representable, it's double
+        // will also be exact.  Outside denormals, this also holds for
+        // halving.  Unless the exponent changes (which it only will in
+        // the vicinity of zero) adding or subtracing doesn't make a
+        // difference.
+        //
+        // We determine the roundoff error for the half-step.  If this
+        // is exactly representable, the full step will also be.
+        stepX = 2 * (temp - stateCopy.getState()(i));
+        (stateCopy.getState())(i) = temp;
+        extrapolateToPlane(stateCopy, destPlane);
+        rightShort = stateCopy.getState();
+      }
+      {
+        genfit::StateOnPlane stateCopy(origState);
+        (stateCopy.getState())(i) -= stepX / 2;
+        extrapolateToPlane(stateCopy, destPlane);
+        leftShort = stateCopy.getState();
+      }
+      {
+        genfit::StateOnPlane stateCopy(origState);
+        (stateCopy.getState())(i) += stepX;
+        extrapolateToPlane(stateCopy, destPlane);
+        rightFull = stateCopy.getState();
+      }
+      {
+        genfit::StateOnPlane stateCopy(origState);
+        (stateCopy.getState())(i) -= stepX;
+        extrapolateToPlane(stateCopy, destPlane);
+        leftFull = stateCopy.getState();
+      }
+
+      // Calculate the derivatives for the individual components of
+      // the track parameters.
+      for (size_t j = 0; j < getDim(); ++j) {
+        double derivFull = (rightFull(j) - leftFull(j)) / 2 / stepX;
+        double derivShort = (rightShort(j) - leftShort(j)) / stepX;
+
+        jacobian(j, i) = 1. / 3.*(4 * derivShort - derivFull);
+      }
     }
   }
-}
 
 
-bool AbsTrackRep::switchPDGSign() {
-  TParticlePDG* particle = TDatabasePDG::Instance()->GetParticle(-pdgCode_);
-  if(particle != nullptr) {
-    pdgCode_ *= -1;
-    return true;
+  bool AbsTrackRep::switchPDGSign()
+  {
+    TParticlePDG* particle = TDatabasePDG::Instance()->GetParticle(-pdgCode_);
+    if (particle != nullptr) {
+      pdgCode_ *= -1;
+      return true;
+    }
+    return false;
   }
-  return false;
-}
 
 
 
-void AbsTrackRep::Print(const Option_t*) const {
-  printOut << "genfit::AbsTrackRep, pdgCode = " << pdgCode_ << ". PropDir = " << (int)propDir_ << "\n";
-}
+  void AbsTrackRep::Print(const Option_t*) const
+  {
+    printOut << "genfit::AbsTrackRep, pdgCode = " << pdgCode_ << ". PropDir = " << (int)propDir_ << "\n";
+  }
 
 
 } /* End of namespace genfit */

--- a/core/src/DetPlane.cc
+++ b/core/src/DetPlane.cc
@@ -29,320 +29,337 @@
 namespace genfit {
 
 
-DetPlane::DetPlane(AbsFinitePlane* finite)
-  :finitePlane_(finite)
-{
-  // default constructor
-  o_.SetXYZ(0.,0.,0.);
-  u_.SetXYZ(1.,0.,0.);
-  v_.SetXYZ(0.,1.,0.);
-  // sane() not needed here
-}
-
-
-DetPlane::DetPlane(const TVector3& o,
-                       const TVector3& u,
-                       const TVector3& v,
-                       AbsFinitePlane* finite)
-  :o_(o), u_(u), v_(v), finitePlane_(finite)
-{
-  sane();
-}
-
-DetPlane::DetPlane(const TVector3& o,
-                       const TVector3& n,
-                       AbsFinitePlane* finite)
-  :o_(o), finitePlane_(finite)
-{
-  setNormal(n);
-}
-
-
-DetPlane::~DetPlane(){
-  ;
-}
-
-
-DetPlane::DetPlane(const DetPlane& rhs) :
-  TObject(rhs),
-  o_(rhs.o_),
-  u_(rhs.u_),
-  v_(rhs.v_)
-{
-  if(rhs.finitePlane_)
-    finitePlane_.reset(rhs.finitePlane_->clone());
-  else finitePlane_.reset();
-}
-
-
-DetPlane& DetPlane::operator=(DetPlane other) {
-  swap(other);
-  return *this;
-}
-
-
-void DetPlane::swap(DetPlane& other) {
-  // by swapping the members of two classes,
-  // the two classes are effectively swapped
-  std::swap(this->o_, other.o_);
-  std::swap(this->u_, other.u_);
-  std::swap(this->v_, other.v_);
-  this->finitePlane_.swap(other.finitePlane_);
-}
-
-
-void DetPlane::set(const TVector3& o,
-                const TVector3& u,
-                const TVector3& v)
-{
-  o_ = o;
-  u_ = u;
-  v_ = v;
-  sane();
-}
-
-
-void DetPlane::setO(const TVector3& o)
-{
-  o_ = o;
-}
-
-void DetPlane::setO(double X,double Y,double Z)
-{
-  o_.SetXYZ(X,Y,Z);
-}
-
-void DetPlane::setU(const TVector3& u)
-{
-  u_ = u;
-  sane(); // sets v_ perpendicular to u_
-}
-
-void DetPlane::setU(double X,double Y,double Z)
-{
-  u_.SetXYZ(X,Y,Z);
-  sane(); // sets v_ perpendicular to u_
-}
-
-void DetPlane::setV(const TVector3& v)
-{
-  v_ = v;
-  u_ = getNormal().Cross(v_);
-  u_ *= -1.;
-  sane();
-}
-
-void DetPlane::setV(double X,double Y,double Z)
-{
-  v_.SetXYZ(X,Y,Z);
-  u_ = getNormal().Cross(v_);
-  u_ *= -1.;
-  sane();
-}
-
-void DetPlane::setUV(const TVector3& u,const TVector3& v)
-{
-  u_ = u;
-  v_ = v;
-  sane();
-}
-
-void DetPlane::setON(const TVector3& o,const TVector3& n){
-  o_ = o;
-  setNormal(n);
-}
-
-
-TVector3 DetPlane::getNormal() const
-{
-  return u_.Cross(v_);
-}
-
-void DetPlane::setNormal(double X,double Y,double Z){
-  setNormal( TVector3(X,Y,Z) );
-}
-
-void DetPlane::setNormal(const TVector3& n){
-  u_ = n.Orthogonal();
-  v_ = n.Cross(u_);
-  u_.SetMag(1.);
-  v_.SetMag(1.);
-}
-
-void DetPlane::setNormal(const double& theta, const double& phi){
-  setNormal( TVector3(TMath::Sin(theta)*TMath::Cos(phi),TMath::Sin(theta)*TMath::Sin(phi),TMath::Cos(theta)) );
-}
-
-
-TVector2 DetPlane::project(const TVector3& x)const
-{
-  return TVector2(u_*x, v_*x);
-}
-
-
-TVector2 DetPlane::LabToPlane(const TVector3& x)const
-{
-  return project(x-o_);
-}
-
-
-TVector3 DetPlane::toLab(const TVector2& x)const
-{
-  TVector3 d(o_);
-  d += x.X()*u_;
-  d += x.Y()*v_;
-  return d;
-}
-
-
-TVector3 DetPlane::dist(const TVector3& x)const
-{
-  return toLab(LabToPlane(x)) - x;
-}
-
-
-void DetPlane::sane(){
-  assert(u_!=v_);
-
-  // ensure unit vectors
-  u_.SetMag(1.);
-  v_.SetMag(1.);
-
-  // check if already orthogonal
-  if (u_.Dot(v_) < 1.E-5) return;
-
-  // ensure orthogonal system
-  v_ = getNormal().Cross(u_);
-}
-
-
-void DetPlane::Print(const Option_t* option) const
-{
-  printOut<<"DetPlane: "
-     <<"O("<<o_.X()<<", "<<o_.Y()<<", "<<o_.Z()<<") "
-     <<"u("<<u_.X()<<", "<<u_.Y()<<", "<<u_.Z()<<") "
-     <<"v("<<v_.X()<<", "<<v_.Y()<<", "<<v_.Z()<<") "
-     <<"n("<<getNormal().X()<<", "<<getNormal().Y()<<", "<<getNormal().Z()<<") "
-       <<std::endl;
-  if(finitePlane_ != nullptr) {
-    finitePlane_->Print(option);
+  DetPlane::DetPlane(AbsFinitePlane* finite)
+    : finitePlane_(finite)
+  {
+    // default constructor
+    o_.SetXYZ(0., 0., 0.);
+    u_.SetXYZ(1., 0., 0.);
+    v_.SetXYZ(0., 1., 0.);
+    // sane() not needed here
   }
 
-}
+
+  DetPlane::DetPlane(const TVector3& o,
+                     const TVector3& u,
+                     const TVector3& v,
+                     AbsFinitePlane* finite)
+    : o_(o), u_(u), v_(v), finitePlane_(finite)
+  {
+    sane();
+  }
+
+  DetPlane::DetPlane(const TVector3& o,
+                     const TVector3& n,
+                     AbsFinitePlane* finite)
+    : o_(o), finitePlane_(finite)
+  {
+    setNormal(n);
+  }
 
 
-/*
-  I could write pages of comments about correct equality checking for
-  floating point numbers, but: When two planes are as close as 10E-5 cm
-  in all nine numbers that define the plane, this will be enough for all
-  practical purposes
- */
-bool operator== (const DetPlane& lhs, const DetPlane& rhs){
-  if (&lhs == &rhs)
+  DetPlane::~DetPlane()
+  {
+    ;
+  }
+
+
+  DetPlane::DetPlane(const DetPlane& rhs) :
+    TObject(rhs),
+    o_(rhs.o_),
+    u_(rhs.u_),
+    v_(rhs.v_)
+  {
+    if (rhs.finitePlane_)
+      finitePlane_.reset(rhs.finitePlane_->clone());
+    else finitePlane_.reset();
+  }
+
+
+  DetPlane& DetPlane::operator=(DetPlane other)
+  {
+    swap(other);
+    return *this;
+  }
+
+
+  void DetPlane::swap(DetPlane& other)
+  {
+    // by swapping the members of two classes,
+    // the two classes are effectively swapped
+    std::swap(this->o_, other.o_);
+    std::swap(this->u_, other.u_);
+    std::swap(this->v_, other.v_);
+    this->finitePlane_.swap(other.finitePlane_);
+  }
+
+
+  void DetPlane::set(const TVector3& o,
+                     const TVector3& u,
+                     const TVector3& v)
+  {
+    o_ = o;
+    u_ = u;
+    v_ = v;
+    sane();
+  }
+
+
+  void DetPlane::setO(const TVector3& o)
+  {
+    o_ = o;
+  }
+
+  void DetPlane::setO(double X, double Y, double Z)
+  {
+    o_.SetXYZ(X, Y, Z);
+  }
+
+  void DetPlane::setU(const TVector3& u)
+  {
+    u_ = u;
+    sane(); // sets v_ perpendicular to u_
+  }
+
+  void DetPlane::setU(double X, double Y, double Z)
+  {
+    u_.SetXYZ(X, Y, Z);
+    sane(); // sets v_ perpendicular to u_
+  }
+
+  void DetPlane::setV(const TVector3& v)
+  {
+    v_ = v;
+    u_ = getNormal().Cross(v_);
+    u_ *= -1.;
+    sane();
+  }
+
+  void DetPlane::setV(double X, double Y, double Z)
+  {
+    v_.SetXYZ(X, Y, Z);
+    u_ = getNormal().Cross(v_);
+    u_ *= -1.;
+    sane();
+  }
+
+  void DetPlane::setUV(const TVector3& u, const TVector3& v)
+  {
+    u_ = u;
+    v_ = v;
+    sane();
+  }
+
+  void DetPlane::setON(const TVector3& o, const TVector3& n)
+  {
+    o_ = o;
+    setNormal(n);
+  }
+
+
+  TVector3 DetPlane::getNormal() const
+  {
+    return u_.Cross(v_);
+  }
+
+  void DetPlane::setNormal(double X, double Y, double Z)
+  {
+    setNormal(TVector3(X, Y, Z));
+  }
+
+  void DetPlane::setNormal(const TVector3& n)
+  {
+    u_ = n.Orthogonal();
+    v_ = n.Cross(u_);
+    u_.SetMag(1.);
+    v_.SetMag(1.);
+  }
+
+  void DetPlane::setNormal(const double& theta, const double& phi)
+  {
+    setNormal(TVector3(TMath::Sin(theta)*TMath::Cos(phi), TMath::Sin(theta)*TMath::Sin(phi), TMath::Cos(theta)));
+  }
+
+
+  TVector2 DetPlane::project(const TVector3& x)const
+  {
+    return TVector2(u_ * x, v_ * x);
+  }
+
+
+  TVector2 DetPlane::LabToPlane(const TVector3& x)const
+  {
+    return project(x - o_);
+  }
+
+
+  TVector3 DetPlane::toLab(const TVector2& x)const
+  {
+    TVector3 d(o_);
+    d += x.X() * u_;
+    d += x.Y() * v_;
+    return d;
+  }
+
+
+  TVector3 DetPlane::dist(const TVector3& x)const
+  {
+    return toLab(LabToPlane(x)) - x;
+  }
+
+
+  void DetPlane::sane()
+  {
+    assert(u_ != v_);
+
+    // ensure unit vectors
+    u_.SetMag(1.);
+    v_.SetMag(1.);
+
+    // check if already orthogonal
+    if (u_.Dot(v_) < 1.E-5) return;
+
+    // ensure orthogonal system
+    v_ = getNormal().Cross(u_);
+  }
+
+
+  void DetPlane::Print(const Option_t* option) const
+  {
+    printOut << "DetPlane: "
+             << "O(" << o_.X() << ", " << o_.Y() << ", " << o_.Z() << ") "
+             << "u(" << u_.X() << ", " << u_.Y() << ", " << u_.Z() << ") "
+             << "v(" << v_.X() << ", " << v_.Y() << ", " << v_.Z() << ") "
+             << "n(" << getNormal().X() << ", " << getNormal().Y() << ", " << getNormal().Z() << ") "
+             << std::endl;
+    if (finitePlane_ != nullptr) {
+      finitePlane_->Print(option);
+    }
+
+  }
+
+
+  /*
+    I could write pages of comments about correct equality checking for
+    floating point numbers, but: When two planes are as close as 10E-5 cm
+    in all nine numbers that define the plane, this will be enough for all
+    practical purposes
+   */
+  bool operator== (const DetPlane& lhs, const DetPlane& rhs)
+  {
+    if (&lhs == &rhs)
+      return true;
+    static const double detplaneEpsilon = 1.E-5;
+    if (
+      fabs((lhs.o_.X() - rhs.o_.X())) > detplaneEpsilon  ||
+      fabs((lhs.o_.Y() - rhs.o_.Y())) > detplaneEpsilon  ||
+      fabs((lhs.o_.Z() - rhs.o_.Z())) > detplaneEpsilon
+    ) return false;
+    else if (
+      fabs((lhs.u_.X() - rhs.u_.X())) > detplaneEpsilon  ||
+      fabs((lhs.u_.Y() - rhs.u_.Y())) > detplaneEpsilon  ||
+      fabs((lhs.u_.Z() - rhs.u_.Z())) > detplaneEpsilon
+    ) return false;
+    else if (
+      fabs((lhs.v_.X() - rhs.v_.X())) > detplaneEpsilon  ||
+      fabs((lhs.v_.Y() - rhs.v_.Y())) > detplaneEpsilon  ||
+      fabs((lhs.v_.Z() - rhs.v_.Z())) > detplaneEpsilon
+    ) return false;
     return true;
-  static const double detplaneEpsilon = 1.E-5;
-  if(
-     fabs( (lhs.o_.X()-rhs.o_.X()) ) > detplaneEpsilon  ||
-     fabs( (lhs.o_.Y()-rhs.o_.Y()) ) > detplaneEpsilon  ||
-     fabs( (lhs.o_.Z()-rhs.o_.Z()) ) > detplaneEpsilon
-     ) return false;
-  else if(
-    fabs( (lhs.u_.X()-rhs.u_.X()) ) > detplaneEpsilon  ||
-    fabs( (lhs.u_.Y()-rhs.u_.Y()) ) > detplaneEpsilon  ||
-    fabs( (lhs.u_.Z()-rhs.u_.Z()) ) > detplaneEpsilon
-    ) return false;
-  else if(
-    fabs( (lhs.v_.X()-rhs.v_.X()) ) > detplaneEpsilon  ||
-    fabs( (lhs.v_.Y()-rhs.v_.Y()) ) > detplaneEpsilon  ||
-    fabs( (lhs.v_.Z()-rhs.v_.Z()) ) > detplaneEpsilon
-    ) return false;
-  return true;
-}
-
-bool operator!= (const DetPlane& lhs, const DetPlane& rhs){
-  return !(lhs==rhs);
-}
-
-
-double DetPlane::distance(const TVector3& point) const {
-  // |(point - o_)*(u_ x v_)|
-  return fabs( (point.X()-o_.X()) * (u_.Y()*v_.Z() - u_.Z()*v_.Y()) +
-               (point.Y()-o_.Y()) * (u_.Z()*v_.X() - u_.X()*v_.Z()) +
-               (point.Z()-o_.Z()) * (u_.X()*v_.Y() - u_.Y()*v_.X()));
-}
-
-double DetPlane::distance(double x, double y, double z) const {
-  // |(point - o_)*(u_ x v_)|
-  return fabs( (x-o_.X()) * (u_.Y()*v_.Z() - u_.Z()*v_.Y()) +
-               (y-o_.Y()) * (u_.Z()*v_.X() - u_.X()*v_.Z()) +
-               (z-o_.Z()) * (u_.X()*v_.Y() - u_.Y()*v_.X()));
-}
-
-
-TVector2 DetPlane::straightLineToPlane (const TVector3& point, const TVector3& dir) const {
-  TVector3 dirNorm(dir.Unit());
-  TVector3 normal = getNormal();
-  double dirTimesN = dirNorm*normal;
-  if(fabs(dirTimesN)<1.E-6){//straight line is parallel to plane, so return infinity
-    return TVector2(1.E100,1.E100);
   }
-  double t = 1./dirTimesN * ((o_-point)*normal);
-  return project(point - o_ + t * dirNorm);
-}
+
+  bool operator!= (const DetPlane& lhs, const DetPlane& rhs)
+  {
+    return !(lhs == rhs);
+  }
+
+
+  double DetPlane::distance(const TVector3& point) const
+  {
+    // |(point - o_)*(u_ x v_)|
+    return fabs((point.X() - o_.X()) * (u_.Y() * v_.Z() - u_.Z() * v_.Y()) +
+                (point.Y() - o_.Y()) * (u_.Z() * v_.X() - u_.X() * v_.Z()) +
+                (point.Z() - o_.Z()) * (u_.X() * v_.Y() - u_.Y() * v_.X()));
+  }
+
+  double DetPlane::distance(double x, double y, double z) const
+  {
+    // |(point - o_)*(u_ x v_)|
+    return fabs((x - o_.X()) * (u_.Y() * v_.Z() - u_.Z() * v_.Y()) +
+                (y - o_.Y()) * (u_.Z() * v_.X() - u_.X() * v_.Z()) +
+                (z - o_.Z()) * (u_.X() * v_.Y() - u_.Y() * v_.X()));
+  }
+
+
+  TVector2 DetPlane::straightLineToPlane(const TVector3& point, const TVector3& dir) const
+  {
+    TVector3 dirNorm(dir.Unit());
+    TVector3 normal = getNormal();
+    double dirTimesN = dirNorm * normal;
+    if (fabs(dirTimesN) < 1.E-6) { //straight line is parallel to plane, so return infinity
+      return TVector2(1.E100, 1.E100);
+    }
+    double t = 1. / dirTimesN * ((o_ - point) * normal);
+    return project(point - o_ + t * dirNorm);
+  }
 
 
 //! gives u,v coordinates of the intersection point of a straight line with plane
-void DetPlane::straightLineToPlane(const double& posX, const double& posY, const double& posZ,
-                                   const double& dirX, const double& dirY, const double& dirZ,
-                                   double& u, double& v) const {
+  void DetPlane::straightLineToPlane(const double& posX, const double& posY, const double& posZ,
+                                     const double& dirX, const double& dirY, const double& dirZ,
+                                     double& u, double& v) const
+  {
 
-  TVector3 W = getNormal();
-  double dirTimesN = dirX*W.X() + dirY*W.Y() + dirZ*W.Z();
-  if(fabs(dirTimesN)<1.E-6){//straight line is parallel to plane, so return infinity
-    u = 1.E100;
-    v = 1.E100;
-    return;
+    TVector3 W = getNormal();
+    double dirTimesN = dirX * W.X() + dirY * W.Y() + dirZ * W.Z();
+    if (fabs(dirTimesN) < 1.E-6) { //straight line is parallel to plane, so return infinity
+      u = 1.E100;
+      v = 1.E100;
+      return;
+    }
+    double t = 1. / dirTimesN * ((o_.X() - posX) * W.X() +
+                                 (o_.Y() - posY) * W.Y() +
+                                 (o_.Z() - posZ) * W.Z());
+
+    double posOnPlaneX = posX - o_.X() + t * dirX;
+    double posOnPlaneY = posY - o_.Y() + t * dirY;
+    double posOnPlaneZ = posZ - o_.Z() + t * dirZ;
+
+    u = u_.X() * posOnPlaneX + u_.Y() * posOnPlaneY + u_.Z() * posOnPlaneZ;
+    v = v_.X() * posOnPlaneX + v_.Y() * posOnPlaneY + v_.Z() * posOnPlaneZ;
   }
-  double t = 1./dirTimesN * ((o_.X()-posX)*W.X() +
-                             (o_.Y()-posY)*W.Y() +
-                             (o_.Z()-posZ)*W.Z());
-
-  double posOnPlaneX = posX-o_.X() + t*dirX;
-  double posOnPlaneY = posY-o_.Y() + t*dirY;
-  double posOnPlaneZ = posZ-o_.Z() + t*dirZ;
-
-  u = u_.X()*posOnPlaneX + u_.Y()*posOnPlaneY + u_.Z()*posOnPlaneZ;
-  v = v_.X()*posOnPlaneX + v_.Y()*posOnPlaneY + v_.Z()*posOnPlaneZ;
-}
 
 
-void DetPlane::rotate(double angle) {
-  TVector3 normal = getNormal();
-  u_.Rotate(angle, normal);
-  v_.Rotate(angle, normal);
+  void DetPlane::rotate(double angle)
+  {
+    TVector3 normal = getNormal();
+    u_.Rotate(angle, normal);
+    v_.Rotate(angle, normal);
 
-  sane();
-}
-
-
-void DetPlane::reset() {
-  o_.SetXYZ(0.,0.,0.);
-  u_.SetXYZ(1.,0.,0.);
-  v_.SetXYZ(0.,1.,0.);
-  finitePlane_.reset();
-}
+    sane();
+  }
 
 
-void DetPlane::Streamer(TBuffer &R__b)
-{
-   // Stream an object of class genfit::DetPlane.
-   // This is modified from the streamer generated by ROOT in order to 
-   // account for the scoped_ptr.
-   //This works around a msvc bug and should be harmless on other platforms
-   typedef ::genfit::DetPlane thisClass;
-   UInt_t R__s, R__c;
-   if (R__b.IsReading()) {
-      Version_t R__v = R__b.ReadVersion(&R__s, &R__c); if (R__v) { }
+  void DetPlane::reset()
+  {
+    o_.SetXYZ(0., 0., 0.);
+    u_.SetXYZ(1., 0., 0.);
+    v_.SetXYZ(0., 1., 0.);
+    finitePlane_.reset();
+  }
+
+
+  void DetPlane::Streamer(TBuffer& R__b)
+  {
+    // Stream an object of class genfit::DetPlane.
+    // This is modified from the streamer generated by ROOT in order to
+    // account for the scoped_ptr.
+    //This works around a msvc bug and should be harmless on other platforms
+    typedef ::genfit::DetPlane thisClass;
+    UInt_t R__s, R__c;
+    if (R__b.IsReading()) {
+      Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+      if (R__v) { }
       //TObject::Streamer(R__b);
       o_.Streamer(R__b);
       u_.Streamer(R__b);
@@ -350,16 +367,16 @@ void DetPlane::Streamer(TBuffer &R__b)
       finitePlane_.reset();
       char flag;
       R__b >> flag;
-      if (flag)	{
-	// Read AbsFinitePlane with correct overload ... see comment
-	// in writing code.
-	TClass* cl = TClass::Load(R__b);
-        AbsFinitePlane *p = (AbsFinitePlane*)(cl->New());
+      if (flag) {
+        // Read AbsFinitePlane with correct overload ... see comment
+        // in writing code.
+        TClass* cl = TClass::Load(R__b);
+        AbsFinitePlane* p = (AbsFinitePlane*)(cl->New());
         cl->Streamer(p, R__b);
         finitePlane_.reset(p);
       }
       R__b.CheckByteCount(R__s, R__c, thisClass::IsA());
-   } else {
+    } else {
       R__c = R__b.WriteVersion(thisClass::IsA(), kTRUE);
       //TObject::Streamer(R__b);
       o_.Streamer(R__b);
@@ -368,40 +385,40 @@ void DetPlane::Streamer(TBuffer &R__b)
       if (finitePlane_) {
         R__b << (char)1;
 
-	// finitPlane_ is a scoped_ptr, but a shared plane may be
-	// written several times in different places (e.g. it may also
-	// be stored in the measurement class).  Since we have no way
-	// of knowing in which other places the same plane is written
-	// (it may even be in another track!), we cannot synchronize
-	// these writes and have to duplicate the SharedPlanePtr's
-	// instead.  ROOT caches which pointers were written and read
-	// if one uses 'R__b << p' or equivalent.  This can lead to
-	// trouble have no way of synchronizing two reads to
-	// shared_ptr's pointing to the same memory location.  But
-	// even if we break the link between the two shared_ptr's,
-	// ROOT will still try to outsmart us, and it will notice that
-	// the finitePlane_ was the same during writing.  This will
-	// lead to the same address being attached to two different
-	// scoped_ptrs in reading.  Highly undesirable.  Since we
-	// cannot know whether other parts of code implicitly or
-	// explicitly rely on TBuffer's caching, we cannot just
-	// disable this caching via R__b.ResetMap() (it's not
-	// documented in any elucidating manner anyway).
-	// 
-	// Therefore, we have to write and read the AbsFinitePlane*
-	// manually, bypassing ROOT's caching.  In order to do this,
-	// we need the information on the actual type, because
-	// otherwise we couldn't read it back reliably.  Finally, the
-	// _working_ means of reading and writing class information
-	// are TClass::Store and TClass::Load, again barely
-	// documented, but if one tries any of the other ways that
-	// suggest themselves, weird breakage will occur.
-	finitePlane_->IsA()->Store(R__b);
+        // finitPlane_ is a scoped_ptr, but a shared plane may be
+        // written several times in different places (e.g. it may also
+        // be stored in the measurement class).  Since we have no way
+        // of knowing in which other places the same plane is written
+        // (it may even be in another track!), we cannot synchronize
+        // these writes and have to duplicate the SharedPlanePtr's
+        // instead.  ROOT caches which pointers were written and read
+        // if one uses 'R__b << p' or equivalent.  This can lead to
+        // trouble have no way of synchronizing two reads to
+        // shared_ptr's pointing to the same memory location.  But
+        // even if we break the link between the two shared_ptr's,
+        // ROOT will still try to outsmart us, and it will notice that
+        // the finitePlane_ was the same during writing.  This will
+        // lead to the same address being attached to two different
+        // scoped_ptrs in reading.  Highly undesirable.  Since we
+        // cannot know whether other parts of code implicitly or
+        // explicitly rely on TBuffer's caching, we cannot just
+        // disable this caching via R__b.ResetMap() (it's not
+        // documented in any elucidating manner anyway).
+        //
+        // Therefore, we have to write and read the AbsFinitePlane*
+        // manually, bypassing ROOT's caching.  In order to do this,
+        // we need the information on the actual type, because
+        // otherwise we couldn't read it back reliably.  Finally, the
+        // _working_ means of reading and writing class information
+        // are TClass::Store and TClass::Load, again barely
+        // documented, but if one tries any of the other ways that
+        // suggest themselves, weird breakage will occur.
+        finitePlane_->IsA()->Store(R__b);
         finitePlane_->Streamer(R__b);
       } else {
         R__b << (char)0;
       }
       R__b.SetByteCount(R__c, kTRUE);
-   }
-}
+    }
+  }
 } /* End of namespace genfit */

--- a/core/src/Exception.cc
+++ b/core/src/Exception.cc
@@ -22,63 +22,69 @@
 
 namespace genfit {
 
-bool Exception::quiet_ = false;
+  bool Exception::quiet_ = false;
 
-Exception::Exception(std::string excString, int line, std::string  file) :
-    excString_(excString), line_(line), file_(file), fatal_(false) {
-  std::ostringstream ErrMsgStream;
-  ErrMsgStream << "genfit::Exception thrown with excString:"
-         << std::endl << excString_ << std::endl
-         << "in line: " << line_ << " in file: " << file_ << std::endl
-         << "with fatal flag " << fatal_ << std::endl;
-  errorMessage_ = ErrMsgStream.str();
-}
-
-Exception::~Exception() noexcept {
-}
-
-void Exception::setNumbers(std::string _numbersLabel,
-         const std::vector<double>& _numbers) {
-  numbersLabel_ = _numbersLabel;
-  numbers_ = _numbers;
-}
-
-void Exception::setMatrices(std::string _matricesLabel,
-          const std::vector<TMatrixD>& _matrices) {
-  matricesLabel_ = _matricesLabel;
-  matrices_ = _matrices;
-}
-
-const char* Exception::what() const noexcept{
-  return errorMessage_.c_str();
-}
-
-void Exception::info() {
-  if(quiet_) return;
-  if(numbers_.empty() && matrices_.empty()) return; //do nothing
-  debugOut << "genfit::Exception Info Output" << std::endl;
-  debugOut << "===========================" << std::endl;
-  if(numbersLabel_ != "") {
-  debugOut << "Numbers Label String:" << std::endl;
-  debugOut << numbersLabel_ << std::endl;
+  Exception::Exception(std::string excString, int line, std::string  file) :
+    excString_(excString), line_(line), file_(file), fatal_(false)
+  {
+    std::ostringstream ErrMsgStream;
+    ErrMsgStream << "genfit::Exception thrown with excString:"
+                 << std::endl << excString_ << std::endl
+                 << "in line: " << line_ << " in file: " << file_ << std::endl
+                 << "with fatal flag " << fatal_ << std::endl;
+    errorMessage_ = ErrMsgStream.str();
   }
-  if(!numbers_.empty()) {
-  debugOut << "---------------------------" << std::endl;
-  debugOut << "Numbers:" << std::endl;
-  for(unsigned int i=0;i<numbers_.size(); ++i ) debugOut << numbers_[i] << std::endl;
+
+  Exception::~Exception() noexcept
+  {
   }
-  if(matricesLabel_ != "") {
-  debugOut << "---------------------------" << std::endl;
-  debugOut << "Matrices Label String:" << std::endl;
-  debugOut << matricesLabel_ << std::endl;
+
+  void Exception::setNumbers(std::string _numbersLabel,
+                             const std::vector<double>& _numbers)
+  {
+    numbersLabel_ = _numbersLabel;
+    numbers_ = _numbers;
   }
-  if(!matrices_.empty()) {
-  debugOut << "---------------------------" << std::endl;
-  debugOut << "Matrices:" << std::endl;
-  for(unsigned int i=0;i<matrices_.size(); ++i ) matrices_[i].Print();
+
+  void Exception::setMatrices(std::string _matricesLabel,
+                              const std::vector<TMatrixD>& _matrices)
+  {
+    matricesLabel_ = _matricesLabel;
+    matrices_ = _matrices;
   }
-  debugOut << "===========================" << std::endl;
-}
+
+  const char* Exception::what() const noexcept
+  {
+    return errorMessage_.c_str();
+  }
+
+  void Exception::info()
+  {
+    if (quiet_) return;
+    if (numbers_.empty() && matrices_.empty()) return; //do nothing
+    debugOut << "genfit::Exception Info Output" << std::endl;
+    debugOut << "===========================" << std::endl;
+    if (numbersLabel_ != "") {
+      debugOut << "Numbers Label String:" << std::endl;
+      debugOut << numbersLabel_ << std::endl;
+    }
+    if (!numbers_.empty()) {
+      debugOut << "---------------------------" << std::endl;
+      debugOut << "Numbers:" << std::endl;
+      for (unsigned int i = 0; i < numbers_.size(); ++i) debugOut << numbers_[i] << std::endl;
+    }
+    if (matricesLabel_ != "") {
+      debugOut << "---------------------------" << std::endl;
+      debugOut << "Matrices Label String:" << std::endl;
+      debugOut << matricesLabel_ << std::endl;
+    }
+    if (!matrices_.empty()) {
+      debugOut << "---------------------------" << std::endl;
+      debugOut << "Matrices:" << std::endl;
+      for (unsigned int i = 0; i < matrices_.size(); ++i) matrices_[i].Print();
+    }
+    debugOut << "===========================" << std::endl;
+  }
 
 } /* End of namespace genfit */
 

--- a/core/src/FieldManager.cc
+++ b/core/src/FieldManager.cc
@@ -23,88 +23,89 @@
 
 namespace genfit {
 
-FieldManager* FieldManager::instance_ = nullptr;
-AbsBField* FieldManager::field_ = nullptr;
+  FieldManager* FieldManager::instance_ = nullptr;
+  AbsBField* FieldManager::field_ = nullptr;
 
 #ifdef CACHE
-bool FieldManager::useCache_ = false;
-unsigned int FieldManager::n_buckets_ = 8;
-fieldCache* FieldManager::cache_ = nullptr;
+  bool FieldManager::useCache_ = false;
+  unsigned int FieldManager::n_buckets_ = 8;
+  fieldCache* FieldManager::cache_ = nullptr;
 #endif
 
 //#define DEBUG
 
 #ifdef CACHE
-void FieldManager::getFieldVal(const double& posX, const double& posY, const double& posZ, double& Bx, double& By, double& Bz){
-  checkInitialized();
+  void FieldManager::getFieldVal(const double& posX, const double& posY, const double& posZ, double& Bx, double& By, double& Bz)
+  {
+    checkInitialized();
 
-  if (useCache_) {
+    if (useCache_) {
 
-    // cache code copied from http://en.wikibooks.org/wiki/Optimizing_C%2B%2B/General_optimization_techniques/Memoization
-    static int last_read_i = 0;
-    static int last_written_i = 0;
-    int i = last_read_i;
+      // cache code copied from http://en.wikibooks.org/wiki/Optimizing_C%2B%2B/General_optimization_techniques/Memoization
+      static int last_read_i = 0;
+      static int last_written_i = 0;
+      int i = last_read_i;
 
-    static const double epsilon = 0.001;
+      static const double epsilon = 0.001;
 
-    #ifdef DEBUG
-    static int used = 0;
-    static int notUsed = 0;
-    #endif
+#ifdef DEBUG
+      static int used = 0;
+      static int notUsed = 0;
+#endif
 
-    do {
-      if (fabs(cache_[i].posX - posX) < epsilon &&
-          fabs(cache_[i].posY - posY) < epsilon &&
-          fabs(cache_[i].posZ - posZ) < epsilon) {
-        Bx = cache_[i].Bx;
-        By = cache_[i].By;
-        Bz = cache_[i].Bz;
-        #ifdef DEBUG
-        ++used;
-        debugOut<<"used the cache! " << double(used)/(used + notUsed) << "\n";
-        #endif
-        return;
+      do {
+        if (fabs(cache_[i].posX - posX) < epsilon &&
+            fabs(cache_[i].posY - posY) < epsilon &&
+            fabs(cache_[i].posZ - posZ) < epsilon) {
+          Bx = cache_[i].Bx;
+          By = cache_[i].By;
+          Bz = cache_[i].Bz;
+#ifdef DEBUG
+          ++used;
+          debugOut << "used the cache! " << double(used) / (used + notUsed) << "\n";
+#endif
+          return;
+        }
+        i = (i + 1) % n_buckets_;
+      } while (i != last_read_i);
+
+      last_read_i = last_written_i = (last_written_i + 1) % n_buckets_;
+
+      cache_[last_written_i].posX = posX;
+      cache_[last_written_i].posY = posY;
+      cache_[last_written_i].posZ = posZ;
+
+      field_->get(posX, posY, posZ, cache_[last_written_i].Bx, cache_[last_written_i].By, cache_[last_written_i].Bz);
+
+      Bx = cache_[last_written_i].Bx;
+      By = cache_[last_written_i].By;
+      Bz = cache_[last_written_i].Bz;
+#ifdef DEBUG
+      ++notUsed;
+      debugOut << "did NOT use the cache! \n";
+#endif
+      return;
+
+    } else
+      return field_->get(posX, posY, posZ, Bx, By, Bz);
+
+  }
+
+
+  void FieldManager::useCache(bool opt, unsigned int nBuckets)
+  {
+    useCache_ = opt;
+    n_buckets_ = nBuckets;
+
+    if (useCache_) {
+      cache_ = new fieldCache[n_buckets_];
+      for (size_t i = 0; i < n_buckets_; ++i) {
+        // Should be safe to initialize with values in Andromeda
+        cache_[i].posX = cache_[i].posY = cache_[i].posZ = 2.4e24 / sqrt(3);
+        cache_[i].Bx = cache_[i].By = cache_[i].Bz = 1e30;
       }
-      i = (i + 1) % n_buckets_;
-    } while (i != last_read_i);
-
-    last_read_i = last_written_i = (last_written_i + 1) % n_buckets_;
-
-    cache_[last_written_i].posX = posX;
-    cache_[last_written_i].posY = posY;
-    cache_[last_written_i].posZ = posZ;
-
-    field_->get(posX, posY, posZ, cache_[last_written_i].Bx, cache_[last_written_i].By, cache_[last_written_i].Bz);
-
-    Bx = cache_[last_written_i].Bx;
-    By = cache_[last_written_i].By;
-    Bz = cache_[last_written_i].Bz;
-    #ifdef DEBUG
-    ++notUsed;
-    debugOut<<"did NOT use the cache! \n";
-    #endif
-    return;
-
+    }
   }
-  else
-    return field_->get(posX, posY, posZ, Bx, By, Bz);
-
-}
-
-
-void FieldManager::useCache(bool opt, unsigned int nBuckets) {
-  useCache_ = opt;
-  n_buckets_ = nBuckets;
-
-  if (useCache_) {
-    cache_ = new fieldCache[n_buckets_];
-    for (size_t i = 0; i < n_buckets_; ++i) {
-      // Should be safe to initialize with values in Andromeda
-      cache_[i].posX = cache_[i].posY = cache_[i].posZ = 2.4e24 / sqrt(3);
-      cache_[i].Bx = cache_[i].By = cache_[i].Bz = 1e30;      
-    }      
-  }
-}
 #endif
 
 } /* End of namespace genfit */

--- a/core/src/FitStatus.cc
+++ b/core/src/FitStatus.cc
@@ -25,88 +25,93 @@
 
 namespace genfit {
 
-PruneFlags::PruneFlags() {
-  reset();
-}
+  PruneFlags::PruneFlags()
+  {
+    reset();
+  }
 
 
-void PruneFlags::reset() {
-  memset(this, 0, sizeof *this);
-}
+  void PruneFlags::reset()
+  {
+    memset(this, 0, sizeof * this);
+  }
 
 
-void PruneFlags::setFlags(Option_t* option) {
-  TString opt = option;
-  opt.ToUpper();
+  void PruneFlags::setFlags(Option_t* option)
+  {
+    TString opt = option;
+    opt.ToUpper();
 
-  value |= opt.Contains("C") ? C : 0;
-  value |= opt.Contains("F") ? F : 0;
-  value |= opt.Contains("L") ? L : 0;
-  value |= opt.Contains("W") ? W : 0;
-  value |= opt.Contains("R") ? R : 0;
-  value |= opt.Contains("M") ? M : 0;
-  value |= opt.Contains("I") ? I : 0;
-  value |= opt.Contains("U") ? U : 0;
-}
-
-
-bool PruneFlags::hasFlags(Option_t* option) const {
-  TString opt = option;
-  opt.ToUpper();
-
-  return !((!(value & C) && opt.Contains("C"))
-	   || (!(value & F) && opt.Contains("F"))
-	   || (!(value & L) && opt.Contains("L"))
-	   || (!(value & W) && opt.Contains("W"))
-	   || (!(value & R) && opt.Contains("R"))
-	   || (!(value & M) && opt.Contains("M"))
-	   || (!(value & I) && opt.Contains("I"))
-	   || (!(value & U) && opt.Contains("U")));
-}
+    value |= opt.Contains("C") ? C : 0;
+    value |= opt.Contains("F") ? F : 0;
+    value |= opt.Contains("L") ? L : 0;
+    value |= opt.Contains("W") ? W : 0;
+    value |= opt.Contains("R") ? R : 0;
+    value |= opt.Contains("M") ? M : 0;
+    value |= opt.Contains("I") ? I : 0;
+    value |= opt.Contains("U") ? U : 0;
+  }
 
 
-bool PruneFlags::isPruned() const {
-  return !!value;
-}
+  bool PruneFlags::hasFlags(Option_t* option) const
+  {
+    TString opt = option;
+    opt.ToUpper();
+
+    return !((!(value & C) && opt.Contains("C"))
+             || (!(value & F) && opt.Contains("F"))
+             || (!(value & L) && opt.Contains("L"))
+             || (!(value & W) && opt.Contains("W"))
+             || (!(value & R) && opt.Contains("R"))
+             || (!(value & M) && opt.Contains("M"))
+             || (!(value & I) && opt.Contains("I"))
+             || (!(value & U) && opt.Contains("U")));
+  }
 
 
-void PruneFlags::Print(const Option_t*) const {
-  printOut << "PruneFlags: ";
-  if (value & C) printOut << "C";
-  if (value & F) printOut << "F";
-  if (value & L) printOut << "L";
-  if (value & W) printOut << "W";
-  if (value & R) printOut << "R";
-  if (value & M) printOut << "M";
-  if (value & I) printOut << "I";
-  if (value & U) printOut << "U";
-  printOut << "\n";
-}
+  bool PruneFlags::isPruned() const
+  {
+    return !!value;
+  }
+
+
+  void PruneFlags::Print(const Option_t*) const
+  {
+    printOut << "PruneFlags: ";
+    if (value & C) printOut << "C";
+    if (value & F) printOut << "F";
+    if (value & L) printOut << "L";
+    if (value & W) printOut << "W";
+    if (value & R) printOut << "R";
+    if (value & M) printOut << "M";
+    if (value & I) printOut << "I";
+    if (value & U) printOut << "U";
+    printOut << "\n";
+  }
 
 
 
-void FitStatus::Print(const Option_t*) const
-{
-  printOut << "fitStatus \n";
-  if (isFitted_) {
-    printOut << " track has been fitted,";
-    if (isFitConvergedFully_) {
-      printOut << " fit has converged fully,";
-    } else if (isFitConvergedPartially_) {
-      printOut << " fit has converged partially,";
+  void FitStatus::Print(const Option_t*) const
+  {
+    printOut << "fitStatus \n";
+    if (isFitted_) {
+      printOut << " track has been fitted,";
+      if (isFitConvergedFully_) {
+        printOut << " fit has converged fully,";
+      } else if (isFitConvergedPartially_) {
+        printOut << " fit has converged partially,";
+      } else {
+        printOut << " fit has NOT converged,";
+      }
+      printOut << " " << nFailedPoints_ << " TrackPoints could not be processed,";
+      if (trackHasChanged_) {
+        printOut << " track has changed since the fit,";
+      }
+      printOut << " fitted charge = " << charge_ << ", ";
+      pruneFlags_.Print();
     } else {
-      printOut << " fit has NOT converged,";
+      printOut << " track has NOT been fitted,";
     }
-    printOut << " " << nFailedPoints_ << " TrackPoints could not be processed,";
-    if (trackHasChanged_) {
-      printOut << " track has changed since the fit,";
-    }
-    printOut << " fitted charge = " << charge_ << ", ";
-    pruneFlags_.Print();
   }
-  else {
-    printOut << " track has NOT been fitted,";
-  }
-}
 
 } /* End of namespace genfit */

--- a/core/src/Material.cc
+++ b/core/src/Material.cc
@@ -4,28 +4,31 @@
 
 namespace genfit {
 
-    bool operator== (const Material& lhs, const Material& rhs){
-        if (&lhs == &rhs)
-            return true;
+  bool operator== (const Material& lhs, const Material& rhs)
+  {
+    if (&lhs == &rhs)
+      return true;
 
-        return !(lhs.density != rhs.density or
-                 lhs.Z != rhs.Z or
-                 lhs.A != rhs.A or
-                 lhs.radiationLength != rhs.radiationLength or
-                 lhs.mEE != rhs.mEE);
+    return !(lhs.density != rhs.density or
+             lhs.Z != rhs.Z or
+             lhs.A != rhs.A or
+             lhs.radiationLength != rhs.radiationLength or
+             lhs.mEE != rhs.mEE);
 
-    }
+  }
 
-    bool operator!= (const Material& lhs, const Material& rhs) {
-        return !(lhs==rhs);
-    }
+  bool operator!= (const Material& lhs, const Material& rhs)
+  {
+    return !(lhs == rhs);
+  }
 
-    void Material::Print(const Option_t*) const {
-        printOut << "Density = " << density << ", \t"
-                 << "Z = " << Z << ", \t"
-                 << "A = " << A << ", \t"
-                 << "radiationLength = " << radiationLength << ", \t"
-                 << "mEE = " << mEE << "\n";
-    }
-    
+  void Material::Print(const Option_t*) const
+  {
+    printOut << "Density = " << density << ", \t"
+             << "Z = " << Z << ", \t"
+             << "A = " << A << ", \t"
+             << "radiationLength = " << radiationLength << ", \t"
+             << "mEE = " << mEE << "\n";
+  }
+
 }

--- a/core/src/MeasuredStateOnPlane.cc
+++ b/core/src/MeasuredStateOnPlane.cc
@@ -29,172 +29,177 @@
 
 namespace genfit {
 
-void MeasuredStateOnPlane::Print(Option_t*) const {
-  printOut << "genfit::MeasuredStateOnPlane ";
-  printOut << "my address " << this << " my plane's address " << this->sharedPlane_.get() << "; use count: " << sharedPlane_.use_count() << std::endl;
-  printOut << " state vector: "; state_.Print();
-  printOut << " covariance matrix: "; cov_.Print();
-  if (sharedPlane_ != nullptr) {
-    printOut << " defined in plane "; sharedPlane_->Print();
-    TVector3 pos, mom;
-    TMatrixDSym cov(6,6);
-    getRep()->getPosMomCov(*this, pos, mom, cov);
-    printOut << " 3D position: "; pos.Print();
-    printOut << " 3D momentum: "; mom.Print();
-    //printOut << " 6D covariance: "; cov.Print();
-  }
-}
-
-void MeasuredStateOnPlane::blowUpCov(double blowUpFac, bool resetOffDiagonals, double maxVal) {
-
-  unsigned int dim = cov_.GetNcols();
-
-  if (resetOffDiagonals) {
-    for (unsigned int i=0; i<dim; ++i) {
-      for (unsigned int j=0; j<dim; ++j) {
-        if (i != j)
-          cov_(i,j) = 0; // reset off-diagonals
-        else
-          cov_(i,j) *= blowUpFac; // blow up diagonals
-      }
+  void MeasuredStateOnPlane::Print(Option_t*) const
+  {
+    printOut << "genfit::MeasuredStateOnPlane ";
+    printOut << "my address " << this << " my plane's address " << this->sharedPlane_.get() << "; use count: " <<
+             sharedPlane_.use_count() << std::endl;
+    printOut << " state vector: "; state_.Print();
+    printOut << " covariance matrix: "; cov_.Print();
+    if (sharedPlane_ != nullptr) {
+      printOut << " defined in plane "; sharedPlane_->Print();
+      TVector3 pos, mom;
+      TMatrixDSym cov(6, 6);
+      getRep()->getPosMomCov(*this, pos, mom, cov);
+      printOut << " 3D position: "; pos.Print();
+      printOut << " 3D momentum: "; mom.Print();
+      //printOut << " 6D covariance: "; cov.Print();
     }
   }
-  else
-    cov_ *= blowUpFac;
 
-  // limit
-  if (maxVal > 0.)
-    for (unsigned int i=0; i<dim; ++i) {
-      for (unsigned int j=0; j<dim; ++j) {
-        cov_(i,j) = std::min(cov_(i,j), maxVal);
+  void MeasuredStateOnPlane::blowUpCov(double blowUpFac, bool resetOffDiagonals, double maxVal)
+  {
+
+    unsigned int dim = cov_.GetNcols();
+
+    if (resetOffDiagonals) {
+      for (unsigned int i = 0; i < dim; ++i) {
+        for (unsigned int j = 0; j < dim; ++j) {
+          if (i != j)
+            cov_(i, j) = 0; // reset off-diagonals
+          else
+            cov_(i, j) *= blowUpFac; // blow up diagonals
+        }
       }
-    }
+    } else
+      cov_ *= blowUpFac;
 
-}
+    // limit
+    if (maxVal > 0.)
+      for (unsigned int i = 0; i < dim; ++i) {
+        for (unsigned int j = 0; j < dim; ++j) {
+          cov_(i, j) = std::min(cov_(i, j), maxVal);
+        }
+      }
 
-
-MeasuredStateOnPlane calcAverageState(const MeasuredStateOnPlane& forwardState, const MeasuredStateOnPlane& backwardState) {
-  // check if both states are defined in the same plane
-  if (forwardState.getPlane() != backwardState.getPlane()) {
-    Exception e("KalmanFitterInfo::calcAverageState: forwardState and backwardState are not defined in the same plane.", __LINE__,__FILE__);
-    throw e;
   }
 
-  // This code is called a lot, so some effort has gone into reducing
-  // the number of temporary objects being constructed.
+
+  MeasuredStateOnPlane calcAverageState(const MeasuredStateOnPlane& forwardState, const MeasuredStateOnPlane& backwardState)
+  {
+    // check if both states are defined in the same plane
+    if (forwardState.getPlane() != backwardState.getPlane()) {
+      Exception e("KalmanFitterInfo::calcAverageState: forwardState and backwardState are not defined in the same plane.", __LINE__,
+                  __FILE__);
+      throw e;
+    }
+
+    // This code is called a lot, so some effort has gone into reducing
+    // the number of temporary objects being constructed.
 
 #if 0
-  // For ease of understanding, here's a very explicit implementation
-  // that uses the textbook algorithm:
-  TMatrixDSym fCovInv, bCovInv, smoothed_cov;
-  tools::invertMatrix(forwardState.getCov(), fCovInv);
-  tools::invertMatrix(backwardState.getCov(), bCovInv);
+    // For ease of understanding, here's a very explicit implementation
+    // that uses the textbook algorithm:
+    TMatrixDSym fCovInv, bCovInv, smoothed_cov;
+    tools::invertMatrix(forwardState.getCov(), fCovInv);
+    tools::invertMatrix(backwardState.getCov(), bCovInv);
 
-  tools::invertMatrix(fCovInv + bCovInv, smoothed_cov);  // one temporary TMatrixDSym
+    tools::invertMatrix(fCovInv + bCovInv, smoothed_cov);  // one temporary TMatrixDSym
 
-  MeasuredStateOnPlane retVal(forwardState);
-  retVal.setState(smoothed_cov*(fCovInv*forwardState.getState() + bCovInv*backwardState.getState())); // four temporary TVectorD's
-  retVal.setCov(smoothed_cov);
-  return retVal;
+    MeasuredStateOnPlane retVal(forwardState);
+    retVal.setState(smoothed_cov * (fCovInv * forwardState.getState() + bCovInv *
+                                    backwardState.getState())); // four temporary TVectorD's
+    retVal.setCov(smoothed_cov);
+    return retVal;
 #endif
 
-  // This is a numerically stable implementation of the averaging
-  // process.  We write S1, S2 for the upper diagonal square roots
-  // (Cholesky decompositions) of the covariance matrices, such that
-  // C1 = S1' S1 (transposition indicated by ').
-  //
-  // Then we can write
-  //  (C1^-1 + C2^-1)^-1 = (S1inv' S1inv + S2inv' S2inv)^-1
-  //                     = ( (S1inv', S2inv') . ( S1inv ) )^-1
-  //                       (                    ( S2inv ) )
-  //                     = ( (R', 0) . Q . Q' . ( R ) )^-1
-  //                       (                    ( 0 ) )
-  // where Q is an orthogonal matrix chosen such that R is upper diagonal.
-  // Since Q'.Q = 1, this reduces to
-  //                     = ( R'.R )^-1
-  //                     = R^-1 . (R')^-1.
-  // This gives the covariance matrix of the average and its Cholesky
-  // decomposition.
-  //
-  // In order to get the averaged state (writing x1 and x2 for the
-  // states) we proceed from
-  //  C1^-1.x1 + C2^-1.x2 = (S1inv', S2inv') . ( S1inv.x1 )
-  //                                           ( S2inv.x2 )
-  // which by the above can be written as
-  //                      =  (R', 0) . Q . ( S1inv.x1 )
-  //                                       ( S2inv.x2 )
-  // with the same (R, Q) as above.
-  //
-  // The average is then after obvious simplification
-  //   average = R^-1 . Q . (S1inv.x1)
-  //                        (S2inv.x2)
-  //
-  // This is what's implemented below, where we make use of the
-  // tridiagonal shapes of the various matrices when multiplying or
-  // inverting.
-  //
-  // This turns out not only more numerically stable, but because the
-  // matrix operations are simpler, it is also faster than the
-  // straightoforward implementation.
-  //
-  // This is an application of the technique of Golub, G.,
-  // Num. Math. 7, 206 (1965) to the least-squares problem underlying
-  // averaging.
-  TDecompChol d1(forwardState.getCov());
-  bool success = d1.Decompose();
-  TDecompChol d2(backwardState.getCov());
-  success &= d2.Decompose();
+    // This is a numerically stable implementation of the averaging
+    // process.  We write S1, S2 for the upper diagonal square roots
+    // (Cholesky decompositions) of the covariance matrices, such that
+    // C1 = S1' S1 (transposition indicated by ').
+    //
+    // Then we can write
+    //  (C1^-1 + C2^-1)^-1 = (S1inv' S1inv + S2inv' S2inv)^-1
+    //                     = ( (S1inv', S2inv') . ( S1inv ) )^-1
+    //                       (                    ( S2inv ) )
+    //                     = ( (R', 0) . Q . Q' . ( R ) )^-1
+    //                       (                    ( 0 ) )
+    // where Q is an orthogonal matrix chosen such that R is upper diagonal.
+    // Since Q'.Q = 1, this reduces to
+    //                     = ( R'.R )^-1
+    //                     = R^-1 . (R')^-1.
+    // This gives the covariance matrix of the average and its Cholesky
+    // decomposition.
+    //
+    // In order to get the averaged state (writing x1 and x2 for the
+    // states) we proceed from
+    //  C1^-1.x1 + C2^-1.x2 = (S1inv', S2inv') . ( S1inv.x1 )
+    //                                           ( S2inv.x2 )
+    // which by the above can be written as
+    //                      =  (R', 0) . Q . ( S1inv.x1 )
+    //                                       ( S2inv.x2 )
+    // with the same (R, Q) as above.
+    //
+    // The average is then after obvious simplification
+    //   average = R^-1 . Q . (S1inv.x1)
+    //                        (S2inv.x2)
+    //
+    // This is what's implemented below, where we make use of the
+    // tridiagonal shapes of the various matrices when multiplying or
+    // inverting.
+    //
+    // This turns out not only more numerically stable, but because the
+    // matrix operations are simpler, it is also faster than the
+    // straightoforward implementation.
+    //
+    // This is an application of the technique of Golub, G.,
+    // Num. Math. 7, 206 (1965) to the least-squares problem underlying
+    // averaging.
+    TDecompChol d1(forwardState.getCov());
+    bool success = d1.Decompose();
+    TDecompChol d2(backwardState.getCov());
+    success &= d2.Decompose();
 
-  if (!success) {
-    Exception e("KalmanFitterInfo::calcAverageState: ill-conditioned covariance matrix.", __LINE__,__FILE__);
-    throw e;
-  }
-
-  int nRows = d1.GetU().GetNrows();
-  assert(nRows == d2.GetU().GetNrows());
-  TMatrixD S1inv, S2inv;
-  tools::transposedInvert(d1.GetU(), S1inv);
-  tools::transposedInvert(d2.GetU(), S2inv);
-
-  TMatrixD A(2*nRows, nRows);
-  TVectorD b(2 * nRows);
-  double *const bk = b.GetMatrixArray();
-  double *const Ak = A.GetMatrixArray();
-  const double* S1invk = S1inv.GetMatrixArray();
-  const double* S2invk = S2inv.GetMatrixArray();
-  // S1inv and S2inv are lower triangular.
-  for (int i = 0; i < nRows; ++i) {
-    double sum1 = 0;
-    double sum2 = 0;
-    for (int j = 0; j <= i; ++j) {
-      Ak[i*nRows + j] = S1invk[i*nRows + j];
-      Ak[(i + nRows)*nRows + j] = S2invk[i*nRows + j];
-      sum1 += S1invk[i*nRows + j]*forwardState.getState().GetMatrixArray()[j];
-      sum2 += S2invk[i*nRows + j]*backwardState.getState().GetMatrixArray()[j];
+    if (!success) {
+      Exception e("KalmanFitterInfo::calcAverageState: ill-conditioned covariance matrix.", __LINE__, __FILE__);
+      throw e;
     }
-    bk[i] = sum1;
-    bk[i + nRows] = sum2;
-  }
 
-  tools::QR(A, b);
-  A.ResizeTo(nRows, nRows);
+    int nRows = d1.GetU().GetNrows();
+    assert(nRows == d2.GetU().GetNrows());
+    TMatrixD S1inv, S2inv;
+    tools::transposedInvert(d1.GetU(), S1inv);
+    tools::transposedInvert(d2.GetU(), S2inv);
 
-  TMatrixD inv;
-  tools::transposedInvert(A, inv);
-  b.ResizeTo(nRows);
-  for (int i = 0; i < nRows; ++i) {
-    double sum = 0;
-    for (int j = i; j < nRows; ++j) {
-      sum += inv.GetMatrixArray()[j*nRows+i] * b[j];
+    TMatrixD A(2 * nRows, nRows);
+    TVectorD b(2 * nRows);
+    double* const bk = b.GetMatrixArray();
+    double* const Ak = A.GetMatrixArray();
+    const double* S1invk = S1inv.GetMatrixArray();
+    const double* S2invk = S2inv.GetMatrixArray();
+    // S1inv and S2inv are lower triangular.
+    for (int i = 0; i < nRows; ++i) {
+      double sum1 = 0;
+      double sum2 = 0;
+      for (int j = 0; j <= i; ++j) {
+        Ak[i * nRows + j] = S1invk[i * nRows + j];
+        Ak[(i + nRows)*nRows + j] = S2invk[i * nRows + j];
+        sum1 += S1invk[i * nRows + j] * forwardState.getState().GetMatrixArray()[j];
+        sum2 += S2invk[i * nRows + j] * backwardState.getState().GetMatrixArray()[j];
+      }
+      bk[i] = sum1;
+      bk[i + nRows] = sum2;
     }
-    b.GetMatrixArray()[i] = sum;
+
+    tools::QR(A, b);
+    A.ResizeTo(nRows, nRows);
+
+    TMatrixD inv;
+    tools::transposedInvert(A, inv);
+    b.ResizeTo(nRows);
+    for (int i = 0; i < nRows; ++i) {
+      double sum = 0;
+      for (int j = i; j < nRows; ++j) {
+        sum += inv.GetMatrixArray()[j * nRows + i] * b[j];
+      }
+      b.GetMatrixArray()[i] = sum;
+    }
+    return MeasuredStateOnPlane(b,
+                                TMatrixDSym(TMatrixDSym::kAtA, inv),
+                                forwardState.getPlane(),
+                                forwardState.getRep(),
+                                forwardState.getAuxInfo());
   }
-  return MeasuredStateOnPlane(b,
-			      TMatrixDSym(TMatrixDSym::kAtA, inv),
-			      forwardState.getPlane(),
-			      forwardState.getRep(),
-			      forwardState.getAuxInfo());
-}
 
 
 } /* End of namespace genfit */

--- a/core/src/MeasurementOnPlane.cc
+++ b/core/src/MeasurementOnPlane.cc
@@ -26,73 +26,76 @@
 
 namespace genfit {
 
-MeasurementOnPlane::MeasurementOnPlane(const MeasurementOnPlane& other) :
+  MeasurementOnPlane::MeasurementOnPlane(const MeasurementOnPlane& other) :
     MeasuredStateOnPlane(other),
     weight_(other.weight_)
-{
-  hMatrix_.reset(other.hMatrix_->clone());
-}
+  {
+    hMatrix_.reset(other.hMatrix_->clone());
+  }
 
 
-MeasurementOnPlane& MeasurementOnPlane::operator=(MeasurementOnPlane other) {
-  swap(other);
-  return *this;
-}
+  MeasurementOnPlane& MeasurementOnPlane::operator=(MeasurementOnPlane other)
+  {
+    swap(other);
+    return *this;
+  }
 
 
-void MeasurementOnPlane::swap(MeasurementOnPlane& other) {
-  MeasuredStateOnPlane::swap(other);
-  this->hMatrix_.swap(other.hMatrix_);
-  std::swap(this->weight_, other.weight_);
-}
+  void MeasurementOnPlane::swap(MeasurementOnPlane& other)
+  {
+    MeasuredStateOnPlane::swap(other);
+    this->hMatrix_.swap(other.hMatrix_);
+    std::swap(this->weight_, other.weight_);
+  }
 
 
-void MeasurementOnPlane::Print(Option_t*) const
-{
-  printOut << "genfit::MeasurementOnPlane, weight = " << weight_ << "\n";
-  printOut << " state vector: "; state_.Print();
-  printOut << " covariance matrix: "; cov_.Print();
-  if (sharedPlane_ != nullptr) {
+  void MeasurementOnPlane::Print(Option_t*) const
+  {
+    printOut << "genfit::MeasurementOnPlane, weight = " << weight_ << "\n";
+    printOut << " state vector: "; state_.Print();
+    printOut << " covariance matrix: "; cov_.Print();
+    if (sharedPlane_ != nullptr) {
       printOut << " defined in plane ";
       sharedPlane_->Print();
+    }
+    printOut << " hMatrix: "; hMatrix_->Print();
+
   }
-  printOut << " hMatrix: "; hMatrix_->Print();
-
-}
 
 
-void MeasurementOnPlane::Streamer(TBuffer &R__b)
-{
-  // Stream an object of class genfit::MeasurementOnPlane.
+  void MeasurementOnPlane::Streamer(TBuffer& R__b)
+  {
+    // Stream an object of class genfit::MeasurementOnPlane.
 
-  //This works around a msvc bug and should be harmless on other platforms
-  typedef ::genfit::MeasurementOnPlane thisClass;
-  UInt_t R__s, R__c;
-  if (R__b.IsReading()) {
-     Version_t R__v = R__b.ReadVersion(&R__s, &R__c); if (R__v) { }
-     MeasuredStateOnPlane::Streamer(R__b);
-     hMatrix_.reset();
-     char flag;
-     R__b.ReadChar(flag);
-     if (flag) {
-       AbsHMatrix *h = 0;
-       R__b >> h;
-       hMatrix_.reset(h);
-     }
-     R__b >> weight_;
-     R__b.CheckByteCount(R__s, R__c, thisClass::IsA());
-  } else {
-     R__c = R__b.WriteVersion(thisClass::IsA(), kTRUE);
-     MeasuredStateOnPlane::Streamer(R__b);
-     if (hMatrix_) {
-       R__b.WriteChar(1);
-       R__b << hMatrix_.get();
-     } else {
-       R__b.WriteChar(0);
-     }
-     R__b << weight_;
-     R__b.SetByteCount(R__c, kTRUE);
+    //This works around a msvc bug and should be harmless on other platforms
+    typedef ::genfit::MeasurementOnPlane thisClass;
+    UInt_t R__s, R__c;
+    if (R__b.IsReading()) {
+      Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+      if (R__v) { }
+      MeasuredStateOnPlane::Streamer(R__b);
+      hMatrix_.reset();
+      char flag;
+      R__b.ReadChar(flag);
+      if (flag) {
+        AbsHMatrix* h = 0;
+        R__b >> h;
+        hMatrix_.reset(h);
+      }
+      R__b >> weight_;
+      R__b.CheckByteCount(R__s, R__c, thisClass::IsA());
+    } else {
+      R__c = R__b.WriteVersion(thisClass::IsA(), kTRUE);
+      MeasuredStateOnPlane::Streamer(R__b);
+      if (hMatrix_) {
+        R__b.WriteChar(1);
+        R__b << hMatrix_.get();
+      } else {
+        R__b.WriteChar(0);
+      }
+      R__b << weight_;
+      R__b.SetByteCount(R__c, kTRUE);
+    }
   }
-}
 
 } /* End of namespace genfit */

--- a/core/src/StateOnPlane.cc
+++ b/core/src/StateOnPlane.cc
@@ -27,42 +27,44 @@
 namespace genfit {
 
 
-void StateOnPlane::Print(Option_t*) const {
-  printOut << "genfit::StateOnPlane ";
-  printOut << " state vector: "; state_.Print();
-  if (sharedPlane_ != nullptr) {
-    printOut << " defined in plane "; sharedPlane_->Print();
-    TVector3 pos(0,0,0), mom(0,0,0);
-    getRep()->getPosMom(*this, pos, mom);
-    printOut << " 3D position: "; pos.Print();
-    printOut << " 3D momentum: "; mom.Print();
+  void StateOnPlane::Print(Option_t*) const
+  {
+    printOut << "genfit::StateOnPlane ";
+    printOut << " state vector: "; state_.Print();
+    if (sharedPlane_ != nullptr) {
+      printOut << " defined in plane "; sharedPlane_->Print();
+      TVector3 pos(0, 0, 0), mom(0, 0, 0);
+      getRep()->getPosMom(*this, pos, mom);
+      printOut << " 3D position: "; pos.Print();
+      printOut << " 3D momentum: "; mom.Print();
+    }
   }
-}
 
 
 // Modified from auto-generated Streamer to account for sharedPlane_
 // Ignores rep_ and sharedPlane_, the owner has to take care of them.
-void StateOnPlane::Streamer(TBuffer &R__b)
-{
-   // Stream an object of class genfit::StateOnPlane.
+  void StateOnPlane::Streamer(TBuffer& R__b)
+  {
+    // Stream an object of class genfit::StateOnPlane.
 
-   //This works around a msvc bug and should be harmless on other platforms
-   typedef ::genfit::StateOnPlane thisClass;
-   UInt_t R__s, R__c;
-   if (R__b.IsReading()) {
-      Version_t R__v = R__b.ReadVersion(&R__s, &R__c); if (R__v) { }
+    //This works around a msvc bug and should be harmless on other platforms
+    typedef ::genfit::StateOnPlane thisClass;
+    UInt_t R__s, R__c;
+    if (R__b.IsReading()) {
+      Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+      if (R__v) { }
       state_.Streamer(R__b);
       auxInfo_.Streamer(R__b);
       sharedPlane_.reset();  // needs to be set by owner;
       rep_ = nullptr;  // needs to be set by owner
       R__b.CheckByteCount(R__s, R__c, thisClass::IsA());
-   } else {
+    } else {
       R__c = R__b.WriteVersion(thisClass::IsA(), kTRUE);
       state_.Streamer(R__b);
       auxInfo_.Streamer(R__b);
       R__b.SetByteCount(R__c, kTRUE);
-   }
-}
+    }
+  }
 
 
 } /* End of namespace genfit */

--- a/core/src/ThinScatterer.cc
+++ b/core/src/ThinScatterer.cc
@@ -25,38 +25,40 @@
 namespace genfit {
 
 
-void ThinScatterer::Print(const Option_t*) const {
-  printOut << "ThinScatterer, defined in plane: ";
-  sharedPlane_->Print();
-  printOut << "Material properties: ";
-  material_.Print();
-}
-
-
-void ThinScatterer::Streamer(TBuffer &R__b)
-{
-  // Stream an object of class genfit::ThinScatterer.
-
-  // TODO: test
-
-  //This works around a msvc bug and should be harmless on other platforms
-  typedef ::genfit::ThinScatterer thisClass;
-  UInt_t R__s, R__c;
-  if (R__b.IsReading()) {
-     Version_t R__v = R__b.ReadVersion(&R__s, &R__c); if (R__v) { }
-     //TObject::Streamer(R__b);
-     sharedPlane_.reset(new DetPlane());
-     sharedPlane_->Streamer(R__b);
-     material_.Streamer(R__b);
-     R__b.CheckByteCount(R__s, R__c, thisClass::IsA());
-  } else {
-     R__c = R__b.WriteVersion(thisClass::IsA(), kTRUE);
-     //TObject::Streamer(R__b);
-     sharedPlane_->Streamer(R__b);
-     material_.Streamer(R__b);
-     R__b.SetByteCount(R__c, kTRUE);
+  void ThinScatterer::Print(const Option_t*) const
+  {
+    printOut << "ThinScatterer, defined in plane: ";
+    sharedPlane_->Print();
+    printOut << "Material properties: ";
+    material_.Print();
   }
-}
+
+
+  void ThinScatterer::Streamer(TBuffer& R__b)
+  {
+    // Stream an object of class genfit::ThinScatterer.
+
+    // TODO: test
+
+    //This works around a msvc bug and should be harmless on other platforms
+    typedef ::genfit::ThinScatterer thisClass;
+    UInt_t R__s, R__c;
+    if (R__b.IsReading()) {
+      Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+      if (R__v) { }
+      //TObject::Streamer(R__b);
+      sharedPlane_.reset(new DetPlane());
+      sharedPlane_->Streamer(R__b);
+      material_.Streamer(R__b);
+      R__b.CheckByteCount(R__s, R__c, thisClass::IsA());
+    } else {
+      R__c = R__b.WriteVersion(thisClass::IsA(), kTRUE);
+      //TObject::Streamer(R__b);
+      sharedPlane_->Streamer(R__b);
+      material_.Streamer(R__b);
+      R__b.SetByteCount(R__c, kTRUE);
+    }
+  }
 
 
 

--- a/core/src/Tools.cc
+++ b/core/src/Tools.cc
@@ -35,337 +35,339 @@
 
 namespace genfit {
 
-void tools::invertMatrix(const TMatrixDSym& mat, TMatrixDSym& inv, double* determinant){
-  inv.ResizeTo(mat);
+  void tools::invertMatrix(const TMatrixDSym& mat, TMatrixDSym& inv, double* determinant)
+  {
+    inv.ResizeTo(mat);
 
-  // check if numerical limits are reached (i.e at least one entry < 1E-100 and/or at least one entry > 1E100)
-  if (!(mat<1.E100) || !(mat>-1.E100)){
-    Exception e("Tools::invertMatrix() - cannot invert matrix, entries too big (>1e100)",
-        __LINE__,__FILE__);
-    e.setFatal();
-    throw e;
-  }
-  // do the trivial inversions for 1x1 and 2x2 matrices manually
-  if (mat.GetNrows() == 1){
-    if (determinant != nullptr) *determinant = mat(0,0);
-    inv(0,0) = 1./mat(0,0);
-    return;
-  }
-
-  if (mat.GetNrows() == 2){
-    double det = mat(0,0)*mat(1,1) - mat(1,0)*mat(1,0);
-    if (determinant != nullptr) *determinant = det;
-    if(fabs(det) < 1E-50){
-      Exception e("Tools::invertMatrix() - cannot invert matrix , determinant = 0",
-          __LINE__,__FILE__);
+    // check if numerical limits are reached (i.e at least one entry < 1E-100 and/or at least one entry > 1E100)
+    if (!(mat < 1.E100) || !(mat > -1.E100)) {
+      Exception e("Tools::invertMatrix() - cannot invert matrix, entries too big (>1e100)",
+                  __LINE__, __FILE__);
       e.setFatal();
       throw e;
     }
-    det = 1./det;
-    inv(0,0) =             det * mat(1,1);
-    inv(0,1) = inv(1,0) = -det * mat(1,0);
-    inv(1,1) =             det * mat(0,0);
-    return;
-  }
+    // do the trivial inversions for 1x1 and 2x2 matrices manually
+    if (mat.GetNrows() == 1) {
+      if (determinant != nullptr) *determinant = mat(0, 0);
+      inv(0, 0) = 1. / mat(0, 0);
+      return;
+    }
 
-  // else use TDecompChol
-  bool status = 0;
-  TDecompChol invertAlgo(mat, 1E-50);
+    if (mat.GetNrows() == 2) {
+      double det = mat(0, 0) * mat(1, 1) - mat(1, 0) * mat(1, 0);
+      if (determinant != nullptr) *determinant = det;
+      if (fabs(det) < 1E-50) {
+        Exception e("Tools::invertMatrix() - cannot invert matrix , determinant = 0",
+                    __LINE__, __FILE__);
+        e.setFatal();
+        throw e;
+      }
+      det = 1. / det;
+      inv(0, 0) =             det * mat(1, 1);
+      inv(0, 1) = inv(1, 0) = -det * mat(1, 0);
+      inv(1, 1) =             det * mat(0, 0);
+      return;
+    }
 
-  status = invertAlgo.Invert(inv);
-  if(status == 0){
-    Exception e("Tools::invertMatrix() - cannot invert matrix, status = 0",
-        __LINE__,__FILE__);
-    e.setFatal();
-    throw e;
-  }
+    // else use TDecompChol
+    bool status = 0;
+    TDecompChol invertAlgo(mat, 1E-50);
 
-  if (determinant != nullptr) {
-    double d1, d2;
-    invertAlgo.Det(d1, d2);
-    *determinant = ldexp(d1, d2);
-  }
-}
-
-void tools::invertMatrix(TMatrixDSym& mat, double* determinant){
-  // check if numerical limits are reached (i.e at least one entry < 1E-100 and/or at least one entry > 1E100)
-  if (!(mat<1.E100) || !(mat>-1.E100)){
-    Exception e("Tools::invertMatrix() - cannot invert matrix, entries too big (>1e100)",
-        __LINE__,__FILE__);
-    e.setFatal();
-    throw e;
-  }
-  // do the trivial inversions for 1x1 and 2x2 matrices manually
-  if (mat.GetNrows() == 1){
-    if (determinant != nullptr) *determinant = mat(0,0);
-    mat(0,0) = 1./mat(0,0);
-    return;
-  }
-
-  if (mat.GetNrows() == 2){
-    double *arr = mat.GetMatrixArray();
-    double det = arr[0]*arr[3] - arr[1]*arr[1];
-    if (determinant != nullptr) *determinant = det;
-    if(fabs(det) < 1E-50){
-      Exception e("Tools::invertMatrix() - cannot invert matrix, determinant = 0",
-          __LINE__,__FILE__);
+    status = invertAlgo.Invert(inv);
+    if (status == 0) {
+      Exception e("Tools::invertMatrix() - cannot invert matrix, status = 0",
+                  __LINE__, __FILE__);
       e.setFatal();
       throw e;
     }
-    det = 1./det;
-    double temp[3];
-    temp[0] =  det * arr[3];
-    temp[1] = -det * arr[1];
-    temp[2] =  det * arr[0];
-    //double *arr = mat.GetMatrixArray();
-    arr[0] = temp[0];
-    arr[1] = arr[2] = temp[1];
-    arr[3] = temp[2];
-    return;
+
+    if (determinant != nullptr) {
+      double d1, d2;
+      invertAlgo.Det(d1, d2);
+      *determinant = ldexp(d1, d2);
+    }
   }
 
-  // else use TDecompChol
-  bool status = 0;
-  TDecompChol invertAlgo(mat, 1E-50);
+  void tools::invertMatrix(TMatrixDSym& mat, double* determinant)
+  {
+    // check if numerical limits are reached (i.e at least one entry < 1E-100 and/or at least one entry > 1E100)
+    if (!(mat < 1.E100) || !(mat > -1.E100)) {
+      Exception e("Tools::invertMatrix() - cannot invert matrix, entries too big (>1e100)",
+                  __LINE__, __FILE__);
+      e.setFatal();
+      throw e;
+    }
+    // do the trivial inversions for 1x1 and 2x2 matrices manually
+    if (mat.GetNrows() == 1) {
+      if (determinant != nullptr) *determinant = mat(0, 0);
+      mat(0, 0) = 1. / mat(0, 0);
+      return;
+    }
 
-  status = invertAlgo.Invert(mat);
-  if(status == 0){
-    Exception e("Tools::invertMatrix() - cannot invert matrix, status = 0",
-        __LINE__,__FILE__);
-    e.setFatal();
-    throw e;
-  }
+    if (mat.GetNrows() == 2) {
+      double* arr = mat.GetMatrixArray();
+      double det = arr[0] * arr[3] - arr[1] * arr[1];
+      if (determinant != nullptr) *determinant = det;
+      if (fabs(det) < 1E-50) {
+        Exception e("Tools::invertMatrix() - cannot invert matrix, determinant = 0",
+                    __LINE__, __FILE__);
+        e.setFatal();
+        throw e;
+      }
+      det = 1. / det;
+      double temp[3];
+      temp[0] =  det * arr[3];
+      temp[1] = -det * arr[1];
+      temp[2] =  det * arr[0];
+      //double *arr = mat.GetMatrixArray();
+      arr[0] = temp[0];
+      arr[1] = arr[2] = temp[1];
+      arr[3] = temp[2];
+      return;
+    }
 
-  if (determinant != nullptr) {
-    double d1, d2;
-    invertAlgo.Det(d1, d2);
-    *determinant = ldexp(d1, d2);
+    // else use TDecompChol
+    bool status = 0;
+    TDecompChol invertAlgo(mat, 1E-50);
+
+    status = invertAlgo.Invert(mat);
+    if (status == 0) {
+      Exception e("Tools::invertMatrix() - cannot invert matrix, status = 0",
+                  __LINE__, __FILE__);
+      e.setFatal();
+      throw e;
+    }
+
+    if (determinant != nullptr) {
+      double d1, d2;
+      invertAlgo.Det(d1, d2);
+      *determinant = ldexp(d1, d2);
+    }
   }
-}
 
 
 // Solves R^T x = b, replaces b with the result x.  R is assumed
 // to be upper-diagonal.  This is forward substitution, but with
 // indices flipped.
-bool tools::transposedForwardSubstitution(const TMatrixD& R, TVectorD& b)
-{
-  size_t n = R.GetNrows();
-  double *const bk = b.GetMatrixArray();
-  const double *const Rk = R.GetMatrixArray();
-  for (unsigned int i = 0; i < n; ++i) {
-    double sum = bk[i];
-    for (unsigned int j = 0; j < i; ++j) {
-      sum -= bk[j]*Rk[j*n + i];  // already replaced previous elements in b.
+  bool tools::transposedForwardSubstitution(const TMatrixD& R, TVectorD& b)
+  {
+    size_t n = R.GetNrows();
+    double* const bk = b.GetMatrixArray();
+    const double* const Rk = R.GetMatrixArray();
+    for (unsigned int i = 0; i < n; ++i) {
+      double sum = bk[i];
+      for (unsigned int j = 0; j < i; ++j) {
+        sum -= bk[j] * Rk[j * n + i]; // already replaced previous elements in b.
+      }
+      if (Rk[i * n + i] == 0)
+        return false;
+      bk[i] = sum / Rk[i * n + i];
     }
-    if (Rk[i*n+i] == 0)
-      return false;
-    bk[i] = sum / Rk[i*n + i];
+    return true;
   }
-  return true;
-}
 
 
 // Same, but for one column of the matrix b.  Used by transposedInvert below
 // assumes b(i,j) == (i == j)
-bool tools::transposedForwardSubstitution(const TMatrixD& R, TMatrixD& b, int nCol)
-{
-  size_t n = R.GetNrows();
-  double *const bk = b.GetMatrixArray() + nCol;
-  const double *const Rk = R.GetMatrixArray();
-  for (unsigned int i = nCol; i < n; ++i) {
-    double sum = (i == (size_t)nCol);
-    for (unsigned int j = 0; j < i; ++j) {
-      sum -= bk[j*n]*Rk[j*n + i];  // already replaced previous elements in b.
+  bool tools::transposedForwardSubstitution(const TMatrixD& R, TMatrixD& b, int nCol)
+  {
+    size_t n = R.GetNrows();
+    double* const bk = b.GetMatrixArray() + nCol;
+    const double* const Rk = R.GetMatrixArray();
+    for (unsigned int i = nCol; i < n; ++i) {
+      double sum = (i == (size_t)nCol);
+      for (unsigned int j = 0; j < i; ++j) {
+        sum -= bk[j * n] * Rk[j * n + i]; // already replaced previous elements in b.
+      }
+      if (Rk[i * n + i] == 0)
+        return false;
+      bk[i * n] = sum / Rk[i * n + i];
     }
-    if (Rk[i*n+i] == 0)
-      return false;
-    bk[i*n] = sum / Rk[i*n + i];
+    return true;
   }
-  return true;
-}
 
 
 // inv will be the inverse of the transposed of the upper-right matrix R
-bool tools::transposedInvert(const TMatrixD& R, TMatrixD& inv)
-{
-  bool result = true;
+  bool tools::transposedInvert(const TMatrixD& R, TMatrixD& inv)
+  {
+    bool result = true;
 
-  inv.ResizeTo(R);
-  double *const invk = inv.GetMatrixArray();
-  int nRows = inv.GetNrows();
-  for (int i = 0; i < nRows; ++i)
-    for (int j = 0; j < nRows; ++j)
-      invk[i*nRows + j] = (i == j);
+    inv.ResizeTo(R);
+    double* const invk = inv.GetMatrixArray();
+    int nRows = inv.GetNrows();
+    for (int i = 0; i < nRows; ++i)
+      for (int j = 0; j < nRows; ++j)
+        invk[i * nRows + j] = (i == j);
 
-  for (int i = 0; i < inv.GetNcols(); ++i)
-    result = result && transposedForwardSubstitution(R, inv, i);
+    for (int i = 0; i < inv.GetNcols(); ++i)
+      result = result && transposedForwardSubstitution(R, inv, i);
 
-  return result;
-}
+    return result;
+  }
 
 // This replaces A with an upper right matrix connected to A by a
 // orthogonal transformation.  I.e., it computes the R from a QR
 // decomposition of A replacing A.
-void tools::QR(TMatrixD& A)
-{
-  int nCols = A.GetNcols();
-  int nRows = A.GetNrows();
-  assert(nRows >= nCols);
-  // This uses Businger and Golub's algorithm from Handbook for
-  // Automatical Computation, Vol. 2, Chapter 8, but without
-  // pivoting.  I.e., we stop at the middle of page 112.  We don't
-  // explicitly calculate the orthogonal matrix.
+  void tools::QR(TMatrixD& A)
+  {
+    int nCols = A.GetNcols();
+    int nRows = A.GetNrows();
+    assert(nRows >= nCols);
+    // This uses Businger and Golub's algorithm from Handbook for
+    // Automatical Computation, Vol. 2, Chapter 8, but without
+    // pivoting.  I.e., we stop at the middle of page 112.  We don't
+    // explicitly calculate the orthogonal matrix.
 
-  double *const ak = A.GetMatrixArray();
-  // No variable-length arrays in C++, alloca does the exact same thing ...
-  double *const u = (double *)alloca(sizeof(double)*nRows);
+    double* const ak = A.GetMatrixArray();
+    // No variable-length arrays in C++, alloca does the exact same thing ...
+    double* const u = (double*)alloca(sizeof(double) * nRows);
 
-  // Main loop over matrix columns.
-  for (int k = 0; k < nCols; ++k) {
-    double akk = ak[k*nCols + k];
+    // Main loop over matrix columns.
+    for (int k = 0; k < nCols; ++k) {
+      double akk = ak[k * nCols + k];
 
-    double sum = akk*akk;
-    // Put together a housholder transformation.
-    for (int i = k + 1; i < nRows; ++i) {
-      sum += ak[i*nCols + k]*ak[i*nCols + k];
-      u[i] = ak[i*nCols + k];
+      double sum = akk * akk;
+      // Put together a housholder transformation.
+      for (int i = k + 1; i < nRows; ++i) {
+        sum += ak[i * nCols + k] * ak[i * nCols + k];
+        u[i] = ak[i * nCols + k];
+      }
+      double sigma = sqrt(sum);
+      double beta = 1 / (sum + sigma * fabs(akk));
+      // The algorithm uses only the uk[i] for i >= k.
+      u[k] = copysign(sigma + fabs(akk), akk);
+
+      // Calculate y (again taking into account zero entries).  This
+      // encodes how the (sub)matrix changes by the householder transformation.
+      for (int i = k; i < nCols; ++i) {
+        double y = 0;
+        for (int j = k; j < nRows; ++j)
+          y += u[j] * ak[j * nCols + i];
+        y *= beta;
+        // ... and apply the changes.
+        for (int j = k; j < nRows; ++j)
+          ak[j * nCols + i] -= u[j] * y; //y[j];
+      }
     }
-    double sigma = sqrt(sum);
-    double beta = 1/(sum + sigma*fabs(akk));
-    // The algorithm uses only the uk[i] for i >= k.
-    u[k] = copysign(sigma + fabs(akk), akk);
 
-    // Calculate y (again taking into account zero entries).  This
-    // encodes how the (sub)matrix changes by the householder transformation.
-    for (int i = k; i < nCols; ++i) {
-      double y = 0;
-      for (int j = k; j < nRows; ++j)
-	y += u[j]*ak[j*nCols + i];
-      y *= beta;
-      // ... and apply the changes.
-      for (int j = k; j < nRows; ++j)
-	ak[j*nCols + i] -= u[j]*y; //y[j];
-    }
+    // Zero below diagonal
+    for (int i = 1; i < nCols; ++i)
+      for (int j = 0; j < i; ++j)
+        ak[i * nCols + j] = 0.;
+    for (int i = nCols; i < nRows; ++i)
+      for (int j = 0; j < nCols; ++j)
+        ak[i * nCols + j] = 0.;
   }
-
-  // Zero below diagonal
-  for (int i = 1; i < nCols; ++i)
-    for (int j = 0; j < i; ++j)
-      ak[i*nCols + j] = 0.;
-  for (int i = nCols; i < nRows; ++i)
-    for (int j = 0; j < nCols; ++j)
-      ak[i*nCols + j] = 0.;
-}
 
 // This replaces A with an upper right matrix connected to A by a
 // orthogonal transformation.  I.e., it computes the R from a QR
 // decomposition of A replacing A.  Simultaneously it transforms b by
 // the inverse orthogonal transformation.
-// 
+//
 // The purpose is this: the least-squared problem
 //   ||Ax - b|| = min
 // is equivalent to
 //   ||QRx - b|| = ||Rx - Q'b|| = min
 // where Q' denotes the transposed (i.e. inverse).
-void tools::QR(TMatrixD& A, TVectorD& b)
-{
-  int nCols = A.GetNcols();
-  int nRows = A.GetNrows();
-  assert(nRows >= nCols);
-  assert(b.GetNrows() == nRows);
-  // This uses Businger and Golub's algorithm from Handbook for
-  // Automatic Computation, Vol. 2, Chapter 8, but without pivoting.
-  // I.e., we stop at the middle of page 112.  We don't explicitly
-  // calculate the orthogonal matrix, but Q'b which is not done
-  // explicitly in Businger et al.
-  // Also in Numer. Math. 7, 269-276 (1965)
+  void tools::QR(TMatrixD& A, TVectorD& b)
+  {
+    int nCols = A.GetNcols();
+    int nRows = A.GetNrows();
+    assert(nRows >= nCols);
+    assert(b.GetNrows() == nRows);
+    // This uses Businger and Golub's algorithm from Handbook for
+    // Automatic Computation, Vol. 2, Chapter 8, but without pivoting.
+    // I.e., we stop at the middle of page 112.  We don't explicitly
+    // calculate the orthogonal matrix, but Q'b which is not done
+    // explicitly in Businger et al.
+    // Also in Numer. Math. 7, 269-276 (1965)
 
-  double *const ak = A.GetMatrixArray();
-  double *const bk = b.GetMatrixArray();
-  // No variable-length arrays in C++, alloca does the exact same thing ...
-  //double * u = (double *)alloca(sizeof(double)*nRows);
-  double u[500];
+    double* const ak = A.GetMatrixArray();
+    double* const bk = b.GetMatrixArray();
+    // No variable-length arrays in C++, alloca does the exact same thing ...
+    //double * u = (double *)alloca(sizeof(double)*nRows);
+    double u[500];
 
-  // Main loop over matrix columns.
-  for (int k = 0; k < nCols; ++k) {
-    double akk = ak[k*nCols + k];
+    // Main loop over matrix columns.
+    for (int k = 0; k < nCols; ++k) {
+      double akk = ak[k * nCols + k];
 
-    double sum = akk*akk;
-    // Put together a housholder transformation.
-    for (int i = k + 1; i < nRows; ++i) {
-      sum += ak[i*nCols + k]*ak[i*nCols + k];
-      u[i] = ak[i*nCols + k];
-    }
-    double sigma = sqrt(sum);
-    double beta = 1/(sum + sigma*fabs(akk));
-    // The algorithm uses only the uk[i] for i >= k.
-    u[k] = copysign(sigma + fabs(akk), akk);
+      double sum = akk * akk;
+      // Put together a housholder transformation.
+      for (int i = k + 1; i < nRows; ++i) {
+        sum += ak[i * nCols + k] * ak[i * nCols + k];
+        u[i] = ak[i * nCols + k];
+      }
+      double sigma = sqrt(sum);
+      double beta = 1 / (sum + sigma * fabs(akk));
+      // The algorithm uses only the uk[i] for i >= k.
+      u[k] = copysign(sigma + fabs(akk), akk);
 
-    // Calculate b (again taking into account zero entries).  This
-    // encodes how the (sub)vector changes by the householder transformation.
-    double yb = 0;
-    for (int j = k; j < nRows; ++j)
-      yb += u[j]*bk[j];
-    yb *= beta;
-    // ... and apply the changes.
-    for (int j = k; j < nRows; ++j)
-      bk[j] -= u[j]*yb;
-
-    // Calculate y (again taking into account zero entries).  This
-    // encodes how the (sub)matrix changes by the householder transformation.
-    for (int i = k; i < nCols; ++i) {
-      double y = 0;
+      // Calculate b (again taking into account zero entries).  This
+      // encodes how the (sub)vector changes by the householder transformation.
+      double yb = 0;
       for (int j = k; j < nRows; ++j)
-	y += u[j]*ak[j*nCols + i];
-      y *= beta;
+        yb += u[j] * bk[j];
+      yb *= beta;
       // ... and apply the changes.
       for (int j = k; j < nRows; ++j)
-	ak[j*nCols + i] -= u[j]*y;
+        bk[j] -= u[j] * yb;
+
+      // Calculate y (again taking into account zero entries).  This
+      // encodes how the (sub)matrix changes by the householder transformation.
+      for (int i = k; i < nCols; ++i) {
+        double y = 0;
+        for (int j = k; j < nRows; ++j)
+          y += u[j] * ak[j * nCols + i];
+        y *= beta;
+        // ... and apply the changes.
+        for (int j = k; j < nRows; ++j)
+          ak[j * nCols + i] -= u[j] * y;
+      }
     }
+
+    // Zero below diagonal
+    for (int i = 1; i < nCols; ++i)
+      for (int j = 0; j < i; ++j)
+        ak[i * nCols + j] = 0.;
+    for (int i = nCols; i < nRows; ++i)
+      for (int j = 0; j < nCols; ++j)
+        ak[i * nCols + j] = 0.;
   }
 
-  // Zero below diagonal
-  for (int i = 1; i < nCols; ++i)
-    for (int j = 0; j < i; ++j)
-      ak[i*nCols + j] = 0.;
-  for (int i = nCols; i < nRows; ++i)
-    for (int j = 0; j < nCols; ++j)
-      ak[i*nCols + j] = 0.;
-}
 
-
-void
-tools::noiseMatrixSqrt(const TMatrixDSym& noise,
-		       TMatrixD& noiseSqrt)
-{
-  // This is the slowest part of the whole Sqrt Kalman.  Using an LDLt
-  // transform is probably the easiest way of remedying this.
-  TMatrixDSymEigen eig(noise);
-  noiseSqrt.ResizeTo(noise);
-  noiseSqrt = eig.GetEigenVectors();
-  double* pNoiseSqrt = noiseSqrt.GetMatrixArray();
-  const TVectorD& evs(eig.GetEigenValues());
-  const double* pEvs = evs.GetMatrixArray();
-  // GetEigenVectors is such that noise = noiseSqrt * evs * noiseSqrt'
-  // We're evaluating the first product with the eigenvalues replaced
-  // by their square roots, so we're multiplying with a diagonal
-  // matrix from the right.
-  int iCol = 0;
-  for (; iCol < noiseSqrt.GetNrows(); ++iCol) {
-    double ev = pEvs[iCol] > 0 ? sqrt(pEvs[iCol]) : 0;
-    // if (ev == 0)
-    //  break;
-    for (int j = 0; j < noiseSqrt.GetNrows(); ++j) {
-      pNoiseSqrt[j*noiseSqrt.GetNcols() + iCol] *= ev;
+  void
+  tools::noiseMatrixSqrt(const TMatrixDSym& noise,
+                         TMatrixD& noiseSqrt)
+  {
+    // This is the slowest part of the whole Sqrt Kalman.  Using an LDLt
+    // transform is probably the easiest way of remedying this.
+    TMatrixDSymEigen eig(noise);
+    noiseSqrt.ResizeTo(noise);
+    noiseSqrt = eig.GetEigenVectors();
+    double* pNoiseSqrt = noiseSqrt.GetMatrixArray();
+    const TVectorD& evs(eig.GetEigenValues());
+    const double* pEvs = evs.GetMatrixArray();
+    // GetEigenVectors is such that noise = noiseSqrt * evs * noiseSqrt'
+    // We're evaluating the first product with the eigenvalues replaced
+    // by their square roots, so we're multiplying with a diagonal
+    // matrix from the right.
+    int iCol = 0;
+    for (; iCol < noiseSqrt.GetNrows(); ++iCol) {
+      double ev = pEvs[iCol] > 0 ? sqrt(pEvs[iCol]) : 0;
+      // if (ev == 0)
+      //  break;
+      for (int j = 0; j < noiseSqrt.GetNrows(); ++j) {
+        pNoiseSqrt[j * noiseSqrt.GetNcols() + iCol] *= ev;
+      }
     }
-  }
-  if (iCol < noiseSqrt.GetNcols()) {
-    // Hit zero eigenvalue, resize matrix
-    noiseSqrt.ResizeTo(noiseSqrt.GetNrows(), iCol);
-  }
+    if (iCol < noiseSqrt.GetNcols()) {
+      // Hit zero eigenvalue, resize matrix
+      noiseSqrt.ResizeTo(noiseSqrt.GetNrows(), iCol);
+    }
 
-  // noiseSqrt * noiseSqrt' = noise
-}
+    // noiseSqrt * noiseSqrt' = noise
+  }
 
 
 // Transports the square root of the covariance matrix using a
@@ -373,24 +375,24 @@ tools::noiseMatrixSqrt(const TMatrixDSym& noise,
 //
 // With covariance square root S, transport matrix F and noise matrix
 // square root Q.
-void
-tools::kalmanPredictionCovSqrt(const TMatrixD& S,
-			       const TMatrixD& F, const TMatrixD& Q,
-			       TMatrixD& Snew)
-{
-  Snew.ResizeTo(S.GetNrows() + Q.GetNcols(),
-		S.GetNcols());
+  void
+  tools::kalmanPredictionCovSqrt(const TMatrixD& S,
+                                 const TMatrixD& F, const TMatrixD& Q,
+                                 TMatrixD& Snew)
+  {
+    Snew.ResizeTo(S.GetNrows() + Q.GetNcols(),
+                  S.GetNcols());
 
-  // This overwrites all elements, no precautions necessary
-  Snew.SetSub(0, 0, TMatrixD(S, TMatrixD::kMultTranspose, F));
-  if (Q.GetNcols() != 0)
-    Snew.SetSub(S.GetNrows(), 0, TMatrixD(TMatrixD::kTransposed, Q));
+    // This overwrites all elements, no precautions necessary
+    Snew.SetSub(0, 0, TMatrixD(S, TMatrixD::kMultTranspose, F));
+    if (Q.GetNcols() != 0)
+      Snew.SetSub(S.GetNrows(), 0, TMatrixD(TMatrixD::kTransposed, Q));
 
-  tools::QR(Snew);
+    tools::QR(Snew);
 
-  // The result is in the upper right corner of the matrix.
-  Snew.ResizeTo(S.GetNrows(), S.GetNrows());
-}
+    // The result is in the upper right corner of the matrix.
+    Snew.ResizeTo(S.GetNrows(), S.GetNrows());
+  }
 
 
 // Kalman measurement update (no transport)
@@ -398,29 +400,29 @@ tools::kalmanPredictionCovSqrt(const TMatrixD& S,
 // res, R, H : residual, measurement covariance square root, H matrix of the measurement
 // gives the update (new state = x + update) and the updated covariance square root.
 // S and Snew are allowed to refer to the same object.
-void
-tools::kalmanUpdateSqrt(const TMatrixD& S,
-			const TVectorD& res, const TMatrixD& R,
-			const AbsHMatrix* H,
-			TVectorD& update, TMatrixD& SNew)
-{
-  TMatrixD pre(S.GetNrows() + R.GetNrows(),
-	       S.GetNcols() + R.GetNcols());
-  pre.SetSub(0,            0,         R); /* Zeros in upper right block */
-  pre.SetSub(R.GetNrows(), 0, H->MHt(S)); pre.SetSub(R.GetNrows(), R.GetNcols(), S);
+  void
+  tools::kalmanUpdateSqrt(const TMatrixD& S,
+                          const TVectorD& res, const TMatrixD& R,
+                          const AbsHMatrix* H,
+                          TVectorD& update, TMatrixD& SNew)
+  {
+    TMatrixD pre(S.GetNrows() + R.GetNrows(),
+                 S.GetNcols() + R.GetNcols());
+    pre.SetSub(0,            0,         R); /* Zeros in upper right block */
+    pre.SetSub(R.GetNrows(), 0, H->MHt(S)); pre.SetSub(R.GetNrows(), R.GetNcols(), S);
 
-  tools::QR(pre);
-  const TMatrixD& r = pre;
+    tools::QR(pre);
+    const TMatrixD& r = pre;
 
-  const TMatrixD& a(r.GetSub(0, R.GetNrows()-1,
-			     0, R.GetNcols()-1));
-  TMatrixD K(TMatrixD::kTransposed, r.GetSub(0, R.GetNrows()-1, R.GetNcols(), pre.GetNcols()-1));
-  SNew = r.GetSub(R.GetNrows(), pre.GetNrows()-1, R.GetNcols(), pre.GetNcols()-1);
+    const TMatrixD& a(r.GetSub(0, R.GetNrows() - 1,
+                               0, R.GetNcols() - 1));
+    TMatrixD K(TMatrixD::kTransposed, r.GetSub(0, R.GetNrows() - 1, R.GetNcols(), pre.GetNcols() - 1));
+    SNew = r.GetSub(R.GetNrows(), pre.GetNrows() - 1, R.GetNcols(), pre.GetNcols() - 1);
 
-  update.ResizeTo(res);
-  update = res;
-  tools::transposedForwardSubstitution(a, update);
-  update *= K;
-}
+    update.ResizeTo(res);
+    update = res;
+    tools::transposedForwardSubstitution(a, update);
+    update *= K;
+  }
 
 } /* End of namespace genfit */

--- a/core/src/Track.cc
+++ b/core/src/Track.cc
@@ -42,1473 +42,1524 @@
 
 namespace genfit {
 
-Track::Track() :
-  cardinalRep_(0), fitStatuses_(), mcTrackId_(-1), timeSeed_(0), stateSeed_(6), covSeed_(6)
-{
-  ;
-}
-
-
-Track::Track(const TrackCand& trackCand, const MeasurementFactory<AbsMeasurement>& factory, AbsTrackRep* rep) :
-  cardinalRep_(0), fitStatuses_(), stateSeed_(6), covSeed_(6)
-{
-
-  if (rep != nullptr)
-    addTrackRep(rep);
-
-  createMeasurements(trackCand, factory);
-
-  // Copy seed information from candidate
-  timeSeed_ = trackCand.getTimeSeed();
-  stateSeed_ = trackCand.getStateSeed();
-  covSeed_ = trackCand.getCovSeed();
-
-  mcTrackId_ = trackCand.getMcTrackId();
-
-  // fill cache
-  fillPointsWithMeasurement();
-
-  checkConsistency();
-}
-
-void
-Track::createMeasurements(const TrackCand& trackCand, const MeasurementFactory<AbsMeasurement>& factory)
-{
-  // create the measurements using the factory.
-  std::vector <AbsMeasurement*> factoryHits = factory.createMany(trackCand);
-
-  if (factoryHits.size() != trackCand.getNHits()) {
-    Exception exc("Track::Track ==> factoryHits.size() != trackCand->getNHits()",__LINE__,__FILE__);
-    exc.setFatal();
-    throw exc;
+  Track::Track() :
+    cardinalRep_(0), fitStatuses_(), mcTrackId_(-1), timeSeed_(0), stateSeed_(6), covSeed_(6)
+  {
+    ;
   }
 
-  // create TrackPoints
-  for (unsigned int i=0; i<factoryHits.size(); ++i){
-    TrackPoint* tp = new TrackPoint(factoryHits[i], this);
-    tp->setSortingParameter(trackCand.getHit(i)->getSortingParameter());
-    insertPoint(tp);
-  }
-}
 
+  Track::Track(const TrackCand& trackCand, const MeasurementFactory<AbsMeasurement>& factory, AbsTrackRep* rep) :
+    cardinalRep_(0), fitStatuses_(), stateSeed_(6), covSeed_(6)
+  {
 
-Track::Track(AbsTrackRep* trackRep, const TVectorD& stateSeed) :
-  cardinalRep_(0), fitStatuses_(), mcTrackId_(-1), timeSeed_(0), stateSeed_(stateSeed),
-  covSeed_(TMatrixDSym::kUnit, TMatrixDSym(6))
-{
-  addTrackRep(trackRep);
-}
+    if (rep != nullptr)
+      addTrackRep(rep);
 
+    createMeasurements(trackCand, factory);
 
-Track::Track(AbsTrackRep* trackRep, const TVector3& posSeed, const TVector3& momSeed) :
-  cardinalRep_(0), fitStatuses_(), mcTrackId_(-1), timeSeed_(0), stateSeed_(6),
-  covSeed_(TMatrixDSym::kUnit, TMatrixDSym(6))
-{
-  addTrackRep(trackRep);
-  setStateSeed(posSeed, momSeed);
-}
+    // Copy seed information from candidate
+    timeSeed_ = trackCand.getTimeSeed();
+    stateSeed_ = trackCand.getStateSeed();
+    covSeed_ = trackCand.getCovSeed();
 
+    mcTrackId_ = trackCand.getMcTrackId();
 
-Track::Track(AbsTrackRep* trackRep, const TVectorD& stateSeed, const TMatrixDSym& covSeed) :
-  cardinalRep_(0), fitStatuses_(), mcTrackId_(-1), timeSeed_(0), stateSeed_(stateSeed),
-  covSeed_(covSeed)
-{
-  addTrackRep(trackRep);
-}
+    // fill cache
+    fillPointsWithMeasurement();
 
-
-Track::Track(const Track& rhs) :
-  TObject(rhs),
-  cardinalRep_(rhs.cardinalRep_), mcTrackId_(rhs.mcTrackId_), timeSeed_(rhs.timeSeed_),
-  stateSeed_(rhs.stateSeed_), covSeed_(rhs.covSeed_)
-{
-  rhs.checkConsistency();
-
-  std::map<const AbsTrackRep*, AbsTrackRep*> oldRepNewRep;
-
-  for (std::vector<AbsTrackRep*>::const_iterator it=rhs.trackReps_.begin(); it!=rhs.trackReps_.end(); ++it) {
-    AbsTrackRep* newRep = (*it)->clone();
-    addTrackRep(newRep);
-    oldRepNewRep[(*it)] = newRep;
+    checkConsistency();
   }
 
-  trackPoints_.reserve(rhs.trackPoints_.size());
-  for (std::vector<TrackPoint*>::const_iterator it=rhs.trackPoints_.begin(); it!=rhs.trackPoints_.end(); ++it) {
-    trackPoints_.push_back(new TrackPoint(**it, oldRepNewRep));
-    trackPoints_.back()->setTrack(this);
-  }
+  void
+  Track::createMeasurements(const TrackCand& trackCand, const MeasurementFactory<AbsMeasurement>& factory)
+  {
+    // create the measurements using the factory.
+    std::vector <AbsMeasurement*> factoryHits = factory.createMany(trackCand);
 
-  for (std::map< const AbsTrackRep*, FitStatus* >::const_iterator it=rhs.fitStatuses_.begin(); it!=rhs.fitStatuses_.end(); ++it) {
-    setFitStatus(it->second->clone(), oldRepNewRep[it->first]);
-  }
-
-  fillPointsWithMeasurement();
-
-  checkConsistency();
-}
-
-Track& Track::operator=(Track other) {
-  swap(other);
-
-  for (std::vector<TrackPoint*>::const_iterator it=trackPoints_.begin(); it!=trackPoints_.end(); ++it) {
-    (*it)->setTrack(this);
-  }
-
-  fillPointsWithMeasurement();
-
-  checkConsistency();
-
-  return *this;
-}
-
-void Track::swap(Track& other) {
-  std::swap(this->trackReps_, other.trackReps_);
-  std::swap(this->cardinalRep_, other.cardinalRep_);
-  std::swap(this->trackPoints_, other.trackPoints_);
-  std::swap(this->trackPointsWithMeasurement_, other.trackPointsWithMeasurement_);
-  std::swap(this->fitStatuses_, other.fitStatuses_);
-  std::swap(this->mcTrackId_, other.mcTrackId_);
-  std::swap(this->timeSeed_, other.timeSeed_);
-  std::swap(this->stateSeed_, other.stateSeed_);
-  std::swap(this->covSeed_, other.covSeed_);
-
-}
-
-Track::~Track() {
-  this->Clear();
-}
-
-void Track::Clear(Option_t*)
-{
-  // This function is needed for TClonesArray embedding.
-  // FIXME: smarter containers or pointers needed ...
-  for (size_t i = 0; i < trackPoints_.size(); ++i)
-    delete trackPoints_[i];
-
-  trackPoints_.clear();
-  trackPointsWithMeasurement_.clear();
-
-  for (std::map< const AbsTrackRep*, FitStatus* >::iterator it = fitStatuses_.begin(); it!= fitStatuses_.end(); ++it)
-    delete it->second;
-  fitStatuses_.clear();
-
-  for (size_t i = 0; i < trackReps_.size(); ++i)
-    delete trackReps_[i];
-  trackReps_.clear();
-
-  cardinalRep_ = 0;
-
-  mcTrackId_ = -1;
-
-  timeSeed_ = 0;
-  stateSeed_.Zero();
-  covSeed_.Zero();
-}
-
-
-TrackPoint* Track::getPoint(int id) const {
-  if (id < 0)
-    id += trackPoints_.size();
-
-  return trackPoints_.at(id);
-}
-
-
-TrackPoint* Track::getPointWithMeasurement(int id) const {
-  if (id < 0)
-    id += trackPointsWithMeasurement_.size();
-
-  return trackPointsWithMeasurement_.at(id);
-}
-
-
-TrackPoint* Track::getPointWithMeasurementAndFitterInfo(int id, const AbsTrackRep* rep) const {
-  if (rep == nullptr)
-    rep = getCardinalRep();
-
-  if (id >= 0) {
-    int i = 0;
-    for (std::vector<TrackPoint*>::const_iterator it = trackPointsWithMeasurement_.begin(); it != trackPointsWithMeasurement_.end(); ++it) {
-      if ((*it)->hasFitterInfo(rep)) {
-        if (id == i)
-          return (*it);
-        ++i;
-      }
+    if (factoryHits.size() != trackCand.getNHits()) {
+      Exception exc("Track::Track ==> factoryHits.size() != trackCand->getNHits()", __LINE__, __FILE__);
+      exc.setFatal();
+      throw exc;
     }
-  } else {
-    // Search backwards.
-    int i = -1;
-    for (std::vector<TrackPoint*>::const_reverse_iterator it = trackPointsWithMeasurement_.rbegin(); it != trackPointsWithMeasurement_.rend(); ++it) {
-      if ((*it)->hasFitterInfo(rep)) {
-        if (id == i)
-          return (*it);
-        --i;
-      }
+
+    // create TrackPoints
+    for (unsigned int i = 0; i < factoryHits.size(); ++i) {
+      TrackPoint* tp = new TrackPoint(factoryHits[i], this);
+      tp->setSortingParameter(trackCand.getHit(i)->getSortingParameter());
+      insertPoint(tp);
     }
   }
 
-  // Not found, i.e. abs(id) > number of fitted TrackPoints
-  return 0;
-}
 
-
-TrackPoint* Track::getPointWithFitterInfo(int id, const AbsTrackRep* rep) const {
-  if (rep == nullptr)
-    rep = getCardinalRep();
-
-  if (id >= 0) {
-    int i = 0;
-    for (std::vector<TrackPoint*>::const_iterator it = trackPoints_.begin(); it != trackPoints_.end(); ++it) {
-      if ((*it)->hasFitterInfo(rep)) {
-        if (id == i)
-          return (*it);
-        ++i;
-      }
-    }
-  } else {
-    // Search backwards.
-    int i = -1;
-    for (std::vector<TrackPoint*>::const_reverse_iterator it = trackPoints_.rbegin(); it != trackPoints_.rend(); ++it) {
-      if ((*it)->hasFitterInfo(rep)) {
-        if (id == i)
-          return (*it);
-        --i;
-      }
-    }
+  Track::Track(AbsTrackRep* trackRep, const TVectorD& stateSeed) :
+    cardinalRep_(0), fitStatuses_(), mcTrackId_(-1), timeSeed_(0), stateSeed_(stateSeed),
+    covSeed_(TMatrixDSym::kUnit, TMatrixDSym(6))
+  {
+    addTrackRep(trackRep);
   }
 
-  // Not found, i.e. abs(id) > number of fitted TrackPoints
-  return 0;
-}
 
-
-const MeasuredStateOnPlane& Track::getFittedState(int id, const AbsTrackRep* rep, bool biased) const {
-  if (rep == nullptr)
-    rep = getCardinalRep();
-
-  TrackPoint* point = getPointWithFitterInfo(id, rep);
-  if (point == nullptr) {
-    Exception exc("Track::getFittedState ==> no trackPoint with fitterInfo for rep",__LINE__,__FILE__);
-    exc.setFatal();
-    throw exc;
-  }
-  return point->getFitterInfo(rep)->getFittedState(biased);
-}
-
-
-int Track::getIdForRep(const AbsTrackRep* rep) const
-{
-  for (size_t i = 0; i < trackReps_.size(); ++i)
-    if (trackReps_[i] == rep)
-      return i;
-
-  Exception exc("Track::getIdForRep ==> cannot find TrackRep in Track",__LINE__,__FILE__);
-  exc.setFatal();
-  throw exc;
-}
-
-
-bool Track::hasFitStatus(const AbsTrackRep* rep) const {
-  if (rep == nullptr)
-    rep = getCardinalRep();
-
-  if (fitStatuses_.find(rep) == fitStatuses_.end())
-    return false;
-
-  return (fitStatuses_.at(rep) != nullptr);
-}
-
-
-bool Track::hasKalmanFitStatus(const AbsTrackRep* rep) const {
-  if (rep == nullptr)
-    rep = getCardinalRep();
-
-  if (fitStatuses_.find(rep) == fitStatuses_.end())
-    return false;
-
-  return (dynamic_cast<KalmanFitStatus*>(fitStatuses_.at(rep)) != nullptr);
-}
-
-
-KalmanFitStatus* Track::getKalmanFitStatus(const AbsTrackRep* rep) const {
-  return dynamic_cast<KalmanFitStatus*>(getFitStatus(rep));
-}
-
-
-void Track::setFitStatus(FitStatus* fitStatus, const AbsTrackRep* rep) {
-  if (fitStatuses_.find(rep) != fitStatuses_.end())
-    delete fitStatuses_.at(rep);
-
-  fitStatuses_[rep] = fitStatus;
-}
-
-
-void Track::setStateSeed(const TVector3& pos, const TVector3& mom) {
-  stateSeed_.ResizeTo(6);
-
-  stateSeed_(0) = pos.X();
-  stateSeed_(1) = pos.Y();
-  stateSeed_(2) = pos.Z();
-
-  stateSeed_(3) = mom.X();
-  stateSeed_(4) = mom.Y();
-  stateSeed_(5) = mom.Z();
-}
-
-
-
-void Track::insertPoint(TrackPoint* point, int id) {
-
-  point->setTrack(this);
-
-  #ifdef DEBUG
-  debugOut << "Track::insertPoint at position " << id  << "\n";
-  #endif
-  assert(point!=nullptr);
-  trackHasChanged();
-
-  point->setTrack(this);
-
-  if (trackPoints_.size() == 0) {
-    trackPoints_.push_back(point);
-
-    if (point->hasRawMeasurements())
-      trackPointsWithMeasurement_.push_back(point);
-
-    return;
+  Track::Track(AbsTrackRep* trackRep, const TVector3& posSeed, const TVector3& momSeed) :
+    cardinalRep_(0), fitStatuses_(), mcTrackId_(-1), timeSeed_(0), stateSeed_(6),
+    covSeed_(TMatrixDSym::kUnit, TMatrixDSym(6))
+  {
+    addTrackRep(trackRep);
+    setStateSeed(posSeed, momSeed);
   }
 
-  if (id == -1 || id == (int)trackPoints_.size()) {
-    trackPoints_.push_back(point);
 
-    if (point->hasRawMeasurements())
-      trackPointsWithMeasurement_.push_back(point);
+  Track::Track(AbsTrackRep* trackRep, const TVectorD& stateSeed, const TMatrixDSym& covSeed) :
+    cardinalRep_(0), fitStatuses_(), mcTrackId_(-1), timeSeed_(0), stateSeed_(stateSeed),
+    covSeed_(covSeed)
+  {
+    addTrackRep(trackRep);
+  }
 
-    deleteReferenceInfo(std::max(0, (int)trackPoints_.size()-2), (int)trackPoints_.size()-1);
 
-    // delete fitter infos if inserted point has a measurement
-    if (point->hasRawMeasurements()) {
-      deleteForwardInfo(-1, -1);
-      deleteBackwardInfo(0, -2);
+  Track::Track(const Track& rhs) :
+    TObject(rhs),
+    cardinalRep_(rhs.cardinalRep_), mcTrackId_(rhs.mcTrackId_), timeSeed_(rhs.timeSeed_),
+    stateSeed_(rhs.stateSeed_), covSeed_(rhs.covSeed_)
+  {
+    rhs.checkConsistency();
+
+    std::map<const AbsTrackRep*, AbsTrackRep*> oldRepNewRep;
+
+    for (std::vector<AbsTrackRep*>::const_iterator it = rhs.trackReps_.begin(); it != rhs.trackReps_.end(); ++it) {
+      AbsTrackRep* newRep = (*it)->clone();
+      addTrackRep(newRep);
+      oldRepNewRep[(*it)] = newRep;
     }
 
-    return;
-  }
+    trackPoints_.reserve(rhs.trackPoints_.size());
+    for (std::vector<TrackPoint*>::const_iterator it = rhs.trackPoints_.begin(); it != rhs.trackPoints_.end(); ++it) {
+      trackPoints_.push_back(new TrackPoint(**it, oldRepNewRep));
+      trackPoints_.back()->setTrack(this);
+    }
 
-  // [-size, size-1] is the allowed range
-  assert(id < (ssize_t)trackPoints_.size() || -id-1 <= (ssize_t)trackPoints_.size());
-
-  if (id < 0)
-    id += trackPoints_.size() + 1;
-
-  // insert
-  trackPoints_.insert(trackPoints_.begin() + id, point);  // insert inserts BEFORE
-
-  // delete fitter infos if inserted point has a measurement
-  if (point->hasRawMeasurements()) {
-    deleteForwardInfo(id, -1);
-    deleteBackwardInfo(0, id);
-  }
-
-  // delete reference info of neighbouring points
-  deleteReferenceInfo(std::max(0, id-1), std::min((int)trackPoints_.size()-1, id+1));
-
-  fillPointsWithMeasurement();
-}
-
-
-void Track::insertPoints(std::vector<TrackPoint*> points, int id) {
-
-  int nBefore = getNumPoints();
-  int n = points.size();
-
-  if (n == 0)
-    return;
-  if (n == 1) {
-    insertPoint(points[0], id);
-    return;
-  }
-
-  for (std::vector<TrackPoint*>::iterator p = points.begin(); p != points.end(); ++p)
-    (*p)->setTrack(this);
-
-  if (id == -1 || id == (int)trackPoints_.size()) {
-    trackPoints_.insert(trackPoints_.end(), points.begin(), points.end());
-
-    deleteReferenceInfo(std::max(0, nBefore-1), nBefore);
-
-    deleteForwardInfo(nBefore, -1);
-    deleteBackwardInfo(0, std::max(0, nBefore-1));
+    for (std::map< const AbsTrackRep*, FitStatus* >::const_iterator it = rhs.fitStatuses_.begin(); it != rhs.fitStatuses_.end(); ++it) {
+      setFitStatus(it->second->clone(), oldRepNewRep[it->first]);
+    }
 
     fillPointsWithMeasurement();
 
-    return;
+    checkConsistency();
+  }
+
+  Track& Track::operator=(Track other)
+  {
+    swap(other);
+
+    for (std::vector<TrackPoint*>::const_iterator it = trackPoints_.begin(); it != trackPoints_.end(); ++it) {
+      (*it)->setTrack(this);
+    }
+
+    fillPointsWithMeasurement();
+
+    checkConsistency();
+
+    return *this;
+  }
+
+  void Track::swap(Track& other)
+  {
+    std::swap(this->trackReps_, other.trackReps_);
+    std::swap(this->cardinalRep_, other.cardinalRep_);
+    std::swap(this->trackPoints_, other.trackPoints_);
+    std::swap(this->trackPointsWithMeasurement_, other.trackPointsWithMeasurement_);
+    std::swap(this->fitStatuses_, other.fitStatuses_);
+    std::swap(this->mcTrackId_, other.mcTrackId_);
+    std::swap(this->timeSeed_, other.timeSeed_);
+    std::swap(this->stateSeed_, other.stateSeed_);
+    std::swap(this->covSeed_, other.covSeed_);
+
+  }
+
+  Track::~Track()
+  {
+    this->Clear();
+  }
+
+  void Track::Clear(Option_t*)
+  {
+    // This function is needed for TClonesArray embedding.
+    // FIXME: smarter containers or pointers needed ...
+    for (size_t i = 0; i < trackPoints_.size(); ++i)
+      delete trackPoints_[i];
+
+    trackPoints_.clear();
+    trackPointsWithMeasurement_.clear();
+
+    for (std::map< const AbsTrackRep*, FitStatus* >::iterator it = fitStatuses_.begin(); it != fitStatuses_.end(); ++it)
+      delete it->second;
+    fitStatuses_.clear();
+
+    for (size_t i = 0; i < trackReps_.size(); ++i)
+      delete trackReps_[i];
+    trackReps_.clear();
+
+    cardinalRep_ = 0;
+
+    mcTrackId_ = -1;
+
+    timeSeed_ = 0;
+    stateSeed_.Zero();
+    covSeed_.Zero();
   }
 
 
-  assert(id < (ssize_t)trackPoints_.size() || -id-1 <= (ssize_t)trackPoints_.size());
+  TrackPoint* Track::getPoint(int id) const
+  {
+    if (id < 0)
+      id += trackPoints_.size();
 
-  if (id < 0)
-    id += trackPoints_.size() + 1;
-
-
-  // insert
-  trackPoints_.insert(trackPoints_.begin() + id, points.begin(), points.end());  // insert inserts BEFORE
-
-  // delete fitter infos if inserted point has a measurement
-  deleteForwardInfo(id, -1);
-  deleteBackwardInfo(0, id+n);
-
-  // delete reference info of neighbouring points
-  deleteReferenceInfo(std::max(0, id-1), std::min((int)trackPoints_.size()-1, id));
-  deleteReferenceInfo(std::max(0, id+n-1), std::min((int)trackPoints_.size()-1, id+n));
-
-  fillPointsWithMeasurement();
-}
+    return trackPoints_.at(id);
+  }
 
 
-void Track::deletePoint(int id) {
+  TrackPoint* Track::getPointWithMeasurement(int id) const
+  {
+    if (id < 0)
+      id += trackPointsWithMeasurement_.size();
 
-  #ifdef DEBUG
-  debugOut << "Track::deletePoint at position " << id  << "\n";
-  #endif
-
-  trackHasChanged();
-
-  if (id < 0)
-    id += trackPoints_.size();
-  assert(id>0);
+    return trackPointsWithMeasurement_.at(id);
+  }
 
 
-  // delete forwardInfo after point (backwardInfo before point) if deleted point has a measurement
-  if (trackPoints_[id]->hasRawMeasurements()) {
+  TrackPoint* Track::getPointWithMeasurementAndFitterInfo(int id, const AbsTrackRep* rep) const
+  {
+    if (rep == nullptr)
+      rep = getCardinalRep();
+
+    if (id >= 0) {
+      int i = 0;
+      for (std::vector<TrackPoint*>::const_iterator it = trackPointsWithMeasurement_.begin(); it != trackPointsWithMeasurement_.end();
+           ++it) {
+        if ((*it)->hasFitterInfo(rep)) {
+          if (id == i)
+            return (*it);
+          ++i;
+        }
+      }
+    } else {
+      // Search backwards.
+      int i = -1;
+      for (std::vector<TrackPoint*>::const_reverse_iterator it = trackPointsWithMeasurement_.rbegin();
+           it != trackPointsWithMeasurement_.rend(); ++it) {
+        if ((*it)->hasFitterInfo(rep)) {
+          if (id == i)
+            return (*it);
+          --i;
+        }
+      }
+    }
+
+    // Not found, i.e. abs(id) > number of fitted TrackPoints
+    return 0;
+  }
+
+
+  TrackPoint* Track::getPointWithFitterInfo(int id, const AbsTrackRep* rep) const
+  {
+    if (rep == nullptr)
+      rep = getCardinalRep();
+
+    if (id >= 0) {
+      int i = 0;
+      for (std::vector<TrackPoint*>::const_iterator it = trackPoints_.begin(); it != trackPoints_.end(); ++it) {
+        if ((*it)->hasFitterInfo(rep)) {
+          if (id == i)
+            return (*it);
+          ++i;
+        }
+      }
+    } else {
+      // Search backwards.
+      int i = -1;
+      for (std::vector<TrackPoint*>::const_reverse_iterator it = trackPoints_.rbegin(); it != trackPoints_.rend(); ++it) {
+        if ((*it)->hasFitterInfo(rep)) {
+          if (id == i)
+            return (*it);
+          --i;
+        }
+      }
+    }
+
+    // Not found, i.e. abs(id) > number of fitted TrackPoints
+    return 0;
+  }
+
+
+  const MeasuredStateOnPlane& Track::getFittedState(int id, const AbsTrackRep* rep, bool biased) const
+  {
+    if (rep == nullptr)
+      rep = getCardinalRep();
+
+    TrackPoint* point = getPointWithFitterInfo(id, rep);
+    if (point == nullptr) {
+      Exception exc("Track::getFittedState ==> no trackPoint with fitterInfo for rep", __LINE__, __FILE__);
+      exc.setFatal();
+      throw exc;
+    }
+    return point->getFitterInfo(rep)->getFittedState(biased);
+  }
+
+
+  int Track::getIdForRep(const AbsTrackRep* rep) const
+  {
+    for (size_t i = 0; i < trackReps_.size(); ++i)
+      if (trackReps_[i] == rep)
+        return i;
+
+    Exception exc("Track::getIdForRep ==> cannot find TrackRep in Track", __LINE__, __FILE__);
+    exc.setFatal();
+    throw exc;
+  }
+
+
+  bool Track::hasFitStatus(const AbsTrackRep* rep) const
+  {
+    if (rep == nullptr)
+      rep = getCardinalRep();
+
+    if (fitStatuses_.find(rep) == fitStatuses_.end())
+      return false;
+
+    return (fitStatuses_.at(rep) != nullptr);
+  }
+
+
+  bool Track::hasKalmanFitStatus(const AbsTrackRep* rep) const
+  {
+    if (rep == nullptr)
+      rep = getCardinalRep();
+
+    if (fitStatuses_.find(rep) == fitStatuses_.end())
+      return false;
+
+    return (dynamic_cast<KalmanFitStatus*>(fitStatuses_.at(rep)) != nullptr);
+  }
+
+
+  KalmanFitStatus* Track::getKalmanFitStatus(const AbsTrackRep* rep) const
+  {
+    return dynamic_cast<KalmanFitStatus*>(getFitStatus(rep));
+  }
+
+
+  void Track::setFitStatus(FitStatus* fitStatus, const AbsTrackRep* rep)
+  {
+    if (fitStatuses_.find(rep) != fitStatuses_.end())
+      delete fitStatuses_.at(rep);
+
+    fitStatuses_[rep] = fitStatus;
+  }
+
+
+  void Track::setStateSeed(const TVector3& pos, const TVector3& mom)
+  {
+    stateSeed_.ResizeTo(6);
+
+    stateSeed_(0) = pos.X();
+    stateSeed_(1) = pos.Y();
+    stateSeed_(2) = pos.Z();
+
+    stateSeed_(3) = mom.X();
+    stateSeed_(4) = mom.Y();
+    stateSeed_(5) = mom.Z();
+  }
+
+
+
+  void Track::insertPoint(TrackPoint* point, int id)
+  {
+
+    point->setTrack(this);
+
+#ifdef DEBUG
+    debugOut << "Track::insertPoint at position " << id  << "\n";
+#endif
+    assert(point != nullptr);
+    trackHasChanged();
+
+    point->setTrack(this);
+
+    if (trackPoints_.size() == 0) {
+      trackPoints_.push_back(point);
+
+      if (point->hasRawMeasurements())
+        trackPointsWithMeasurement_.push_back(point);
+
+      return;
+    }
+
+    if (id == -1 || id == (int)trackPoints_.size()) {
+      trackPoints_.push_back(point);
+
+      if (point->hasRawMeasurements())
+        trackPointsWithMeasurement_.push_back(point);
+
+      deleteReferenceInfo(std::max(0, (int)trackPoints_.size() - 2), (int)trackPoints_.size() - 1);
+
+      // delete fitter infos if inserted point has a measurement
+      if (point->hasRawMeasurements()) {
+        deleteForwardInfo(-1, -1);
+        deleteBackwardInfo(0, -2);
+      }
+
+      return;
+    }
+
+    // [-size, size-1] is the allowed range
+    assert(id < (ssize_t)trackPoints_.size() || -id - 1 <= (ssize_t)trackPoints_.size());
+
+    if (id < 0)
+      id += trackPoints_.size() + 1;
+
+    // insert
+    trackPoints_.insert(trackPoints_.begin() + id, point);  // insert inserts BEFORE
+
+    // delete fitter infos if inserted point has a measurement
+    if (point->hasRawMeasurements()) {
+      deleteForwardInfo(id, -1);
+      deleteBackwardInfo(0, id);
+    }
+
+    // delete reference info of neighbouring points
+    deleteReferenceInfo(std::max(0, id - 1), std::min((int)trackPoints_.size() - 1, id + 1));
+
+    fillPointsWithMeasurement();
+  }
+
+
+  void Track::insertPoints(std::vector<TrackPoint*> points, int id)
+  {
+
+    int nBefore = getNumPoints();
+    int n = points.size();
+
+    if (n == 0)
+      return;
+    if (n == 1) {
+      insertPoint(points[0], id);
+      return;
+    }
+
+    for (std::vector<TrackPoint*>::iterator p = points.begin(); p != points.end(); ++p)
+      (*p)->setTrack(this);
+
+    if (id == -1 || id == (int)trackPoints_.size()) {
+      trackPoints_.insert(trackPoints_.end(), points.begin(), points.end());
+
+      deleteReferenceInfo(std::max(0, nBefore - 1), nBefore);
+
+      deleteForwardInfo(nBefore, -1);
+      deleteBackwardInfo(0, std::max(0, nBefore - 1));
+
+      fillPointsWithMeasurement();
+
+      return;
+    }
+
+
+    assert(id < (ssize_t)trackPoints_.size() || -id - 1 <= (ssize_t)trackPoints_.size());
+
+    if (id < 0)
+      id += trackPoints_.size() + 1;
+
+
+    // insert
+    trackPoints_.insert(trackPoints_.begin() + id, points.begin(), points.end());  // insert inserts BEFORE
+
+    // delete fitter infos if inserted point has a measurement
     deleteForwardInfo(id, -1);
-    deleteBackwardInfo(0, id-1);
+    deleteBackwardInfo(0, id + n);
+
+    // delete reference info of neighbouring points
+    deleteReferenceInfo(std::max(0, id - 1), std::min((int)trackPoints_.size() - 1, id));
+    deleteReferenceInfo(std::max(0, id + n - 1), std::min((int)trackPoints_.size() - 1, id + n));
+
+    fillPointsWithMeasurement();
   }
 
-  // delete reference info of neighbouring points
-  deleteReferenceInfo(std::max(0, id-1), std::min((int)trackPoints_.size()-1, id+1));
 
-  // delete point
-  std::vector<TrackPoint*>::iterator it = std::find(trackPointsWithMeasurement_.begin(), trackPointsWithMeasurement_.end(), trackPoints_[id]);
-  if (it != trackPointsWithMeasurement_.end())
-    trackPointsWithMeasurement_.erase(it);
+  void Track::deletePoint(int id)
+  {
 
-  delete trackPoints_[id];
-  trackPoints_.erase(trackPoints_.begin()+id);
+#ifdef DEBUG
+    debugOut << "Track::deletePoint at position " << id  << "\n";
+#endif
 
-  fillPointsWithMeasurement();
+    trackHasChanged();
 
-}
+    if (id < 0)
+      id += trackPoints_.size();
+    assert(id > 0);
 
 
-void Track::insertMeasurement(AbsMeasurement* measurement, int id) {
-  insertPoint(new TrackPoint(measurement, this), id);
-}
-  
-void Track::deleteFittedState(const genfit::AbsTrackRep* rep) {
-  if(hasFitStatus(rep)) {
+    // delete forwardInfo after point (backwardInfo before point) if deleted point has a measurement
+    if (trackPoints_[id]->hasRawMeasurements()) {
+      deleteForwardInfo(id, -1);
+      deleteBackwardInfo(0, id - 1);
+    }
+
+    // delete reference info of neighbouring points
+    deleteReferenceInfo(std::max(0, id - 1), std::min((int)trackPoints_.size() - 1, id + 1));
+
+    // delete point
+    std::vector<TrackPoint*>::iterator it = std::find(trackPointsWithMeasurement_.begin(), trackPointsWithMeasurement_.end(),
+                                                      trackPoints_[id]);
+    if (it != trackPointsWithMeasurement_.end())
+      trackPointsWithMeasurement_.erase(it);
+
+    delete trackPoints_[id];
+    trackPoints_.erase(trackPoints_.begin() + id);
+
+    fillPointsWithMeasurement();
+
+  }
+
+
+  void Track::insertMeasurement(AbsMeasurement* measurement, int id)
+  {
+    insertPoint(new TrackPoint(measurement, this), id);
+  }
+
+  void Track::deleteFittedState(const genfit::AbsTrackRep* rep)
+  {
+    if (hasFitStatus(rep)) {
+      delete fitStatuses_.at(rep);
+      fitStatuses_.erase(rep);
+    }
+
+    // delete FitterInfos related to the deleted TrackRep
+    for (const auto& trackPoint : trackPoints_) {
+      if (trackPoint->hasFitterInfo(rep)) {
+        trackPoint->deleteFitterInfo(rep);
+      }
+    }
+  }
+
+
+  void Track::mergeTrack(const Track* other, int id)
+  {
+
+#ifdef DEBUG
+    debugOut << "Track::mergeTrack\n";
+#endif
+
+    if (other->getNumPoints() == 0)
+      return;
+
+    std::map<const AbsTrackRep*, AbsTrackRep*> otherRepThisRep;
+    std::vector<const AbsTrackRep*> otherRepsToRemove;
+
+    for (std::vector<AbsTrackRep*>::const_iterator otherRep = other->trackReps_.begin(); otherRep != other->trackReps_.end();
+         ++otherRep) {
+      bool found(false);
+      for (std::vector<AbsTrackRep*>::const_iterator thisRep = trackReps_.begin(); thisRep != trackReps_.end(); ++thisRep) {
+        if ((*thisRep)->isSame(*otherRep)) {
+          otherRepThisRep[*otherRep] = *thisRep;
+#ifdef DEBUG
+          debugOut << " map other rep " << *otherRep << " to " << (*thisRep) << "\n";
+#endif
+          if (found) {
+            Exception exc("Track::mergeTrack ==> more than one matching rep.", __LINE__, __FILE__);
+            exc.setFatal();
+            throw exc;
+          }
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        otherRepsToRemove.push_back(*otherRep);
+#ifdef DEBUG
+        debugOut << " remove other rep " << *otherRep << "\n";
+#endif
+      }
+    }
+
+
+    std::vector<TrackPoint*> points;
+    points.reserve(other->getNumPoints());
+
+    for (std::vector<TrackPoint*>::const_iterator otherTp = other->trackPoints_.begin(); otherTp != other->trackPoints_.end();
+         ++otherTp) {
+      points.push_back(new TrackPoint(**otherTp, otherRepThisRep, &otherRepsToRemove));
+    }
+
+    insertPoints(points, id);
+  }
+
+
+  void Track::addTrackRep(AbsTrackRep* trackRep)
+  {
+    trackReps_.push_back(trackRep);
+    fitStatuses_[trackRep] = new FitStatus();
+  }
+
+
+  void Track::deleteTrackRep(int id)
+  {
+    if (id < 0)
+      id += trackReps_.size();
+
+    AbsTrackRep* rep = trackReps_.at(id);
+
+    // update cardinalRep_
+    if (int(cardinalRep_) == id)
+      cardinalRep_ = 0; // reset
+    else if (int(cardinalRep_) > id)
+      --cardinalRep_; // make cardinalRep_ point to the same TrackRep before and after deletion
+
+    // delete FitterInfos related to the deleted TrackRep
+    for (std::vector<TrackPoint*>::const_iterator pointIt = trackPoints_.begin(); pointIt != trackPoints_.end(); ++pointIt) {
+      (*pointIt)->deleteFitterInfo(rep);
+    }
+
+    // delete fitStatus
     delete fitStatuses_.at(rep);
     fitStatuses_.erase(rep);
+
+    // delete rep
+    delete rep;
+    trackReps_.erase(trackReps_.begin() + id);
   }
 
-  // delete FitterInfos related to the deleted TrackRep
-  for (const auto& trackPoint : trackPoints_) {
-    if(trackPoint->hasFitterInfo(rep)) {
-      trackPoint->deleteFitterInfo(rep);
+
+  void Track::setCardinalRep(int id)
+  {
+
+    if (id < 0)
+      id += trackReps_.size();
+
+    if (id >= 0 && (unsigned int)id < trackReps_.size())
+      cardinalRep_ = id;
+    else {
+      cardinalRep_ = 0;
+      errorOut << "Track::setCardinalRep: Attempted to set cardinalRep_ to a value out of bounds. Resetting  cardinalRep_ to 0." <<
+               std::endl;
     }
   }
-}
 
 
-void Track::mergeTrack(const Track* other, int id) {
+  void Track::determineCardinalRep()
+  {
 
-  #ifdef DEBUG
-  debugOut << "Track::mergeTrack\n";
-  #endif
+    // Todo: test
 
-  if (other->getNumPoints() == 0)
-    return;
+    if (trackReps_.size() <= 1)
+      return;
 
-  std::map<const AbsTrackRep*, AbsTrackRep*> otherRepThisRep;
-  std::vector<const AbsTrackRep*> otherRepsToRemove;
+    double minChi2(9.E99);
+    const AbsTrackRep* bestRep(nullptr);
 
-  for (std::vector<AbsTrackRep*>::const_iterator otherRep=other->trackReps_.begin(); otherRep!=other->trackReps_.end(); ++otherRep) {
-    bool found(false);
-    for (std::vector<AbsTrackRep*>::const_iterator thisRep=trackReps_.begin(); thisRep!=trackReps_.end(); ++thisRep) {
-      if ((*thisRep)->isSame(*otherRep)) {
-        otherRepThisRep[*otherRep] = *thisRep;
-        #ifdef DEBUG
-        debugOut << " map other rep " << *otherRep << " to " << (*thisRep) << "\n";
-        #endif
-        if (found) {
-          Exception exc("Track::mergeTrack ==> more than one matching rep.",__LINE__,__FILE__);
-          exc.setFatal();
-          throw exc;
+    for (std::map< const AbsTrackRep*, FitStatus* >::const_iterator it = fitStatuses_.begin(); it != fitStatuses_.end(); ++it) {
+      if (it->second->isFitConverged()) {
+        if (it->second->getChi2() < minChi2) {
+          minChi2 = it->second->getChi2();
+          bestRep = it->first;
         }
-        found = true;
+      }
+    }
+
+    if (bestRep != nullptr) {
+      setCardinalRep(getIdForRep(bestRep));
+    }
+  }
+
+
+  bool Track::sort()
+  {
+#ifdef DEBUG
+    debugOut << "Track::sort \n";
+#endif
+
+    int nPoints(trackPoints_.size());
+    // original order
+    std::vector<TrackPoint*> pointsBefore(trackPoints_);
+
+    // sort
+    std::stable_sort(trackPoints_.begin(), trackPoints_.end(), TrackPointComparator());
+
+    // see where order changed
+    int equalUntil(-1), equalFrom(nPoints);
+    for (int i = 0; i < nPoints; ++i) {
+      if (pointsBefore[i] == trackPoints_[i])
+        equalUntil = i;
+      else
         break;
+    }
+
+    if (equalUntil == nPoints - 1)
+      return false; // sorting did not change anything
+
+
+    trackHasChanged();
+
+    for (int i = nPoints - 1; i > equalUntil; --i) {
+      if (pointsBefore[i] == trackPoints_[i])
+        equalFrom = i;
+      else
+        break;
+    }
+
+#ifdef DEBUG
+    debugOut << "Track::sort. Equal up to (including) hit " << equalUntil << " and from (including) hit " << equalFrom << " \n";
+#endif
+
+    deleteForwardInfo(equalUntil + 1, -1);
+    deleteBackwardInfo(0, equalFrom - 1);
+
+    deleteReferenceInfo(std::max(0, equalUntil + 1), std::min((int)trackPoints_.size() - 1, equalFrom - 1));
+
+    fillPointsWithMeasurement();
+
+    return true;
+  }
+
+
+  bool Track::udpateSeed(int id, AbsTrackRep* rep, bool biased)
+  {
+    try {
+      const MeasuredStateOnPlane& fittedState = getFittedState(id, rep, biased);
+      setTimeSeed(fittedState.getTime());
+      setStateSeed(fittedState.get6DState());
+      setCovSeed(fittedState.get6DCov());
+
+      double fittedCharge = fittedState.getCharge();
+
+      for (unsigned int i = 0; i < trackReps_.size(); ++i) {
+        if (trackReps_[i]->getPDGCharge() * fittedCharge < 0) {
+          trackReps_[i]->switchPDGSign();
+        }
       }
+    } catch (Exception& e) {
+      // in this case the original track seed will be used
+      return false;
     }
-    if (!found) {
-      otherRepsToRemove.push_back(*otherRep);
-      #ifdef DEBUG
-      debugOut << " remove other rep " << *otherRep << "\n";
-      #endif
-    }
+    return true;
   }
 
 
-  std::vector<TrackPoint*> points;
-  points.reserve(other->getNumPoints());
+  void Track::reverseTrackPoints()
+  {
 
-  for (std::vector<TrackPoint*>::const_iterator otherTp=other->trackPoints_.begin(); otherTp!=other->trackPoints_.end(); ++otherTp) {
-    points.push_back(new TrackPoint(**otherTp, otherRepThisRep, &otherRepsToRemove));
+    std::reverse(trackPoints_.begin(), trackPoints_.end());
+
+    deleteForwardInfo(0, -1);
+    deleteBackwardInfo(0, -1);
+    deleteReferenceInfo(0, -1);
+
+    fillPointsWithMeasurement();
   }
 
-  insertPoints(points, id);
-}
 
-
-void Track::addTrackRep(AbsTrackRep* trackRep) {
-  trackReps_.push_back(trackRep);
-  fitStatuses_[trackRep] = new FitStatus();
-}
-
-
-void Track::deleteTrackRep(int id) {
-  if (id < 0)
-    id += trackReps_.size();
-
-  AbsTrackRep* rep = trackReps_.at(id);
-
-  // update cardinalRep_
-  if (int(cardinalRep_) == id)
-    cardinalRep_ = 0; // reset
-  else if (int(cardinalRep_) > id)
-    --cardinalRep_; // make cardinalRep_ point to the same TrackRep before and after deletion
-
-  // delete FitterInfos related to the deleted TrackRep
-  for (std::vector<TrackPoint*>::const_iterator pointIt = trackPoints_.begin(); pointIt != trackPoints_.end(); ++pointIt) {
-    (*pointIt)->deleteFitterInfo(rep);
-  }
-
-  // delete fitStatus
-  delete fitStatuses_.at(rep);
-  fitStatuses_.erase(rep);
-
-  // delete rep
-  delete rep;
-  trackReps_.erase(trackReps_.begin()+id);
-}
-
-
-void Track::setCardinalRep(int id) {
-
-  if (id < 0)
-    id += trackReps_.size();
-
-  if (id >= 0 && (unsigned int)id < trackReps_.size())
-    cardinalRep_ = id;
-  else {
-    cardinalRep_ = 0;
-    errorOut << "Track::setCardinalRep: Attempted to set cardinalRep_ to a value out of bounds. Resetting  cardinalRep_ to 0." << std::endl;
-  }
-}
-
-
-void Track::determineCardinalRep() {
-
-  // Todo: test
-
-  if (trackReps_.size() <= 1)
-    return;
-
-  double minChi2(9.E99);
-  const AbsTrackRep* bestRep(nullptr);
-
-  for (std::map< const AbsTrackRep*, FitStatus* >::const_iterator it = fitStatuses_.begin(); it != fitStatuses_.end(); ++it) {
-    if (it->second->isFitConverged()) {
-      if (it->second->getChi2() < minChi2) {
-        minChi2 = it->second->getChi2();
-        bestRep = it->first;
-      }
-    }
-  }
-
-  if (bestRep != nullptr) {
-    setCardinalRep(getIdForRep(bestRep));
-  }
-}
-
-
-bool Track::sort() {
-  #ifdef DEBUG
-  debugOut << "Track::sort \n";
-  #endif
-
-  int nPoints(trackPoints_.size());
-  // original order
-  std::vector<TrackPoint*> pointsBefore(trackPoints_);
-
-  // sort
-  std::stable_sort(trackPoints_.begin(), trackPoints_.end(), TrackPointComparator());
-
-  // see where order changed
-  int equalUntil(-1), equalFrom(nPoints);
-  for (int i = 0; i<nPoints; ++i) {
-    if (pointsBefore[i] == trackPoints_[i])
-      equalUntil = i;
-    else
-      break;
-  }
-
-  if (equalUntil == nPoints-1)
-    return false; // sorting did not change anything
-
-
-  trackHasChanged();
-
-  for (int i = nPoints-1; i>equalUntil; --i) {
-    if (pointsBefore[i] == trackPoints_[i])
-      equalFrom = i;
-    else
-      break;
-  }
-
-  #ifdef DEBUG
-  debugOut << "Track::sort. Equal up to (including) hit " << equalUntil << " and from (including) hit " << equalFrom << " \n";
-  #endif
-
-  deleteForwardInfo(equalUntil+1, -1);
-  deleteBackwardInfo(0, equalFrom-1);
-
-  deleteReferenceInfo(std::max(0, equalUntil+1), std::min((int)trackPoints_.size()-1, equalFrom-1));
-
-  fillPointsWithMeasurement();
-
-  return true;
-}
-
-
-bool Track::udpateSeed(int id, AbsTrackRep* rep, bool biased) {
-  try {
-    const MeasuredStateOnPlane& fittedState = getFittedState(id, rep, biased);
-    setTimeSeed(fittedState.getTime());
-    setStateSeed(fittedState.get6DState());
-    setCovSeed(fittedState.get6DCov());
-
-    double fittedCharge = fittedState.getCharge();
-
-    for (unsigned int i = 0; i<trackReps_.size(); ++i) {
-      if (trackReps_[i]->getPDGCharge() * fittedCharge < 0) {
-        trackReps_[i]->switchPDGSign();
-      }
-    }
-  }
-  catch (Exception& e) {
-    // in this case the original track seed will be used
-    return false;
-  }
-  return true;
-}
-
-
-void Track::reverseTrackPoints() {
-
-  std::reverse(trackPoints_.begin(),trackPoints_.end());
-
-  deleteForwardInfo(0, -1);
-  deleteBackwardInfo(0, -1);
-  deleteReferenceInfo(0, -1);
-
-  fillPointsWithMeasurement();
-}
-
-
-void Track::switchPDGSigns(AbsTrackRep* rep) {
-  if (rep != nullptr) {
-    rep->switchPDGSign();
-    return;
-  }
-
-  for (unsigned int i = 0; i<trackReps_.size(); ++i) {
-    trackReps_[i]->switchPDGSign();
-  }
-}
-
-
-void Track::reverseTrack() {
-  udpateSeed(-1); // set fitted state of last hit as new seed
-  reverseMomSeed(); // flip momentum direction
-  switchPDGSigns();
-  reverseTrackPoints(); // also deletes all fitterInfos
-}
-
-
-void Track::deleteForwardInfo(int startId, int endId, const AbsTrackRep* rep) {
-  #ifdef DEBUG
-  debugOut << "Track::deleteForwardInfo from position " << startId  << " to " << endId << "\n";
-  #endif
-
-  trackHasChanged();
-
-  if (startId < 0)
-    startId += trackPoints_.size();
-  if (endId < 0)
-    endId += trackPoints_.size();
-  endId += 1;
-
-  assert (endId >= startId);
-
-  for (std::vector<TrackPoint*>::const_iterator pointIt = trackPoints_.begin() + startId; pointIt != trackPoints_.begin() + endId; ++pointIt) {
+  void Track::switchPDGSigns(AbsTrackRep* rep)
+  {
     if (rep != nullptr) {
-      if ((*pointIt)->hasFitterInfo(rep))
-        (*pointIt)->getFitterInfo(rep)->deleteForwardInfo();
-    }
-    else {
-      const std::vector<AbsFitterInfo*> fitterInfos = (*pointIt)->getFitterInfos();
-      for (std::vector<AbsFitterInfo*>::const_iterator fitterInfoIt = fitterInfos.begin(); fitterInfoIt != fitterInfos.end(); ++fitterInfoIt) {
-        (*fitterInfoIt)->deleteForwardInfo();
-      }
-    }
-  }
-}
-
-void Track::deleteBackwardInfo(int startId, int endId, const AbsTrackRep* rep) {
-
-  #ifdef DEBUG
-  debugOut << "Track::deleteBackwardInfo from position " << startId  << " to " << endId << "\n";
-  #endif
-
-  trackHasChanged();
-
-  if (startId < 0)
-    startId += trackPoints_.size();
-  if (endId < 0)
-    endId += trackPoints_.size();
-  endId += 1;
-
-  assert (endId >= startId);
-
-
-  for (std::vector<TrackPoint*>::const_iterator pointIt = trackPoints_.begin() + startId; pointIt != trackPoints_.begin() + endId; ++pointIt) {
-    if (rep != nullptr) {
-      if ((*pointIt)->hasFitterInfo(rep))
-        (*pointIt)->getFitterInfo(rep)->deleteBackwardInfo();
-    }
-    else {
-      const std::vector<AbsFitterInfo*> fitterInfos = (*pointIt)->getFitterInfos();
-      for (std::vector<AbsFitterInfo*>::const_iterator fitterInfoIt = fitterInfos.begin(); fitterInfoIt != fitterInfos.end(); ++fitterInfoIt) {
-        (*fitterInfoIt)->deleteBackwardInfo();
-      }
-    }
-  }
-}
-
-void Track::deleteReferenceInfo(int startId, int endId, const AbsTrackRep* rep) {
-
-  #ifdef DEBUG
-  debugOut << "Track::deleteReferenceInfo from position " << startId  << " to " << endId << "\n";
-  #endif
-
-  trackHasChanged();
-
-  if (startId < 0)
-    startId += trackPoints_.size();
-  if (endId < 0)
-    endId += trackPoints_.size();
-  endId += 1;
-
-  assert (endId >= startId);
-
-  for (std::vector<TrackPoint*>::const_iterator pointIt = trackPoints_.begin() + startId; pointIt != trackPoints_.begin() + endId; ++pointIt) {
-    if (rep != nullptr) {
-      if ((*pointIt)->hasFitterInfo(rep))
-        (*pointIt)->getFitterInfo(rep)->deleteReferenceInfo();
-    }
-    else {
-      std::vector<AbsFitterInfo*> fitterInfos = (*pointIt)->getFitterInfos();
-      for (std::vector<AbsFitterInfo*>::const_iterator fitterInfoIt = fitterInfos.begin(); fitterInfoIt != fitterInfos.end(); ++fitterInfoIt) {
-        (*fitterInfoIt)->deleteReferenceInfo();
-      }
-    }
-  }
-}
-
-void Track::deleteMeasurementInfo(int startId, int endId, const AbsTrackRep* rep) {
-
-  #ifdef DEBUG
-  debugOut << "Track::deleteMeasurementInfo from position " << startId  << " to " << endId << "\n";
-  #endif
-
-  trackHasChanged();
-
-  if (startId < 0)
-    startId += trackPoints_.size();
-  if (endId < 0)
-    endId += trackPoints_.size();
-  endId += 1;
-
-  assert (endId >= startId);
-
-  for (std::vector<TrackPoint*>::const_iterator pointIt = trackPoints_.begin() + startId; pointIt != trackPoints_.begin() + endId; ++pointIt) {
-    if (rep != nullptr) {
-      if ((*pointIt)->hasFitterInfo(rep))
-        (*pointIt)->getFitterInfo(rep)->deleteMeasurementInfo();
-    }
-    else {
-      std::vector<AbsFitterInfo*> fitterInfos = (*pointIt)->getFitterInfos();
-      for (std::vector<AbsFitterInfo*>::const_iterator fitterInfoIt = fitterInfos.begin(); fitterInfoIt != fitterInfos.end(); ++fitterInfoIt) {
-        (*fitterInfoIt)->deleteMeasurementInfo();
-      }
-    }
-  }
-}
-
-void Track::deleteFitterInfo(int startId, int endId, const AbsTrackRep* rep) {
-
-  #ifdef DEBUG
-  debugOut << "Track::deleteFitterInfo from position " << startId  << " to " << endId << "\n";
-  #endif
-
-  trackHasChanged();
-
-  if (startId < 0)
-    startId += trackPoints_.size();
-  if (endId < 0)
-    endId += trackPoints_.size();
-  endId += 1;
-
-  assert (endId >= startId);
-
-  for (std::vector<TrackPoint*>::const_iterator pointIt = trackPoints_.begin() + startId; pointIt != trackPoints_.begin() + endId; ++pointIt) {
-    if (rep != nullptr) {
-      if ((*pointIt)->hasFitterInfo(rep))
-        (*pointIt)->deleteFitterInfo(rep);
-    }
-    else {
-      for (std::vector<AbsTrackRep*>::const_iterator repIt = trackReps_.begin(); repIt != trackReps_.end(); ++repIt) {
-        if ((*pointIt)->hasFitterInfo(*repIt))
-          (*pointIt)->deleteFitterInfo(*repIt);
-      }
-    }
-  }
-}
-
-
-double Track::getTrackLen(AbsTrackRep* rep, int startId, int endId) const {
-
-  if (startId < 0)
-    startId += trackPoints_.size();
-  if (endId < 0)
-    endId += trackPoints_.size();
-
-  bool backwards(false);
-  if (startId > endId) {
-    double temp = startId;
-    startId = endId;
-    endId = temp;
-    backwards = true;
-  }
-
-  endId += 1;
-
-  if (rep == nullptr)
-    rep = getCardinalRep();
-
-  double trackLen(0);
-  StateOnPlane state;
-
-  for (std::vector<TrackPoint*>::const_iterator pointIt = trackPoints_.begin() + startId; pointIt != trackPoints_.begin() + endId; ++pointIt) {
-    if (! (*pointIt)->hasFitterInfo(rep)) {
-      Exception e("Track::getTracklength: trackPoint has no fitterInfo", __LINE__,__FILE__);
-      throw e;
+      rep->switchPDGSign();
+      return;
     }
 
-    if (pointIt != trackPoints_.begin() + startId) {
-      trackLen += rep->extrapolateToPlane(state, (*pointIt)->getFitterInfo(rep)->getPlane());
-    }
-
-    state = (*pointIt)->getFitterInfo(rep)->getFittedState();
-  }
-
-  if (backwards)
-    trackLen *= -1.;
-
-  return trackLen;
-}
-
-
-TrackCand* Track::constructTrackCand() const {
-  TrackCand* cand = new TrackCand();
-
-  cand->setTime6DSeedAndPdgCode(timeSeed_, stateSeed_, getCardinalRep()->getPDG());
-  cand->setCovSeed(covSeed_);
-  cand->setMcTrackId(mcTrackId_);
-
-  for (unsigned int i = 0; i < trackPointsWithMeasurement_.size(); ++i) {
-    const TrackPoint* tp = trackPointsWithMeasurement_[i];
-    const std::vector< AbsMeasurement* >& measurements = tp->getRawMeasurements();
-
-    for (unsigned int j = 0; j < measurements.size(); ++j) {
-      const AbsMeasurement* m = measurements[j];
-      TrackCandHit* tch;
-
-      int planeId = -1;
-      if (dynamic_cast<const PlanarMeasurement*>(m)) {
-        planeId = static_cast<const PlanarMeasurement*>(m)->getPlaneId();
-      }
-
-      if (m->isLeftRightMeasurement()) {
-        tch = new WireTrackCandHit(m->getDetId(), m->getHitId(), planeId,
-            tp->getSortingParameter(), m->getLeftRightResolution());
-      }
-      else {
-        tch = new TrackCandHit(m->getDetId(), m->getHitId(), planeId,
-            tp->getSortingParameter());
-      }
-      cand->addHit(tch);
-    }
-  }
-
-  return cand;
-}
-
-
-double Track::getTOF(AbsTrackRep* rep, int startId, int endId) const {
-
-  if (startId < 0)
-    startId += trackPoints_.size();
-  if (endId < 0)
-    endId += trackPoints_.size();
-
-  if (startId > endId) {
-    std::swap(startId, endId);
-  }
-
-  endId += 1;
-
-  if (rep == nullptr)
-    rep = getCardinalRep();
-
-  StateOnPlane state;
-
-  const TrackPoint* startPoint(trackPoints_[startId]);
-  const TrackPoint* endPoint(trackPoints_[endId]);
-  
-  if (!startPoint->hasFitterInfo(rep)
-      || !endPoint->hasFitterInfo(rep)) {
-      Exception e("Track::getTOF: trackPoint has no fitterInfo", __LINE__,__FILE__);
-      throw e;
-    }
-
-  double tof = (rep->getTime(endPoint->getFitterInfo(rep)->getFittedState())
-		- rep->getTime(startPoint->getFitterInfo(rep)->getFittedState()));
-  return tof;
-}
-
-
-void Track::fixWeights(AbsTrackRep* rep, int startId, int endId) {
-
-  if (startId < 0)
-    startId += trackPoints_.size();
-  if (endId < 0)
-    endId += trackPoints_.size();
-
-  assert(startId >= 0);
-  assert(startId <= endId);
-  assert(endId <= (int)trackPoints_.size());
-
-  std::vector< AbsFitterInfo* > fis;
-
-  for (std::vector<TrackPoint*>::iterator tp = trackPoints_.begin() + startId; tp != trackPoints_.begin() + endId; ++tp) {
-    fis.clear();
-    if (rep == nullptr) {
-      fis = (*tp)->getFitterInfos();
-    }
-    else if ((*tp)->hasFitterInfo(rep)) {
-      fis.push_back((*tp)->getFitterInfo(rep));
-    }
-
-    for (std::vector< AbsFitterInfo* >::iterator fi = fis.begin(); fi != fis.end(); ++fi) {
-      KalmanFitterInfo* kfi = dynamic_cast<KalmanFitterInfo*>(*fi);
-      if (kfi == nullptr)
-        continue;
-
-      kfi->fixWeights();
-    }
-  }
-}
-
-
-void Track::prune(const Option_t* option) {
-
-  PruneFlags f;
-  f.setFlags(option);
-
-  for (std::map< const AbsTrackRep*, FitStatus* >::const_iterator it=fitStatuses_.begin(); it!=fitStatuses_.end(); ++it) {
-    it->second->getPruneFlags().setFlags(option);
-  }
-
-  // prune trackPoints
-  if (f.hasFlags("F") || f.hasFlags("L")) {
-    TrackPoint* firstPoint = getPointWithFitterInfo(0);
-    TrackPoint* lastPoint = getPointWithFitterInfo(-1);
-    for (unsigned int i = 0; i<trackPoints_.size(); ++i) {
-      if (trackPoints_[i] == firstPoint && f.hasFlags("F"))
-        continue;
-
-      if (trackPoints_[i] == lastPoint && f.hasFlags("L"))
-        continue;
-
-      delete trackPoints_[i];
-      trackPoints_.erase(trackPoints_.begin()+i);
-      --i;
-    }
-  }
-
-  // prune TrackReps
-  if (f.hasFlags("C")) {
     for (unsigned int i = 0; i < trackReps_.size(); ++i) {
-      if (i != cardinalRep_) {
-        deleteTrackRep(i);
+      trackReps_[i]->switchPDGSign();
+    }
+  }
+
+
+  void Track::reverseTrack()
+  {
+    udpateSeed(-1); // set fitted state of last hit as new seed
+    reverseMomSeed(); // flip momentum direction
+    switchPDGSigns();
+    reverseTrackPoints(); // also deletes all fitterInfos
+  }
+
+
+  void Track::deleteForwardInfo(int startId, int endId, const AbsTrackRep* rep)
+  {
+#ifdef DEBUG
+    debugOut << "Track::deleteForwardInfo from position " << startId  << " to " << endId << "\n";
+#endif
+
+    trackHasChanged();
+
+    if (startId < 0)
+      startId += trackPoints_.size();
+    if (endId < 0)
+      endId += trackPoints_.size();
+    endId += 1;
+
+    assert(endId >= startId);
+
+    for (std::vector<TrackPoint*>::const_iterator pointIt = trackPoints_.begin() + startId; pointIt != trackPoints_.begin() + endId;
+         ++pointIt) {
+      if (rep != nullptr) {
+        if ((*pointIt)->hasFitterInfo(rep))
+          (*pointIt)->getFitterInfo(rep)->deleteForwardInfo();
+      } else {
+        const std::vector<AbsFitterInfo*> fitterInfos = (*pointIt)->getFitterInfos();
+        for (std::vector<AbsFitterInfo*>::const_iterator fitterInfoIt = fitterInfos.begin(); fitterInfoIt != fitterInfos.end();
+             ++fitterInfoIt) {
+          (*fitterInfoIt)->deleteForwardInfo();
+        }
+      }
+    }
+  }
+
+  void Track::deleteBackwardInfo(int startId, int endId, const AbsTrackRep* rep)
+  {
+
+#ifdef DEBUG
+    debugOut << "Track::deleteBackwardInfo from position " << startId  << " to " << endId << "\n";
+#endif
+
+    trackHasChanged();
+
+    if (startId < 0)
+      startId += trackPoints_.size();
+    if (endId < 0)
+      endId += trackPoints_.size();
+    endId += 1;
+
+    assert(endId >= startId);
+
+
+    for (std::vector<TrackPoint*>::const_iterator pointIt = trackPoints_.begin() + startId; pointIt != trackPoints_.begin() + endId;
+         ++pointIt) {
+      if (rep != nullptr) {
+        if ((*pointIt)->hasFitterInfo(rep))
+          (*pointIt)->getFitterInfo(rep)->deleteBackwardInfo();
+      } else {
+        const std::vector<AbsFitterInfo*> fitterInfos = (*pointIt)->getFitterInfos();
+        for (std::vector<AbsFitterInfo*>::const_iterator fitterInfoIt = fitterInfos.begin(); fitterInfoIt != fitterInfos.end();
+             ++fitterInfoIt) {
+          (*fitterInfoIt)->deleteBackwardInfo();
+        }
+      }
+    }
+  }
+
+  void Track::deleteReferenceInfo(int startId, int endId, const AbsTrackRep* rep)
+  {
+
+#ifdef DEBUG
+    debugOut << "Track::deleteReferenceInfo from position " << startId  << " to " << endId << "\n";
+#endif
+
+    trackHasChanged();
+
+    if (startId < 0)
+      startId += trackPoints_.size();
+    if (endId < 0)
+      endId += trackPoints_.size();
+    endId += 1;
+
+    assert(endId >= startId);
+
+    for (std::vector<TrackPoint*>::const_iterator pointIt = trackPoints_.begin() + startId; pointIt != trackPoints_.begin() + endId;
+         ++pointIt) {
+      if (rep != nullptr) {
+        if ((*pointIt)->hasFitterInfo(rep))
+          (*pointIt)->getFitterInfo(rep)->deleteReferenceInfo();
+      } else {
+        std::vector<AbsFitterInfo*> fitterInfos = (*pointIt)->getFitterInfos();
+        for (std::vector<AbsFitterInfo*>::const_iterator fitterInfoIt = fitterInfos.begin(); fitterInfoIt != fitterInfos.end();
+             ++fitterInfoIt) {
+          (*fitterInfoIt)->deleteReferenceInfo();
+        }
+      }
+    }
+  }
+
+  void Track::deleteMeasurementInfo(int startId, int endId, const AbsTrackRep* rep)
+  {
+
+#ifdef DEBUG
+    debugOut << "Track::deleteMeasurementInfo from position " << startId  << " to " << endId << "\n";
+#endif
+
+    trackHasChanged();
+
+    if (startId < 0)
+      startId += trackPoints_.size();
+    if (endId < 0)
+      endId += trackPoints_.size();
+    endId += 1;
+
+    assert(endId >= startId);
+
+    for (std::vector<TrackPoint*>::const_iterator pointIt = trackPoints_.begin() + startId; pointIt != trackPoints_.begin() + endId;
+         ++pointIt) {
+      if (rep != nullptr) {
+        if ((*pointIt)->hasFitterInfo(rep))
+          (*pointIt)->getFitterInfo(rep)->deleteMeasurementInfo();
+      } else {
+        std::vector<AbsFitterInfo*> fitterInfos = (*pointIt)->getFitterInfos();
+        for (std::vector<AbsFitterInfo*>::const_iterator fitterInfoIt = fitterInfos.begin(); fitterInfoIt != fitterInfos.end();
+             ++fitterInfoIt) {
+          (*fitterInfoIt)->deleteMeasurementInfo();
+        }
+      }
+    }
+  }
+
+  void Track::deleteFitterInfo(int startId, int endId, const AbsTrackRep* rep)
+  {
+
+#ifdef DEBUG
+    debugOut << "Track::deleteFitterInfo from position " << startId  << " to " << endId << "\n";
+#endif
+
+    trackHasChanged();
+
+    if (startId < 0)
+      startId += trackPoints_.size();
+    if (endId < 0)
+      endId += trackPoints_.size();
+    endId += 1;
+
+    assert(endId >= startId);
+
+    for (std::vector<TrackPoint*>::const_iterator pointIt = trackPoints_.begin() + startId; pointIt != trackPoints_.begin() + endId;
+         ++pointIt) {
+      if (rep != nullptr) {
+        if ((*pointIt)->hasFitterInfo(rep))
+          (*pointIt)->deleteFitterInfo(rep);
+      } else {
+        for (std::vector<AbsTrackRep*>::const_iterator repIt = trackReps_.begin(); repIt != trackReps_.end(); ++repIt) {
+          if ((*pointIt)->hasFitterInfo(*repIt))
+            (*pointIt)->deleteFitterInfo(*repIt);
+        }
+      }
+    }
+  }
+
+
+  double Track::getTrackLen(AbsTrackRep* rep, int startId, int endId) const
+  {
+
+    if (startId < 0)
+      startId += trackPoints_.size();
+    if (endId < 0)
+      endId += trackPoints_.size();
+
+    bool backwards(false);
+    if (startId > endId) {
+      double temp = startId;
+      startId = endId;
+      endId = temp;
+      backwards = true;
+    }
+
+    endId += 1;
+
+    if (rep == nullptr)
+      rep = getCardinalRep();
+
+    double trackLen(0);
+    StateOnPlane state;
+
+    for (std::vector<TrackPoint*>::const_iterator pointIt = trackPoints_.begin() + startId; pointIt != trackPoints_.begin() + endId;
+         ++pointIt) {
+      if (!(*pointIt)->hasFitterInfo(rep)) {
+        Exception e("Track::getTracklength: trackPoint has no fitterInfo", __LINE__, __FILE__);
+        throw e;
+      }
+
+      if (pointIt != trackPoints_.begin() + startId) {
+        trackLen += rep->extrapolateToPlane(state, (*pointIt)->getFitterInfo(rep)->getPlane());
+      }
+
+      state = (*pointIt)->getFitterInfo(rep)->getFittedState();
+    }
+
+    if (backwards)
+      trackLen *= -1.;
+
+    return trackLen;
+  }
+
+
+  TrackCand* Track::constructTrackCand() const
+  {
+    TrackCand* cand = new TrackCand();
+
+    cand->setTime6DSeedAndPdgCode(timeSeed_, stateSeed_, getCardinalRep()->getPDG());
+    cand->setCovSeed(covSeed_);
+    cand->setMcTrackId(mcTrackId_);
+
+    for (unsigned int i = 0; i < trackPointsWithMeasurement_.size(); ++i) {
+      const TrackPoint* tp = trackPointsWithMeasurement_[i];
+      const std::vector< AbsMeasurement* >& measurements = tp->getRawMeasurements();
+
+      for (unsigned int j = 0; j < measurements.size(); ++j) {
+        const AbsMeasurement* m = measurements[j];
+        TrackCandHit* tch;
+
+        int planeId = -1;
+        if (dynamic_cast<const PlanarMeasurement*>(m)) {
+          planeId = static_cast<const PlanarMeasurement*>(m)->getPlaneId();
+        }
+
+        if (m->isLeftRightMeasurement()) {
+          tch = new WireTrackCandHit(m->getDetId(), m->getHitId(), planeId,
+                                     tp->getSortingParameter(), m->getLeftRightResolution());
+        } else {
+          tch = new TrackCandHit(m->getDetId(), m->getHitId(), planeId,
+                                 tp->getSortingParameter());
+        }
+        cand->addHit(tch);
+      }
+    }
+
+    return cand;
+  }
+
+
+  double Track::getTOF(AbsTrackRep* rep, int startId, int endId) const
+  {
+
+    if (startId < 0)
+      startId += trackPoints_.size();
+    if (endId < 0)
+      endId += trackPoints_.size();
+
+    if (startId > endId) {
+      std::swap(startId, endId);
+    }
+
+    endId += 1;
+
+    if (rep == nullptr)
+      rep = getCardinalRep();
+
+    StateOnPlane state;
+
+    const TrackPoint* startPoint(trackPoints_[startId]);
+    const TrackPoint* endPoint(trackPoints_[endId]);
+
+    if (!startPoint->hasFitterInfo(rep)
+        || !endPoint->hasFitterInfo(rep)) {
+      Exception e("Track::getTOF: trackPoint has no fitterInfo", __LINE__, __FILE__);
+      throw e;
+    }
+
+    double tof = (rep->getTime(endPoint->getFitterInfo(rep)->getFittedState())
+                  - rep->getTime(startPoint->getFitterInfo(rep)->getFittedState()));
+    return tof;
+  }
+
+
+  void Track::fixWeights(AbsTrackRep* rep, int startId, int endId)
+  {
+
+    if (startId < 0)
+      startId += trackPoints_.size();
+    if (endId < 0)
+      endId += trackPoints_.size();
+
+    assert(startId >= 0);
+    assert(startId <= endId);
+    assert(endId <= (int)trackPoints_.size());
+
+    std::vector< AbsFitterInfo* > fis;
+
+    for (std::vector<TrackPoint*>::iterator tp = trackPoints_.begin() + startId; tp != trackPoints_.begin() + endId; ++tp) {
+      fis.clear();
+      if (rep == nullptr) {
+        fis = (*tp)->getFitterInfos();
+      } else if ((*tp)->hasFitterInfo(rep)) {
+        fis.push_back((*tp)->getFitterInfo(rep));
+      }
+
+      for (std::vector< AbsFitterInfo* >::iterator fi = fis.begin(); fi != fis.end(); ++fi) {
+        KalmanFitterInfo* kfi = dynamic_cast<KalmanFitterInfo*>(*fi);
+        if (kfi == nullptr)
+          continue;
+
+        kfi->fixWeights();
+      }
+    }
+  }
+
+
+  void Track::prune(const Option_t* option)
+  {
+
+    PruneFlags f;
+    f.setFlags(option);
+
+    for (std::map< const AbsTrackRep*, FitStatus* >::const_iterator it = fitStatuses_.begin(); it != fitStatuses_.end(); ++it) {
+      it->second->getPruneFlags().setFlags(option);
+    }
+
+    // prune trackPoints
+    if (f.hasFlags("F") || f.hasFlags("L")) {
+      TrackPoint* firstPoint = getPointWithFitterInfo(0);
+      TrackPoint* lastPoint = getPointWithFitterInfo(-1);
+      for (unsigned int i = 0; i < trackPoints_.size(); ++i) {
+        if (trackPoints_[i] == firstPoint && f.hasFlags("F"))
+          continue;
+
+        if (trackPoints_[i] == lastPoint && f.hasFlags("L"))
+          continue;
+
+        delete trackPoints_[i];
+        trackPoints_.erase(trackPoints_.begin() + i);
         --i;
       }
     }
+
+    // prune TrackReps
+    if (f.hasFlags("C")) {
+      for (unsigned int i = 0; i < trackReps_.size(); ++i) {
+        if (i != cardinalRep_) {
+          deleteTrackRep(i);
+          --i;
+        }
+      }
+    }
+
+
+    // from remaining trackPoints: prune measurementsOnPlane, unneeded fitterInfoStuff
+    for (unsigned int i = 0; i < trackPoints_.size(); ++i) {
+      if (f.hasFlags("W"))
+        trackPoints_[i]->deleteRawMeasurements();
+
+      std::vector< AbsFitterInfo* > fis =  trackPoints_[i]->getFitterInfos();
+      for (unsigned int j = 0; j < fis.size(); ++j) {
+
+        if (i == 0 && f.hasFlags("FLI"))
+          fis[j]->deleteForwardInfo();
+        else if (i == trackPoints_.size() - 1 && f.hasFlags("FLI"))
+          fis[j]->deleteBackwardInfo();
+        else if (f.hasFlags("FI"))
+          fis[j]->deleteForwardInfo();
+        else if (f.hasFlags("LI"))
+          fis[j]->deleteBackwardInfo();
+
+        if (f.hasFlags("U") && dynamic_cast<KalmanFitterInfo*>(fis[j]) != nullptr) {
+          static_cast<KalmanFitterInfo*>(fis[j])->deletePredictions();
+        }
+
+        // also delete reference info if points have been removed since it is invalid then!
+        if (f.hasFlags("R") or f.hasFlags("F") or f.hasFlags("L"))
+          fis[j]->deleteReferenceInfo();
+        if (f.hasFlags("M"))
+          fis[j]->deleteMeasurementInfo();
+      }
+    }
+
+    fillPointsWithMeasurement();
+
+#ifdef DEBUG
+    debugOut << "pruned Track: "; Print();
+#endif
+
   }
 
 
-  // from remaining trackPoints: prune measurementsOnPlane, unneeded fitterInfoStuff
-  for (unsigned int i = 0; i<trackPoints_.size(); ++i) {
-    if (f.hasFlags("W"))
-      trackPoints_[i]->deleteRawMeasurements();
+  void Track::Print(const Option_t* option) const
+  {
+    TString opt = option;
+    opt.ToUpper();
+    if (opt.Contains("C")) { // compact
 
-    std::vector< AbsFitterInfo* > fis =  trackPoints_[i]->getFitterInfos();
-    for (unsigned int j = 0; j<fis.size(); ++j) {
+      printOut << "\n    ";
+      for (unsigned int i = 0; i < trackPoints_.size(); ++i) {
 
-      if (i == 0 && f.hasFlags("FLI"))
-        fis[j]->deleteForwardInfo();
-      else if (i == trackPoints_.size()-1 && f.hasFlags("FLI"))
-        fis[j]->deleteBackwardInfo();
-      else if (f.hasFlags("FI"))
-        fis[j]->deleteForwardInfo();
-      else if (f.hasFlags("LI"))
-        fis[j]->deleteBackwardInfo();
+        int color = 32 * (size_t)(trackPoints_[i]) % 15;
+        switch (color) {
+          case 0:
+            printOut << "\033[1;30m";
+            break;
+          case 1:
+            printOut << "\033[0;34m";
+            break;
+          case 2:
+            printOut << "\033[1;34m";
+            break;
+          case 3:
+            printOut << "\033[0;32m";
+            break;
+          case 4:
+            printOut << "\033[1;32m";
+            break;
+          case 5:
+            printOut << "\033[0;36m";
+            break;
+          case 6:
+            printOut << "\033[1;36m";
+            break;
+          case 7:
+            printOut << "\033[0;31m";
+            break;
+          case 8:
+            printOut << "\033[1;31m";
+            break;
+          case 9:
+            printOut << "\033[0;35m";
+            break;
+          case 10:
+            printOut << "\033[1;35m";
+            break;
+          case 11:
+            printOut << "\033[0;33m";
+            break;
+          case 12:
+            printOut << "\033[1;33m";
+            break;
+          case 13:
+            printOut << "\033[0;37m";
+            break;
+          default:
+            ;
+        }
+        printOut << trackPoints_[i] << "\033[00m  ";
+      }
+      printOut << "\n";
 
-      if (f.hasFlags("U") && dynamic_cast<KalmanFitterInfo*>(fis[j]) != nullptr) {
-        static_cast<KalmanFitterInfo*>(fis[j])->deletePredictions();
+      printOut << "   ";
+      for (unsigned int i = 0; i < trackPoints_.size(); ++i) {
+        printf("% -9.3g  ", trackPoints_[i]->getSortingParameter());
       }
 
-      // also delete reference info if points have been removed since it is invalid then!
-      if (f.hasFlags("R") or f.hasFlags("F") or f.hasFlags("L"))
-        fis[j]->deleteReferenceInfo();
-      if (f.hasFlags("M"))
-        fis[j]->deleteMeasurementInfo();
+      for (std::vector<AbsTrackRep*>::const_iterator rep = trackReps_.begin(); rep != trackReps_.end(); ++rep) {
+        printOut << "\n" << getIdForRep(*rep) << "   ";
+        for (unsigned int i = 0; i < trackPoints_.size(); ++i) {
+          if (! trackPoints_[i]->hasFitterInfo(*rep)) {
+            printOut << "           ";
+            continue;
+          }
+          AbsFitterInfo* fi = trackPoints_[i]->getFitterInfo(*rep);
+          if (fi->hasMeasurements())
+            printOut << "M";
+          else
+            printOut << " ";
+
+          if (fi->hasReferenceState())
+            printOut << "R";
+          else
+            printOut << " ";
+
+          printOut << "         ";
+        }
+        printOut << "\n";
+
+        printOut << " -> ";
+        for (unsigned int i = 0; i < trackPoints_.size(); ++i) {
+          if (! trackPoints_[i]->hasFitterInfo(*rep)) {
+            printOut << "           ";
+            continue;
+          }
+          AbsFitterInfo* fi = trackPoints_[i]->getFitterInfo(*rep);
+          if (fi->hasForwardPrediction())
+            printOut << "P";
+          else
+            printOut << " ";
+
+          if (fi->hasForwardUpdate())
+            printOut << "U";
+          else
+            printOut << " ";
+
+          printOut << "         ";
+        }
+        printOut << "\n";
+
+        printOut << " <- ";
+        for (unsigned int i = 0; i < trackPoints_.size(); ++i) {
+          if (! trackPoints_[i]->hasFitterInfo(*rep)) {
+            printOut << "           ";
+            continue;
+          }
+          AbsFitterInfo* fi = trackPoints_[i]->getFitterInfo(*rep);
+          if (fi->hasBackwardPrediction())
+            printOut << "P";
+          else
+            printOut << " ";
+
+          if (fi->hasBackwardUpdate())
+            printOut << "U";
+          else
+            printOut << " ";
+
+          printOut << "         ";
+        }
+
+        printOut << "\n";
+
+      } //end loop over reps
+
+      printOut << "\n";
+      return;
     }
+
+
+
+    printOut << "=======================================================================================\n";
+    printOut << "genfit::Track, containing " << trackPoints_.size() << " TrackPoints and " << trackReps_.size() << " TrackReps.\n";
+    printOut << " Seed state: "; stateSeed_.Print();
+
+    for (unsigned int i = 0; i < trackReps_.size(); ++i) {
+      printOut << " TrackRep Nr. " << i;
+      if (i == cardinalRep_)
+        printOut << " (This is the cardinal rep)";
+      printOut << "\n";
+      trackReps_[i]->Print();
+    }
+
+    printOut << "---------------------------------------------------------------------------------------\n";
+
+    for (unsigned int i = 0; i < trackPoints_.size(); ++i) {
+      printOut << "TrackPoint Nr. " << i << "\n";
+      trackPoints_[i]->Print();
+      printOut << "..........................................................................\n";
+    }
+
+    for (std::map< const AbsTrackRep*, FitStatus* >::const_iterator it = fitStatuses_.begin(); it != fitStatuses_.end(); ++it) {
+      it->second->Print();
+    }
+
+    printOut << "=======================================================================================\n";
+
   }
 
-  fillPointsWithMeasurement();
 
-  #ifdef DEBUG
-  debugOut << "pruned Track: "; Print();
-  #endif
+  void Track::checkConsistency() const
+  {
 
-}
+    // cppcheck-suppress unreadVariable
+    bool consistent = true;
+    std::stringstream failures;
 
+    std::map<const AbsTrackRep*, const KalmanFitterInfo*> prevFis;
 
-void Track::Print(const Option_t* option) const {
-  TString opt = option;
-  opt.ToUpper();
-  if (opt.Contains("C")) { // compact
-
-    printOut << "\n    ";
-    for (unsigned int i=0; i<trackPoints_.size(); ++i) {
-
-      int color = 32*(size_t)(trackPoints_[i]) % 15;
-      switch (color) {
-        case 0:
-          printOut<<"\033[1;30m";
-          break;
-        case 1:
-          printOut<<"\033[0;34m";
-          break;
-        case 2:
-          printOut<<"\033[1;34m";
-          break;
-        case 3:
-          printOut<<"\033[0;32m";
-          break;
-        case 4:
-          printOut<<"\033[1;32m";
-          break;
-        case 5:
-          printOut<<"\033[0;36m";
-          break;
-        case 6:
-          printOut<<"\033[1;36m";
-          break;
-        case 7:
-          printOut<<"\033[0;31m";
-          break;
-        case 8:
-          printOut<<"\033[1;31m";
-          break;
-        case 9:
-          printOut<<"\033[0;35m";
-          break;
-        case 10:
-          printOut<<"\033[1;35m";
-          break;
-        case 11:
-          printOut<<"\033[0;33m";
-          break;
-        case 12:
-          printOut<<"\033[1;33m";
-          break;
-        case 13:
-          printOut<<"\033[0;37m";
-          break;
-        default:
-          ;
-      }
-      printOut << trackPoints_[i] << "\033[00m  ";
+    // check if seed is 6D
+    if (stateSeed_.GetNrows() != 6) {
+      failures << "Track::checkConsistency(): stateSeed_ dimension != 6" << std::endl;
+      // cppcheck-suppress unreadVariable
+      consistent = false;
     }
-    printOut << "\n";
 
-    printOut << "   ";
-    for (unsigned int i=0; i<trackPoints_.size(); ++i) {
-      printf("% -9.3g  ", trackPoints_[i]->getSortingParameter());
+    if (covSeed_.GetNrows() != 6) {
+      failures << "Track::checkConsistency(): covSeed_ dimension != 6" << std::endl;
+      // cppcheck-suppress unreadVariable
+      consistent = false;
+    }
+
+    if (covSeed_.Max() == 0.) {
+      // Nota bene: The consistency is not set to false when this occurs, because it does not break the consistency of
+      // the track. However, when something else fails we keep this as additional error information.
+      failures << "Track::checkConsistency(): Warning: covSeed_ is zero" << std::endl;
+    }
+
+    // check if correct number of fitStatuses
+    if (fitStatuses_.size() != trackReps_.size()) {
+      failures << "Track::checkConsistency(): Number of fitStatuses is != number of TrackReps " << std::endl;
+      // cppcheck-suppress unreadVariable
+      consistent = false;
+    }
+
+    // check if cardinalRep_ is in range of trackReps_
+    if (trackReps_.size() && cardinalRep_ >= trackReps_.size()) {
+      failures << "Track::checkConsistency(): cardinalRep id " << cardinalRep_ << " out of bounds" << std::endl;
+      // cppcheck-suppress unreadVariable
+      consistent = false;
     }
 
     for (std::vector<AbsTrackRep*>::const_iterator rep = trackReps_.begin(); rep != trackReps_.end(); ++rep) {
-      printOut << "\n" << getIdForRep(*rep) << "   ";
-      for (unsigned int i=0; i<trackPoints_.size(); ++i) {
-        if (! trackPoints_[i]->hasFitterInfo(*rep)) {
-          printOut << "           ";
-          continue;
-        }
-        AbsFitterInfo* fi = trackPoints_[i]->getFitterInfo(*rep);
-        if (fi->hasMeasurements())
-          printOut << "M";
-        else
-          printOut << " ";
-
-        if (fi->hasReferenceState())
-          printOut << "R";
-        else
-          printOut << " ";
-
-        printOut << "         ";
-      }
-      printOut << "\n";
-
-      printOut << " -> ";
-      for (unsigned int i=0; i<trackPoints_.size(); ++i) {
-        if (! trackPoints_[i]->hasFitterInfo(*rep)) {
-          printOut << "           ";
-          continue;
-        }
-        AbsFitterInfo* fi = trackPoints_[i]->getFitterInfo(*rep);
-        if (fi->hasForwardPrediction())
-          printOut << "P";
-        else
-          printOut << " ";
-
-        if (fi->hasForwardUpdate())
-          printOut << "U";
-        else
-          printOut << " ";
-
-        printOut << "         ";
-      }
-      printOut << "\n";
-
-      printOut << " <- ";
-      for (unsigned int i=0; i<trackPoints_.size(); ++i) {
-        if (! trackPoints_[i]->hasFitterInfo(*rep)) {
-          printOut << "           ";
-          continue;
-        }
-        AbsFitterInfo* fi = trackPoints_[i]->getFitterInfo(*rep);
-        if (fi->hasBackwardPrediction())
-          printOut << "P";
-        else
-          printOut << " ";
-
-        if (fi->hasBackwardUpdate())
-          printOut << "U";
-        else
-          printOut << " ";
-
-        printOut << "         ";
-      }
-
-      printOut << "\n";
-
-    } //end loop over reps
-
-    printOut << "\n";
-    return;
-  }
-
-
-
-  printOut << "=======================================================================================\n";
-  printOut << "genfit::Track, containing " << trackPoints_.size() << " TrackPoints and " << trackReps_.size() << " TrackReps.\n";
-  printOut << " Seed state: "; stateSeed_.Print();
-
-  for (unsigned int i=0; i<trackReps_.size(); ++i) {
-    printOut << " TrackRep Nr. " << i;
-    if (i == cardinalRep_)
-      printOut << " (This is the cardinal rep)";
-    printOut << "\n";
-    trackReps_[i]->Print();
-  }
-
-  printOut << "---------------------------------------------------------------------------------------\n";
-
-  for (unsigned int i=0; i<trackPoints_.size(); ++i) {
-    printOut << "TrackPoint Nr. " << i << "\n";
-    trackPoints_[i]->Print();
-    printOut << "..........................................................................\n";
-  }
-
-  for (std::map< const AbsTrackRep*, FitStatus* >::const_iterator it=fitStatuses_.begin(); it!=fitStatuses_.end(); ++it) {
-    it->second->Print();
-  }
-
-  printOut << "=======================================================================================\n";
-
-}
-
-
-void Track::checkConsistency() const {
-
-  // cppcheck-suppress unreadVariable
-  bool consistent = true;
-  std::stringstream failures;
-
-  std::map<const AbsTrackRep*, const KalmanFitterInfo*> prevFis;
-
-  // check if seed is 6D
-  if (stateSeed_.GetNrows() != 6) {
-    failures << "Track::checkConsistency(): stateSeed_ dimension != 6" << std::endl;
-    // cppcheck-suppress unreadVariable
-    consistent = false;
-  }
-
-  if (covSeed_.GetNrows() != 6) {
-    failures << "Track::checkConsistency(): covSeed_ dimension != 6" << std::endl;
-    // cppcheck-suppress unreadVariable
-    consistent = false;
-  }
-
-  if (covSeed_.Max() == 0.) {
-    // Nota bene: The consistency is not set to false when this occurs, because it does not break the consistency of
-    // the track. However, when something else fails we keep this as additional error information.
-    failures << "Track::checkConsistency(): Warning: covSeed_ is zero" << std::endl;
-  }
-
-  // check if correct number of fitStatuses
-  if (fitStatuses_.size() != trackReps_.size()) {
-    failures << "Track::checkConsistency(): Number of fitStatuses is != number of TrackReps " << std::endl;
-    // cppcheck-suppress unreadVariable
-    consistent = false;
-  }
-
-  // check if cardinalRep_ is in range of trackReps_
-  if (trackReps_.size() && cardinalRep_ >= trackReps_.size()) {
-    failures << "Track::checkConsistency(): cardinalRep id " << cardinalRep_ << " out of bounds" << std::endl;
-    // cppcheck-suppress unreadVariable
-    consistent = false;
-  }
-
-  for (std::vector<AbsTrackRep*>::const_iterator rep = trackReps_.begin(); rep != trackReps_.end(); ++rep) {
-    // check for nullptr
-    if ((*rep) == nullptr) {
-      failures << "Track::checkConsistency(): TrackRep is nullptr" << std::endl;
-      // cppcheck-suppress unreadVariable
-      consistent = false;
-    }
-
-    // check for valid pdg code
-    TParticlePDG* particle = TDatabasePDG::Instance()->GetParticle((*rep)->getPDG());
-    if (particle == nullptr) {
-      failures << "Track::checkConsistency(): TrackRep pdg ID " << (*rep)->getPDG() << " is not valid" << std::endl;
-      // cppcheck-suppress unreadVariable
-      consistent = false;
-    }
-
-    // check if corresponding FitStatus is there
-    if (fitStatuses_.find(*rep) == fitStatuses_.end() and fitStatuses_.find(*rep)->second != nullptr) {
-      failures << "Track::checkConsistency(): No FitStatus for Rep or FitStatus is nullptr" << std::endl;
-      // cppcheck-suppress unreadVariable
-      consistent = false;
-    }
-  }
-
-  // check TrackPoints
-  for (std::vector<TrackPoint*>::const_iterator tp = trackPoints_.begin(); tp != trackPoints_.end(); ++tp) {
-    // check for nullptr
-    if ((*tp) == nullptr) {
-      failures << "Track::checkConsistency(): TrackPoint is nullptr" << std::endl;
-      // cppcheck-suppress unreadVariable
-      consistent = false;
-    }
-    // check if trackPoint points back to this track
-    if ((*tp)->getTrack() != this) {
-      failures << "Track::checkConsistency(): TrackPoint does not point back to this track" << std::endl;
-      // cppcheck-suppress unreadVariable
-      consistent = false;
-    }
-
-    // check rawMeasurements
-    const std::vector<AbsMeasurement*>& rawMeasurements = (*tp)->getRawMeasurements();
-    for (std::vector<AbsMeasurement*>::const_iterator m = rawMeasurements.begin(); m != rawMeasurements.end(); ++m) {
       // check for nullptr
-      if ((*m) == nullptr) {
-        failures << "Track::checkConsistency(): Measurement is nullptr" << std::endl;
-	// cppcheck-suppress unreadVariable
+      if ((*rep) == nullptr) {
+        failures << "Track::checkConsistency(): TrackRep is nullptr" << std::endl;
+        // cppcheck-suppress unreadVariable
         consistent = false;
       }
-      // check if measurement points back to TrackPoint
-      if ((*m)->getTrackPoint() != *tp) {
-        failures << "Track::checkConsistency(): Measurement does not point back to correct TrackPoint" << std::endl;
-	// cppcheck-suppress unreadVariable
+
+      // check for valid pdg code
+      TParticlePDG* particle = TDatabasePDG::Instance()->GetParticle((*rep)->getPDG());
+      if (particle == nullptr) {
+        failures << "Track::checkConsistency(): TrackRep pdg ID " << (*rep)->getPDG() << " is not valid" << std::endl;
+        // cppcheck-suppress unreadVariable
+        consistent = false;
+      }
+
+      // check if corresponding FitStatus is there
+      if (fitStatuses_.find(*rep) == fitStatuses_.end() and fitStatuses_.find(*rep)->second != nullptr) {
+        failures << "Track::checkConsistency(): No FitStatus for Rep or FitStatus is nullptr" << std::endl;
+        // cppcheck-suppress unreadVariable
         consistent = false;
       }
     }
 
-    // check fitterInfos
-    std::vector<AbsFitterInfo*> fitterInfos = (*tp)->getFitterInfos();
-    for (std::vector<AbsFitterInfo*>::const_iterator fi = fitterInfos.begin(); fi != fitterInfos.end(); ++fi) {
+    // check TrackPoints
+    for (std::vector<TrackPoint*>::const_iterator tp = trackPoints_.begin(); tp != trackPoints_.end(); ++tp) {
       // check for nullptr
-      if ((*fi) == nullptr) {
-        failures << "Track::checkConsistency(): FitterInfo is nullptr. TrackPoint: " << *tp << std::endl;
-	// cppcheck-suppress unreadVariable
+      if ((*tp) == nullptr) {
+        failures << "Track::checkConsistency(): TrackPoint is nullptr" << std::endl;
+        // cppcheck-suppress unreadVariable
+        consistent = false;
+      }
+      // check if trackPoint points back to this track
+      if ((*tp)->getTrack() != this) {
+        failures << "Track::checkConsistency(): TrackPoint does not point back to this track" << std::endl;
+        // cppcheck-suppress unreadVariable
         consistent = false;
       }
 
-      // check if fitterInfos point to valid TrackReps in trackReps_
-      int mycount (0);
-      for (std::vector<AbsTrackRep*>::const_iterator rep = trackReps_.begin(); rep != trackReps_.end(); ++rep) {
-        if ( (*rep) == (*fi)->getRep() ) {
-          ++mycount;
+      // check rawMeasurements
+      const std::vector<AbsMeasurement*>& rawMeasurements = (*tp)->getRawMeasurements();
+      for (std::vector<AbsMeasurement*>::const_iterator m = rawMeasurements.begin(); m != rawMeasurements.end(); ++m) {
+        // check for nullptr
+        if ((*m) == nullptr) {
+          failures << "Track::checkConsistency(): Measurement is nullptr" << std::endl;
+          // cppcheck-suppress unreadVariable
+          consistent = false;
+        }
+        // check if measurement points back to TrackPoint
+        if ((*m)->getTrackPoint() != *tp) {
+          failures << "Track::checkConsistency(): Measurement does not point back to correct TrackPoint" << std::endl;
+          // cppcheck-suppress unreadVariable
+          consistent = false;
         }
       }
-      if (mycount ==  0) {
-        failures << "Track::checkConsistency(): fitterInfo points to TrackRep which is not in Track" << std::endl;
-	// cppcheck-suppress unreadVariable
-        consistent = false;
-      }
 
-      if (!( (*fi)->checkConsistency(&(this->getFitStatus((*fi)->getRep())->getPruneFlags())) ) ) {
-        failures << "Track::checkConsistency(): FitterInfo not consistent. TrackPoint: " << *tp << std::endl;
-	// cppcheck-suppress unreadVariable
-        consistent = false;
-      }
+      // check fitterInfos
+      std::vector<AbsFitterInfo*> fitterInfos = (*tp)->getFitterInfos();
+      for (std::vector<AbsFitterInfo*>::const_iterator fi = fitterInfos.begin(); fi != fitterInfos.end(); ++fi) {
+        // check for nullptr
+        if ((*fi) == nullptr) {
+          failures << "Track::checkConsistency(): FitterInfo is nullptr. TrackPoint: " << *tp << std::endl;
+          // cppcheck-suppress unreadVariable
+          consistent = false;
+        }
 
-      if (dynamic_cast<KalmanFitterInfo*>(*fi) != nullptr) {
-        if (prevFis[(*fi)->getRep()] != nullptr &&
-            static_cast<KalmanFitterInfo*>(*fi)->hasReferenceState() &&
-            prevFis[(*fi)->getRep()]->hasReferenceState() ) {
-          double len = static_cast<KalmanFitterInfo*>(*fi)->getReferenceState()->getForwardSegmentLength();
-          double prevLen = prevFis[(*fi)->getRep()]->getReferenceState()->getBackwardSegmentLength();
-          if (fabs(prevLen + len) > 1E-10 ) {
-            failures << "Track::checkConsistency(): segment lengths of reference states for rep " << (*fi)->getRep() << " (id " << getIdForRep((*fi)->getRep()) << ") at TrackPoint " << (*tp) << " don't match" << std::endl;
-            failures << prevLen << " + " << len << " = " << prevLen + len << std::endl;
-            failures << "TrackPoint " << *tp << ", FitterInfo " << *fi << ", rep " << getIdForRep((*fi)->getRep()) << std::endl;
-	    // cppcheck-suppress unreadVariable
-            consistent = false;
+        // check if fitterInfos point to valid TrackReps in trackReps_
+        int mycount(0);
+        for (std::vector<AbsTrackRep*>::const_iterator rep = trackReps_.begin(); rep != trackReps_.end(); ++rep) {
+          if ((*rep) == (*fi)->getRep()) {
+            ++mycount;
           }
         }
+        if (mycount ==  0) {
+          failures << "Track::checkConsistency(): fitterInfo points to TrackRep which is not in Track" << std::endl;
+          // cppcheck-suppress unreadVariable
+          consistent = false;
+        }
 
-        prevFis[(*fi)->getRep()] = static_cast<KalmanFitterInfo*>(*fi);
+        if (!((*fi)->checkConsistency(&(this->getFitStatus((*fi)->getRep())->getPruneFlags())))) {
+          failures << "Track::checkConsistency(): FitterInfo not consistent. TrackPoint: " << *tp << std::endl;
+          // cppcheck-suppress unreadVariable
+          consistent = false;
+        }
+
+        if (dynamic_cast<KalmanFitterInfo*>(*fi) != nullptr) {
+          if (prevFis[(*fi)->getRep()] != nullptr &&
+              static_cast<KalmanFitterInfo*>(*fi)->hasReferenceState() &&
+              prevFis[(*fi)->getRep()]->hasReferenceState()) {
+            double len = static_cast<KalmanFitterInfo*>(*fi)->getReferenceState()->getForwardSegmentLength();
+            double prevLen = prevFis[(*fi)->getRep()]->getReferenceState()->getBackwardSegmentLength();
+            if (fabs(prevLen + len) > 1E-10) {
+              failures << "Track::checkConsistency(): segment lengths of reference states for rep " << (*fi)->getRep() << " (id " << getIdForRep((
+                         *fi)->getRep()) << ") at TrackPoint " << (*tp) << " don't match" << std::endl;
+              failures << prevLen << " + " << len << " = " << prevLen + len << std::endl;
+              failures << "TrackPoint " << *tp << ", FitterInfo " << *fi << ", rep " << getIdForRep((*fi)->getRep()) << std::endl;
+              // cppcheck-suppress unreadVariable
+              consistent = false;
+            }
+          }
+
+          prevFis[(*fi)->getRep()] = static_cast<KalmanFitterInfo*>(*fi);
+        } else
+          prevFis[(*fi)->getRep()] = nullptr;
+
+      } // end loop over FitterInfos
+
+    } // end loop over TrackPoints
+
+
+    // check trackPointsWithMeasurement_
+    std::vector<TrackPoint*> trackPointsWithMeasurement;
+
+    for (std::vector<TrackPoint*>::const_iterator it = trackPoints_.begin(); it != trackPoints_.end(); ++it) {
+      if ((*it)->hasRawMeasurements()) {
+        trackPointsWithMeasurement.push_back(*it);
       }
-      else
-        prevFis[(*fi)->getRep()] = nullptr;
-
-    } // end loop over FitterInfos
-
-  } // end loop over TrackPoints
-
-
-  // check trackPointsWithMeasurement_
-  std::vector<TrackPoint*> trackPointsWithMeasurement;
-
-  for (std::vector<TrackPoint*>::const_iterator it = trackPoints_.begin(); it != trackPoints_.end(); ++it) {
-    if ((*it)->hasRawMeasurements()) {
-      trackPointsWithMeasurement.push_back(*it);
     }
-  }
 
-  if (trackPointsWithMeasurement.size() != trackPointsWithMeasurement_.size()) {
-    failures << "Track::checkConsistency(): trackPointsWithMeasurement_ has incorrect size" << std::endl;
-    // cppcheck-suppress unreadVariable
-    consistent = false;
-  }
-
-  for (unsigned int i = 0; i < trackPointsWithMeasurement.size(); ++i) {
-    if (trackPointsWithMeasurement[i] != trackPointsWithMeasurement_[i]) {
-      failures << "Track::checkConsistency(): trackPointsWithMeasurement_ is not correct" << std::endl;
-      failures << "has         id " << i << ", address " << trackPointsWithMeasurement_[i] << std::endl;
-      failures << "should have id " << i << ", address " << trackPointsWithMeasurement[i] << std::endl;
+    if (trackPointsWithMeasurement.size() != trackPointsWithMeasurement_.size()) {
+      failures << "Track::checkConsistency(): trackPointsWithMeasurement_ has incorrect size" << std::endl;
       // cppcheck-suppress unreadVariable
       consistent = false;
     }
-  }
 
-  if (not consistent) {
-    throw genfit::Exception(failures.str(), __LINE__, __FILE__);
-  }
-}
+    for (unsigned int i = 0; i < trackPointsWithMeasurement.size(); ++i) {
+      if (trackPointsWithMeasurement[i] != trackPointsWithMeasurement_[i]) {
+        failures << "Track::checkConsistency(): trackPointsWithMeasurement_ is not correct" << std::endl;
+        failures << "has         id " << i << ", address " << trackPointsWithMeasurement_[i] << std::endl;
+        failures << "should have id " << i << ", address " << trackPointsWithMeasurement[i] << std::endl;
+        // cppcheck-suppress unreadVariable
+        consistent = false;
+      }
+    }
 
-
-void Track::trackHasChanged() {
-
-  #ifdef DEBUG
-  debugOut << "Track::trackHasChanged \n";
-  #endif
-
-  if (fitStatuses_.empty())
-    return;
-
-  for (std::map< const AbsTrackRep*, FitStatus* >::const_iterator it=fitStatuses_.begin(); it!=fitStatuses_.end(); ++it) {
-    it->second->setHasTrackChanged();
-  }
-}
-
-
-void Track::fillPointsWithMeasurement() {
-  trackPointsWithMeasurement_.clear();
-  trackPointsWithMeasurement_.reserve(trackPoints_.size());
-
-  for (std::vector<TrackPoint*>::const_iterator it = trackPoints_.begin(); it != trackPoints_.end(); ++it) {
-    if ((*it)->hasRawMeasurements()) {
-      trackPointsWithMeasurement_.push_back(*it);
+    if (not consistent) {
+      throw genfit::Exception(failures.str(), __LINE__, __FILE__);
     }
   }
-}
 
 
-void Track::Streamer(TBuffer &R__b)
-{
-   // Stream an object of class genfit::Track.
-  const bool streamTrackPoints = true; // debugging option
-   //This works around a msvc bug and should be harmless on other platforms
-   typedef ::genfit::Track thisClass;
-   UInt_t R__s, R__c;
-   if (R__b.IsReading()) {
+  void Track::trackHasChanged()
+  {
+
+#ifdef DEBUG
+    debugOut << "Track::trackHasChanged \n";
+#endif
+
+    if (fitStatuses_.empty())
+      return;
+
+    for (std::map< const AbsTrackRep*, FitStatus* >::const_iterator it = fitStatuses_.begin(); it != fitStatuses_.end(); ++it) {
+      it->second->setHasTrackChanged();
+    }
+  }
+
+
+  void Track::fillPointsWithMeasurement()
+  {
+    trackPointsWithMeasurement_.clear();
+    trackPointsWithMeasurement_.reserve(trackPoints_.size());
+
+    for (std::vector<TrackPoint*>::const_iterator it = trackPoints_.begin(); it != trackPoints_.end(); ++it) {
+      if ((*it)->hasRawMeasurements()) {
+        trackPointsWithMeasurement_.push_back(*it);
+      }
+    }
+  }
+
+
+  void Track::Streamer(TBuffer& R__b)
+  {
+    // Stream an object of class genfit::Track.
+    const bool streamTrackPoints = true; // debugging option
+    //This works around a msvc bug and should be harmless on other platforms
+    typedef ::genfit::Track thisClass;
+    UInt_t R__s, R__c;
+    if (R__b.IsReading()) {
       this->Clear();
-      Version_t R__v = R__b.ReadVersion(&R__s, &R__c); if (R__v) { }
+      Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+      if (R__v) { }
       TObject::Streamer(R__b);
       {
-        std::vector<AbsTrackRep*> &R__stl =  trackReps_;
+        std::vector<AbsTrackRep*>& R__stl =  trackReps_;
         R__stl.clear();
-        TClass *R__tcl1 = TBuffer::GetClass(typeid(genfit::AbsTrackRep));
-        if (R__tcl1==0) {
-          Error("trackReps_ streamer","Missing the TClass object for genfit::AbsTrackRep!");
+        TClass* R__tcl1 = TBuffer::GetClass(typeid(genfit::AbsTrackRep));
+        if (R__tcl1 == 0) {
+          Error("trackReps_ streamer", "Missing the TClass object for genfit::AbsTrackRep!");
           return;
         }
         int R__i, R__n;
@@ -1521,13 +1572,12 @@ void Track::Streamer(TBuffer &R__b)
         }
       }
       R__b >> cardinalRep_;
-      if (streamTrackPoints)
-      {
-        std::vector<TrackPoint*> &R__stl =  trackPoints_;
+      if (streamTrackPoints) {
+        std::vector<TrackPoint*>& R__stl =  trackPoints_;
         R__stl.clear();
-        TClass *R__tcl1 = TBuffer::GetClass(typeid(genfit::TrackPoint));
-        if (R__tcl1==0) {
-          Error("trackPoints_ streamer","Missing the TClass object for genfit::TrackPoint!");
+        TClass* R__tcl1 = TBuffer::GetClass(typeid(genfit::TrackPoint));
+        if (R__tcl1 == 0) {
+          Error("trackPoints_ streamer", "Missing the TClass object for genfit::TrackPoint!");
           return;
         }
         int R__i, R__n;
@@ -1542,16 +1592,16 @@ void Track::Streamer(TBuffer &R__b)
         }
       }
       {
-        std::map<const AbsTrackRep*,FitStatus*> &R__stl =  fitStatuses_;
+        std::map<const AbsTrackRep*, FitStatus*>& R__stl =  fitStatuses_;
         R__stl.clear();
-        TClass *R__tcl1 = TBuffer::GetClass(typeid(genfit::AbsTrackRep));
-        if (R__tcl1==0) {
-          Error("fitStatuses_ streamer","Missing the TClass object for genfit::AbsTrackRep!");
+        TClass* R__tcl1 = TBuffer::GetClass(typeid(genfit::AbsTrackRep));
+        if (R__tcl1 == 0) {
+          Error("fitStatuses_ streamer", "Missing the TClass object for genfit::AbsTrackRep!");
           return;
         }
-        TClass *R__tcl2 = TBuffer::GetClass(typeid(genfit::FitStatus));
-        if (R__tcl2==0) {
-          Error("fitStatuses_ streamer","Missing the TClass object for genfit::FitStatus!");
+        TClass* R__tcl2 = TBuffer::GetClass(typeid(genfit::FitStatus));
+        if (R__tcl2 == 0) {
+          Error("fitStatuses_ streamer", "Missing the TClass object for genfit::FitStatus!");
           return;
         }
         int R__i, R__n;
@@ -1568,26 +1618,26 @@ void Track::Streamer(TBuffer &R__b)
       // timeSeed_ was introduced in version 3.  If reading an earlier
       // version, default to zero.
       if (R__v >= 3) {
-	R__b >> timeSeed_;
+        R__b >> timeSeed_;
       } else {
-	timeSeed_ = 0;
+        timeSeed_ = 0;
       }
       stateSeed_.Streamer(R__b);
       covSeed_.Streamer(R__b);
       R__b.CheckByteCount(R__s, R__c, thisClass::IsA());
 
       fillPointsWithMeasurement();
-   } else {
+    } else {
       R__c = R__b.WriteVersion(thisClass::IsA(), kTRUE);
       TObject::Streamer(R__b);
       {
-        std::vector<AbsTrackRep*> &R__stl =  trackReps_;
-        int R__n=int(R__stl.size());
+        std::vector<AbsTrackRep*>& R__stl =  trackReps_;
+        int R__n = int(R__stl.size());
         R__b << R__n;
-        if(R__n) {
-          TClass *R__tcl1 = TBuffer::GetClass(typeid(genfit::AbsTrackRep));
-          if (R__tcl1==0) {
-            Error("trackReps_ streamer","Missing the TClass object for genfit::AbsTrackRep!");
+        if (R__n) {
+          TClass* R__tcl1 = TBuffer::GetClass(typeid(genfit::AbsTrackRep));
+          if (R__tcl1 == 0) {
+            Error("trackReps_ streamer", "Missing the TClass object for genfit::AbsTrackRep!");
             return;
           }
           std::vector<AbsTrackRep*>::iterator R__k;
@@ -1597,12 +1647,11 @@ void Track::Streamer(TBuffer &R__b)
         }
       }
       R__b << cardinalRep_;
-      if (streamTrackPoints)
-      {
-        std::vector<TrackPoint*> &R__stl =  trackPoints_;
-        int R__n=int(R__stl.size());
+      if (streamTrackPoints) {
+        std::vector<TrackPoint*>& R__stl =  trackPoints_;
+        int R__n = int(R__stl.size());
         R__b << R__n;
-        if(R__n) {
+        if (R__n) {
           std::vector<TrackPoint*>::iterator R__k;
           for (R__k = R__stl.begin(); R__k != R__stl.end(); ++R__k) {
             R__b << (*R__k);
@@ -1610,21 +1659,21 @@ void Track::Streamer(TBuffer &R__b)
         }
       }
       {
-        std::map<const AbsTrackRep*,FitStatus*> &R__stl =  fitStatuses_;
-        int R__n=int(R__stl.size());
+        std::map<const AbsTrackRep*, FitStatus*>& R__stl =  fitStatuses_;
+        int R__n = int(R__stl.size());
         R__b << R__n;
-        if(R__n) {
-          TClass *R__tcl1 = TBuffer::GetClass(typeid(genfit::AbsTrackRep));
-          if (R__tcl1==0) {
-            Error("fitStatuses_ streamer","Missing the TClass object for genfit::AbsTrackRep!");
+        if (R__n) {
+          TClass* R__tcl1 = TBuffer::GetClass(typeid(genfit::AbsTrackRep));
+          if (R__tcl1 == 0) {
+            Error("fitStatuses_ streamer", "Missing the TClass object for genfit::AbsTrackRep!");
             return;
           }
-          TClass *R__tcl2 = TBuffer::GetClass(typeid(genfit::FitStatus));
-          if (R__tcl2==0) {
-            Error("fitStatuses_ streamer","Missing the TClass object for genfit::FitStatus!");
+          TClass* R__tcl2 = TBuffer::GetClass(typeid(genfit::FitStatus));
+          if (R__tcl2 == 0) {
+            Error("fitStatuses_ streamer", "Missing the TClass object for genfit::FitStatus!");
             return;
           }
-          std::map<const AbsTrackRep*,FitStatus*>::iterator R__k;
+          std::map<const AbsTrackRep*, FitStatus*>::iterator R__k;
           for (R__k = R__stl.begin(); R__k != R__stl.end(); ++R__k) {
             int id = this->getIdForRep((*R__k).first);
             R__b << id;
@@ -1636,19 +1685,20 @@ void Track::Streamer(TBuffer &R__b)
       stateSeed_.Streamer(R__b);
       covSeed_.Streamer(R__b);
       R__b.SetByteCount(R__c, kTRUE);
-   }
-}
+    }
+  }
 
-void Track::deleteTrackPointsAndFitStatus() {
-  for (size_t i = 0; i < trackPoints_.size(); ++i)
-    delete trackPoints_[i];
+  void Track::deleteTrackPointsAndFitStatus()
+  {
+    for (size_t i = 0; i < trackPoints_.size(); ++i)
+      delete trackPoints_[i];
 
-  trackPoints_.clear();
-  trackPointsWithMeasurement_.clear();
+    trackPoints_.clear();
+    trackPointsWithMeasurement_.clear();
 
-  for (std::map< const AbsTrackRep*, FitStatus* >::iterator it = fitStatuses_.begin(); it!= fitStatuses_.end(); ++it)
-    delete it->second;
-  fitStatuses_.clear();
-}
+    for (std::map< const AbsTrackRep*, FitStatus* >::iterator it = fitStatuses_.begin(); it != fitStatuses_.end(); ++it)
+      delete it->second;
+    fitStatuses_.clear();
+  }
 
 } /* End of namespace genfit */

--- a/core/src/TrackCand.cc
+++ b/core/src/TrackCand.cc
@@ -28,273 +28,294 @@
 namespace genfit {
 
 
-TrackCand::TrackCand() :
-  mcTrackId_(-1),
-  pdg_(0),
-  time_(0),
-  state6D_(6),
-  cov6D_(6),
-  q_(0)
-{
-  ;
-}
-
-TrackCand::~TrackCand() {
-  for (unsigned int i=0; i<hits_.size(); ++i) {
-    delete hits_[i];
-  }
-  hits_.clear();
-}
-
-
-TrackCand::TrackCand( const TrackCand& other ) :
-  TObject(other),
-  mcTrackId_(other.mcTrackId_),
-  pdg_(0),
-  time_(other.time_),
-  state6D_(other.state6D_),
-  cov6D_(other.cov6D_),
-  q_(other.q_)
-{
-  // deep copy
-  hits_.reserve(other.hits_.size());
-  for (unsigned int i=0; i<other.hits_.size(); ++i) {
-    hits_.push_back( (other.hits_[i])->clone() );
+  TrackCand::TrackCand() :
+    mcTrackId_(-1),
+    pdg_(0),
+    time_(0),
+    state6D_(6),
+    cov6D_(6),
+    q_(0)
+  {
+    ;
   }
 
-  if (other.pdg_ != 0)
-    setPdgCode(other.pdg_);
-}
-
-TrackCand& TrackCand::operator=(TrackCand other) {
-  swap(other);
-  return *this;
-}
-
-
-void TrackCand::swap(TrackCand& other) {
-  // by swapping the members of two classes,
-  // the two classes are effectively swapped
-  std::swap(this->hits_, other.hits_);
-  std::swap(this->mcTrackId_, other.mcTrackId_);
-  std::swap(this->pdg_, other.pdg_);
-  std::swap(this->time_, other.time_);
-  std::swap(this->state6D_, other.state6D_);
-  std::swap(this->cov6D_, other.cov6D_);
-  std::swap(this->q_, other.q_);
-}
+  TrackCand::~TrackCand()
+  {
+    for (unsigned int i = 0; i < hits_.size(); ++i) {
+      delete hits_[i];
+    }
+    hits_.clear();
+  }
 
 
-TrackCandHit* TrackCand::getHit(int i) const {
-  if (i < 0)
-    i += hits_.size();
+  TrackCand::TrackCand(const TrackCand& other) :
+    TObject(other),
+    mcTrackId_(other.mcTrackId_),
+    pdg_(0),
+    time_(other.time_),
+    state6D_(other.state6D_),
+    cov6D_(other.cov6D_),
+    q_(other.q_)
+  {
+    // deep copy
+    hits_.reserve(other.hits_.size());
+    for (unsigned int i = 0; i < other.hits_.size(); ++i) {
+      hits_.push_back((other.hits_[i])->clone());
+    }
 
-  return hits_.at(i);
-}
+    if (other.pdg_ != 0)
+      setPdgCode(other.pdg_);
+  }
 
-
-void TrackCand::getHit(int i, int& detId, int& hitId) const {
-  if (i < 0)
-    i += hits_.size();
-
-  detId = hits_.at(i)->getDetId();
-  hitId = hits_[i]->getHitId();
-}
-
-
-void TrackCand::getHit(int i, int& detId, int& hitId, double& sortingParameter) const {
-  if (i < 0)
-    i += hits_.size();
-
-  detId = hits_.at(i)->getDetId();
-  hitId = hits_[i]->getHitId();
-  sortingParameter = hits_[i]->getSortingParameter();
-}
-
-
-void TrackCand::getHitWithPlane(int i, int& detId, int& hitId, int& planeId) const {
-  if (i < 0)
-    i += hits_.size();
-
-  detId = hits_.at(i)->getDetId();
-  hitId = hits_[i]->getHitId();
-  planeId = hits_[i]->getPlaneId();
-}
+  TrackCand& TrackCand::operator=(TrackCand other)
+  {
+    swap(other);
+    return *this;
+  }
 
 
-void TrackCand::addHit(int detId, int hitId, int planeId, double sortingParameter)
-{
-  hits_.push_back(new TrackCandHit(detId, hitId, planeId, sortingParameter));
-}
+  void TrackCand::swap(TrackCand& other)
+  {
+    // by swapping the members of two classes,
+    // the two classes are effectively swapped
+    std::swap(this->hits_, other.hits_);
+    std::swap(this->mcTrackId_, other.mcTrackId_);
+    std::swap(this->pdg_, other.pdg_);
+    std::swap(this->time_, other.time_);
+    std::swap(this->state6D_, other.state6D_);
+    std::swap(this->cov6D_, other.cov6D_);
+    std::swap(this->q_, other.q_);
+  }
 
-std::vector<int> TrackCand::getHitIDs(int detId) const {
-  std::vector<int> result;
-  for(unsigned int i=0; i<hits_.size(); ++i){
-    if(detId==-2 || hits_[i]->getDetId() == detId) {
-      result.push_back(hits_[i]->getHitId());
+
+  TrackCandHit* TrackCand::getHit(int i) const
+  {
+    if (i < 0)
+      i += hits_.size();
+
+    return hits_.at(i);
+  }
+
+
+  void TrackCand::getHit(int i, int& detId, int& hitId) const
+  {
+    if (i < 0)
+      i += hits_.size();
+
+    detId = hits_.at(i)->getDetId();
+    hitId = hits_[i]->getHitId();
+  }
+
+
+  void TrackCand::getHit(int i, int& detId, int& hitId, double& sortingParameter) const
+  {
+    if (i < 0)
+      i += hits_.size();
+
+    detId = hits_.at(i)->getDetId();
+    hitId = hits_[i]->getHitId();
+    sortingParameter = hits_[i]->getSortingParameter();
+  }
+
+
+  void TrackCand::getHitWithPlane(int i, int& detId, int& hitId, int& planeId) const
+  {
+    if (i < 0)
+      i += hits_.size();
+
+    detId = hits_.at(i)->getDetId();
+    hitId = hits_[i]->getHitId();
+    planeId = hits_[i]->getPlaneId();
+  }
+
+
+  void TrackCand::addHit(int detId, int hitId, int planeId, double sortingParameter)
+  {
+    hits_.push_back(new TrackCandHit(detId, hitId, planeId, sortingParameter));
+  }
+
+  std::vector<int> TrackCand::getHitIDs(int detId) const
+  {
+    std::vector<int> result;
+    for (unsigned int i = 0; i < hits_.size(); ++i) {
+      if (detId == -2 || hits_[i]->getDetId() == detId) {
+        result.push_back(hits_[i]->getHitId());
+      }
+    }
+    return result;
+  }
+
+  std::vector<int> TrackCand::getDetIDs() const
+  {
+    std::vector<int> result;
+    for (unsigned int i = 0; i < hits_.size(); ++i) {
+      result.push_back(hits_[i]->getDetId());
+    }
+    return result;
+  }
+
+  std::vector<double> TrackCand::getSortingParameters() const
+  {
+    std::vector<double> result;
+    for (unsigned int i = 0; i < hits_.size(); ++i) {
+      result.push_back(hits_[i]->getSortingParameter());
+    }
+    return result;
+  }
+
+  std::set<int> TrackCand::getUniqueDetIDs() const
+  {
+    std::set<int> retVal;
+    for (unsigned int i = 0; i < hits_.size(); ++i) {
+      retVal.insert(hits_[i]->getDetId());
+    }
+    return retVal;
+  }
+
+
+  void TrackCand::setPdgCode(int pdgCode)
+  {
+    pdg_ = pdgCode;
+    TParticlePDG* part = TDatabasePDG::Instance()->GetParticle(pdg_);
+    q_ = part->Charge() / (3.);
+  }
+
+
+  void TrackCand::reset()
+  {
+    for (unsigned int i = 0; i < hits_.size(); ++i) {
+      delete hits_[i];
+    }
+    hits_.clear();
+  }
+
+
+  bool TrackCand::hitInTrack(int detId, int hitId) const
+  {
+    for (unsigned int i = 0; i < hits_.size(); ++i) {
+      if (detId == hits_[i]->getDetId() && hitId == hits_[i]->getHitId())
+        return true;
+    }
+    return false;
+  }
+
+
+  bool operator== (const TrackCand& lhs, const TrackCand& rhs)
+  {
+    if (lhs.getNHits() != rhs.getNHits()) return false;
+    for (unsigned int i = 0; i < lhs.getNHits(); ++i) {
+      // use == operator of the TrackCandHits
+      if (*(lhs.getHit(i)) != *(rhs.getHit(i)))
+        return false;
+    }
+    return true;
+  }
+
+
+  void TrackCand::Print(const Option_t* option) const
+  {
+    printOut << "======== TrackCand::print ========\n";
+    printOut << "mcTrackId=" << mcTrackId_ << "\n";
+    printOut << "seed values for 6D state: \n";
+    state6D_.Print(option);
+    printOut << "charge = " << q_ << "\n";
+    printOut << "PDG code = " << pdg_ << "\n";
+    for (unsigned int i = 0; i < hits_.size(); ++i) {
+      hits_[i]->Print();
     }
   }
-  return result;
-}
-
-std::vector<int> TrackCand::getDetIDs() const {
-  std::vector<int> result;
-  for(unsigned int i=0; i<hits_.size(); ++i){
-    result.push_back(hits_[i]->getDetId());
-  }
-  return result;
-}
-
-std::vector<double> TrackCand::getSortingParameters() const {
-  std::vector<double> result;
-  for(unsigned int i=0; i<hits_.size(); ++i){
-    result.push_back(hits_[i]->getSortingParameter());
-  }
-  return result;
-}
-
-std::set<int> TrackCand::getUniqueDetIDs() const {
-  std::set<int> retVal;
-  for (unsigned int i = 0; i < hits_.size(); ++i) {
-    retVal.insert(hits_[i]->getDetId());
-  }
-  return retVal;
-}
 
 
-void TrackCand::setPdgCode(int pdgCode) {
-  pdg_ = pdgCode;
-  TParticlePDG* part = TDatabasePDG::Instance()->GetParticle(pdg_);
-  q_ = part->Charge() / (3.);
-}
-
-
-void TrackCand::reset()
-{
-  for (unsigned int i=0; i<hits_.size(); ++i) {
-    delete hits_[i];
-  }
-  hits_.clear();
-}
-
-
-bool TrackCand::hitInTrack(int detId, int hitId) const
-{
-  for (unsigned int i = 0; i < hits_.size(); ++i){
-    if (detId == hits_[i]->getDetId() && hitId == hits_[i]->getHitId())
-      return true;
-  }
-  return false;
-}
-
-
-bool operator== (const TrackCand& lhs, const TrackCand& rhs){
-  if(lhs.getNHits() != rhs.getNHits()) return false;
-  for (unsigned int i = 0; i < lhs.getNHits(); ++i){
-    // use == operator of the TrackCandHits
-    if (*(lhs.getHit(i)) != *(rhs.getHit(i)))
-      return false;
-  }
-  return true;
-}
-
-
-void TrackCand::Print(const Option_t* option) const {
-  printOut << "======== TrackCand::print ========\n";
-  printOut << "mcTrackId=" << mcTrackId_ << "\n";
-  printOut << "seed values for 6D state: \n";
-  state6D_.Print(option);
-  printOut << "charge = " << q_ << "\n";
-  printOut << "PDG code = " << pdg_ << "\n";
-  for(unsigned int i=0; i<hits_.size(); ++i){
-    hits_[i]->Print();
-  }
-}
-
-
-void TrackCand::append(const TrackCand& rhs){
-  for(unsigned int i=0; i<rhs.getNHits(); ++i){
-    addHit(rhs.getHit(i)->clone());
-  }
-}
-
-
-void TrackCand::sortHits(){
-  std::stable_sort(hits_.begin(), hits_.end(), compareTrackCandHits);
-}
-
-
-void TrackCand::sortHits(const std::vector<unsigned int>& indices){
-
-  const unsigned int nHits(getNHits());
-  if (indices.size() != nHits){
-    abort();
-    Exception exc("TrackCand::sortHits ==> Size of indices != number of hits!",__LINE__,__FILE__);
-    throw exc;
+  void TrackCand::append(const TrackCand& rhs)
+  {
+    for (unsigned int i = 0; i < rhs.getNHits(); ++i) {
+      addHit(rhs.getHit(i)->clone());
+    }
   }
 
-  //these containers will hold the sorted results. They are created to avoid probably slower in-place sorting
-  std::vector<TrackCandHit*> sortedHits(nHits);
-  for (unsigned int i=0; i<nHits; ++i){
-    sortedHits[i] = hits_[indices[i]];
+
+  void TrackCand::sortHits()
+  {
+    std::stable_sort(hits_.begin(), hits_.end(), compareTrackCandHits);
   }
-  //write the changes back to the private data members:
-  hits_ = sortedHits;
-}
 
 
-void TrackCand::set6DSeed(const TVectorD& state6D, const double charge) {
-  if (pdg_ != 0 && q_ != charge)
-    pdg_ = -pdg_;
-  q_ = charge;
-  state6D_ = state6D;
-}
+  void TrackCand::sortHits(const std::vector<unsigned int>& indices)
+  {
 
-void TrackCand::set6DSeedAndPdgCode(const TVectorD& state6D, const int pdgCode) {
-  setPdgCode(pdgCode);
-  state6D_ = state6D;
-}
+    const unsigned int nHits(getNHits());
+    if (indices.size() != nHits) {
+      abort();
+      Exception exc("TrackCand::sortHits ==> Size of indices != number of hits!", __LINE__, __FILE__);
+      throw exc;
+    }
 
-void TrackCand::setPosMomSeed(const TVector3& pos, const TVector3& mom, const double charge) {
-  if (pdg_ != 0 && q_ != charge)
-    pdg_ = -pdg_;
-  q_ = charge;
-  state6D_[0] = pos[0];  state6D_[1] = pos[1];  state6D_[2] = pos[2];
-  state6D_[3] = mom[0];  state6D_[4] = mom[1];  state6D_[5] = mom[2];
-}
-
-void TrackCand::setPosMomSeedAndPdgCode(const TVector3& pos, const TVector3& mom, const int pdgCode) {
-  setPdgCode(pdgCode);
-  state6D_[0] = pos[0];  state6D_[1] = pos[1];  state6D_[2] = pos[2];
-  state6D_[3] = mom[0];  state6D_[4] = mom[1];  state6D_[5] = mom[2];
-}
+    //these containers will hold the sorted results. They are created to avoid probably slower in-place sorting
+    std::vector<TrackCandHit*> sortedHits(nHits);
+    for (unsigned int i = 0; i < nHits; ++i) {
+      sortedHits[i] = hits_[indices[i]];
+    }
+    //write the changes back to the private data members:
+    hits_ = sortedHits;
+  }
 
 
-void TrackCand::setTime6DSeed(double time, const TVectorD& state6D, const double charge)
-{
-  time_ = time;
-  set6DSeed(state6D, charge);
-}
+  void TrackCand::set6DSeed(const TVectorD& state6D, const double charge)
+  {
+    if (pdg_ != 0 && q_ != charge)
+      pdg_ = -pdg_;
+    q_ = charge;
+    state6D_ = state6D;
+  }
 
-void TrackCand::setTime6DSeedAndPdgCode(double time, const TVectorD& state6D, const int pdgCode)
-{
-  time_ = time;
-  set6DSeedAndPdgCode(state6D, pdgCode);
-}
+  void TrackCand::set6DSeedAndPdgCode(const TVectorD& state6D, const int pdgCode)
+  {
+    setPdgCode(pdgCode);
+    state6D_ = state6D;
+  }
 
-void TrackCand::setTimePosMomSeed(double time, const TVector3& pos,
-				  const TVector3& mom, const double charge)
-{
-  time_ = time;
-  setPosMomSeed(pos, mom, charge);
-}
+  void TrackCand::setPosMomSeed(const TVector3& pos, const TVector3& mom, const double charge)
+  {
+    if (pdg_ != 0 && q_ != charge)
+      pdg_ = -pdg_;
+    q_ = charge;
+    state6D_[0] = pos[0];  state6D_[1] = pos[1];  state6D_[2] = pos[2];
+    state6D_[3] = mom[0];  state6D_[4] = mom[1];  state6D_[5] = mom[2];
+  }
 
-void TrackCand::setTimePosMomSeedAndPdgCode(double time, const TVector3& pos,
-					    const TVector3& mom, const int pdgCode)
-{
-  time_ = time;
-  setPosMomSeedAndPdgCode(pos, mom, pdgCode);
-}
+  void TrackCand::setPosMomSeedAndPdgCode(const TVector3& pos, const TVector3& mom, const int pdgCode)
+  {
+    setPdgCode(pdgCode);
+    state6D_[0] = pos[0];  state6D_[1] = pos[1];  state6D_[2] = pos[2];
+    state6D_[3] = mom[0];  state6D_[4] = mom[1];  state6D_[5] = mom[2];
+  }
+
+
+  void TrackCand::setTime6DSeed(double time, const TVectorD& state6D, const double charge)
+  {
+    time_ = time;
+    set6DSeed(state6D, charge);
+  }
+
+  void TrackCand::setTime6DSeedAndPdgCode(double time, const TVectorD& state6D, const int pdgCode)
+  {
+    time_ = time;
+    set6DSeedAndPdgCode(state6D, pdgCode);
+  }
+
+  void TrackCand::setTimePosMomSeed(double time, const TVector3& pos,
+                                    const TVector3& mom, const double charge)
+  {
+    time_ = time;
+    setPosMomSeed(pos, mom, charge);
+  }
+
+  void TrackCand::setTimePosMomSeedAndPdgCode(double time, const TVector3& pos,
+                                              const TVector3& mom, const int pdgCode)
+  {
+    time_ = time;
+    setPosMomSeedAndPdgCode(pos, mom, pdgCode);
+  }
 
 
 } /* End of namespace genfit */

--- a/core/src/TrackCandHit.cc
+++ b/core/src/TrackCandHit.cc
@@ -22,33 +22,35 @@
 
 namespace genfit {
 
-TrackCandHit::TrackCandHit(int detId,
-                               int hitId,
-                               int planeId,
-                               double sortingParameter)
-  : detId_(detId),
-    hitId_(hitId),
-    planeId_(planeId),
-    sortingParameter_(sortingParameter)
-{
-  ;
-}
+  TrackCandHit::TrackCandHit(int detId,
+                             int hitId,
+                             int planeId,
+                             double sortingParameter)
+    : detId_(detId),
+      hitId_(hitId),
+      planeId_(planeId),
+      sortingParameter_(sortingParameter)
+  {
+    ;
+  }
 
 
-void TrackCandHit::Print(Option_t*) const {
-  printOut << "  TrackCandHit. DetId = " << detId_
-           << " \t HitId = " << hitId_
-           << " \t PlaneId = " << planeId_
-           << " \t SortingParameter = " << sortingParameter_ << "\n";
-}
+  void TrackCandHit::Print(Option_t*) const
+  {
+    printOut << "  TrackCandHit. DetId = " << detId_
+             << " \t HitId = " << hitId_
+             << " \t PlaneId = " << planeId_
+             << " \t SortingParameter = " << sortingParameter_ << "\n";
+  }
 
 
-bool operator== (const TrackCandHit& lhs, const TrackCandHit& rhs){
-  if(lhs.detId_ == rhs.detId_ &&
-     lhs.hitId_ == rhs.hitId_ &&
-     lhs.planeId_ == rhs.planeId_)
-    return true;
-  return false;
-}
+  bool operator== (const TrackCandHit& lhs, const TrackCandHit& rhs)
+  {
+    if (lhs.detId_ == rhs.detId_ &&
+        lhs.hitId_ == rhs.hitId_ &&
+        lhs.planeId_ == rhs.planeId_)
+      return true;
+    return false;
+  }
 
 } /* End of namespace genfit */

--- a/core/src/TrackPoint.cc
+++ b/core/src/TrackPoint.cc
@@ -29,218 +29,232 @@
 
 namespace genfit {
 
-TrackPoint::TrackPoint() :
-  sortingParameter_(0), track_(nullptr), thinScatterer_(nullptr)
-{
-  ;
-}
-
-TrackPoint::TrackPoint(Track* track) :
-  sortingParameter_(0), track_(track), thinScatterer_(nullptr)
-{
-  ;
-}
-
-TrackPoint::TrackPoint(const std::vector< genfit::AbsMeasurement* >& rawMeasurements, Track* track) :
-  sortingParameter_(0), track_(track), thinScatterer_(nullptr)
-{
-  rawMeasurements_.reserve(rawMeasurements.size());
-
-  for (std::vector<AbsMeasurement*>::const_iterator m = rawMeasurements.begin(); m != rawMeasurements.end(); ++m) {
-    addRawMeasurement(*m);
-  }
-}
-
-TrackPoint::TrackPoint(AbsMeasurement* rawMeasurement, Track* track) :
-  sortingParameter_(0), track_(track), thinScatterer_(nullptr)
-{
-  addRawMeasurement(rawMeasurement);
-}
-
-
-TrackPoint::TrackPoint(const TrackPoint& rhs) :
-  TObject(rhs),
-  sortingParameter_(rhs.sortingParameter_), track_(rhs.track_), thinScatterer_(nullptr)
-{
-  // clone rawMeasurements
-  for (std::vector<AbsMeasurement*>::const_iterator it = rhs.rawMeasurements_.begin(); it != rhs.rawMeasurements_.end(); ++it) {
-    AbsMeasurement* tp = (*it)->clone();
-    addRawMeasurement(tp);
+  TrackPoint::TrackPoint() :
+    sortingParameter_(0), track_(nullptr), thinScatterer_(nullptr)
+  {
+    ;
   }
 
-  // copy fitterInfos
-  for (std::map<const AbsTrackRep*, AbsFitterInfo* >::const_iterator it = rhs.fitterInfos_.begin(); it != rhs.fitterInfos_.end();  ++it ) {
-    AbsFitterInfo* fi = it->second->clone();
-    fi->setTrackPoint(this);
-    setFitterInfo(fi);
+  TrackPoint::TrackPoint(Track* track) :
+    sortingParameter_(0), track_(track), thinScatterer_(nullptr)
+  {
+    ;
   }
 
-  if (rhs.thinScatterer_ != nullptr)
-    thinScatterer_.reset(new ThinScatterer(*(rhs.thinScatterer_)));
-}
+  TrackPoint::TrackPoint(const std::vector< genfit::AbsMeasurement* >& rawMeasurements, Track* track) :
+    sortingParameter_(0), track_(track), thinScatterer_(nullptr)
+  {
+    rawMeasurements_.reserve(rawMeasurements.size());
 
-TrackPoint::TrackPoint(const TrackPoint& rhs,
-    const std::map<const AbsTrackRep*, AbsTrackRep*>& map,
-    const std::vector<const genfit::AbsTrackRep*> * repsToIgnore) :
-  sortingParameter_(rhs.sortingParameter_), track_(rhs.track_), thinScatterer_(nullptr)
-{
-  // clone rawMeasurements
-  for (std::vector<AbsMeasurement*>::const_iterator it = rhs.rawMeasurements_.begin(); it!=rhs.rawMeasurements_.end(); ++it) {
-    AbsMeasurement* m = (*it)->clone();
-    addRawMeasurement(m);
-  }
-
-  // copy fitterInfos
-  for (std::map<const AbsTrackRep*, AbsFitterInfo* >::const_iterator it = rhs.fitterInfos_.begin(); it != rhs.fitterInfos_.end();  ++it ) {
-    if (repsToIgnore != nullptr) {
-      if (std::find(repsToIgnore->begin(), repsToIgnore->end(), it->first) != repsToIgnore->end())
-        continue;
+    for (std::vector<AbsMeasurement*>::const_iterator m = rawMeasurements.begin(); m != rawMeasurements.end(); ++m) {
+      addRawMeasurement(*m);
     }
-    AbsFitterInfo* fi = it->second->clone();
-    fi->setRep(map.at(it->first));
-    fi->setTrackPoint(this);
-    setFitterInfo(fi);
   }
 
-  if (rhs.thinScatterer_ != nullptr)
-    thinScatterer_.reset(new ThinScatterer(*(rhs.thinScatterer_)));
-}
-
-
-TrackPoint& TrackPoint::operator=(TrackPoint rhs) {
-  swap(rhs);
-
-  for (std::vector<AbsMeasurement*>::const_iterator it = rawMeasurements_.begin(); it!=rawMeasurements_.end(); ++it) {
-    (*it)->setTrackPoint(this);
+  TrackPoint::TrackPoint(AbsMeasurement* rawMeasurement, Track* track) :
+    sortingParameter_(0), track_(track), thinScatterer_(nullptr)
+  {
+    addRawMeasurement(rawMeasurement);
   }
 
-  for (std::map<const AbsTrackRep*, AbsFitterInfo* >::const_iterator it = fitterInfos_.begin(); it != fitterInfos_.end();  ++it ) {
-    it->second->setTrackPoint(this);
+
+  TrackPoint::TrackPoint(const TrackPoint& rhs) :
+    TObject(rhs),
+    sortingParameter_(rhs.sortingParameter_), track_(rhs.track_), thinScatterer_(nullptr)
+  {
+    // clone rawMeasurements
+    for (std::vector<AbsMeasurement*>::const_iterator it = rhs.rawMeasurements_.begin(); it != rhs.rawMeasurements_.end(); ++it) {
+      AbsMeasurement* tp = (*it)->clone();
+      addRawMeasurement(tp);
+    }
+
+    // copy fitterInfos
+    for (std::map<const AbsTrackRep*, AbsFitterInfo* >::const_iterator it = rhs.fitterInfos_.begin(); it != rhs.fitterInfos_.end();
+         ++it) {
+      AbsFitterInfo* fi = it->second->clone();
+      fi->setTrackPoint(this);
+      setFitterInfo(fi);
+    }
+
+    if (rhs.thinScatterer_ != nullptr)
+      thinScatterer_.reset(new ThinScatterer(*(rhs.thinScatterer_)));
   }
 
-  return *this;
-}
+  TrackPoint::TrackPoint(const TrackPoint& rhs,
+                         const std::map<const AbsTrackRep*, AbsTrackRep*>& map,
+                         const std::vector<const genfit::AbsTrackRep*>* repsToIgnore) :
+    sortingParameter_(rhs.sortingParameter_), track_(rhs.track_), thinScatterer_(nullptr)
+  {
+    // clone rawMeasurements
+    for (std::vector<AbsMeasurement*>::const_iterator it = rhs.rawMeasurements_.begin(); it != rhs.rawMeasurements_.end(); ++it) {
+      AbsMeasurement* m = (*it)->clone();
+      addRawMeasurement(m);
+    }
+
+    // copy fitterInfos
+    for (std::map<const AbsTrackRep*, AbsFitterInfo* >::const_iterator it = rhs.fitterInfos_.begin(); it != rhs.fitterInfos_.end();
+         ++it) {
+      if (repsToIgnore != nullptr) {
+        if (std::find(repsToIgnore->begin(), repsToIgnore->end(), it->first) != repsToIgnore->end())
+          continue;
+      }
+      AbsFitterInfo* fi = it->second->clone();
+      fi->setRep(map.at(it->first));
+      fi->setTrackPoint(this);
+      setFitterInfo(fi);
+    }
+
+    if (rhs.thinScatterer_ != nullptr)
+      thinScatterer_.reset(new ThinScatterer(*(rhs.thinScatterer_)));
+  }
 
 
-void TrackPoint::swap(TrackPoint& other) {
-  std::swap(this->sortingParameter_, other.sortingParameter_);
-  std::swap(this->track_, other.track_);
-  std::swap(this->rawMeasurements_, other.rawMeasurements_);
-  std::swap(this->fitterInfos_, other.fitterInfos_);
-  this->thinScatterer_.swap(other.thinScatterer_);
-}
+  TrackPoint& TrackPoint::operator=(TrackPoint rhs)
+  {
+    swap(rhs);
+
+    for (std::vector<AbsMeasurement*>::const_iterator it = rawMeasurements_.begin(); it != rawMeasurements_.end(); ++it) {
+      (*it)->setTrackPoint(this);
+    }
+
+    for (std::map<const AbsTrackRep*, AbsFitterInfo* >::const_iterator it = fitterInfos_.begin(); it != fitterInfos_.end();  ++it) {
+      it->second->setTrackPoint(this);
+    }
+
+    return *this;
+  }
 
 
-TrackPoint::~TrackPoint() {
-  // FIXME: We definitely need some smart containers or smart pointers that
-  // take care of this, but so far we haven't found a convincing
-  // option (2013-07-05).
-  
-  for (size_t i = 0; i < rawMeasurements_.size(); ++i)
-    delete rawMeasurements_[i];
-
-  std::map< const AbsTrackRep*, AbsFitterInfo* >::iterator it;
-  for (it = fitterInfos_.begin(); it != fitterInfos_.end(); ++it)
-    delete it->second;
-}
+  void TrackPoint::swap(TrackPoint& other)
+  {
+    std::swap(this->sortingParameter_, other.sortingParameter_);
+    std::swap(this->track_, other.track_);
+    std::swap(this->rawMeasurements_, other.rawMeasurements_);
+    std::swap(this->fitterInfos_, other.fitterInfos_);
+    this->thinScatterer_.swap(other.thinScatterer_);
+  }
 
 
-AbsMeasurement* TrackPoint::getRawMeasurement(int i) const {
-  if (i < 0)
-    i += rawMeasurements_.size();
+  TrackPoint::~TrackPoint()
+  {
+    // FIXME: We definitely need some smart containers or smart pointers that
+    // take care of this, but so far we haven't found a convincing
+    // option (2013-07-05).
 
-  return rawMeasurements_.at(i);
-}
+    for (size_t i = 0; i < rawMeasurements_.size(); ++i)
+      delete rawMeasurements_[i];
+
+    std::map< const AbsTrackRep*, AbsFitterInfo* >::iterator it;
+    for (it = fitterInfos_.begin(); it != fitterInfos_.end(); ++it)
+      delete it->second;
+  }
 
 
-std::vector< AbsFitterInfo* > TrackPoint::getFitterInfos() const {
-  std::vector< AbsFitterInfo* > retVal;
+  AbsMeasurement* TrackPoint::getRawMeasurement(int i) const
+  {
+    if (i < 0)
+      i += rawMeasurements_.size();
 
-  if (fitterInfos_.empty())
+    return rawMeasurements_.at(i);
+  }
+
+
+  std::vector< AbsFitterInfo* > TrackPoint::getFitterInfos() const
+  {
+    std::vector< AbsFitterInfo* > retVal;
+
+    if (fitterInfos_.empty())
+      return retVal;
+
+    for (std::map<const AbsTrackRep*, AbsFitterInfo* >::const_iterator it = fitterInfos_.begin(); it != fitterInfos_.end();  ++it) {
+      retVal.push_back(it->second);
+    }
+
     return retVal;
-
-  for (std::map<const AbsTrackRep*, AbsFitterInfo* >::const_iterator it = fitterInfos_.begin(); it != fitterInfos_.end();  ++it ) {
-    retVal.push_back(it->second);
   }
 
-  return retVal;
-}
 
-
-AbsFitterInfo* TrackPoint::getFitterInfo(const AbsTrackRep* rep) const {
-  if (!rep)
-    rep = track_->getCardinalRep();
-  std::map<const AbsTrackRep*, AbsFitterInfo*>::const_iterator it = fitterInfos_.find(rep);
-  if (it == fitterInfos_.end())
-    return nullptr;
-  return fitterInfos_.at(rep);
-}
-
-
-KalmanFitterInfo* TrackPoint::getKalmanFitterInfo(const AbsTrackRep* rep) const {
-  return dynamic_cast<KalmanFitterInfo*>(getFitterInfo(rep));
-}
-
-
-
-void TrackPoint::deleteRawMeasurements() {
-  for (size_t i = 0; i < rawMeasurements_.size(); ++i)
-    delete rawMeasurements_[i];
-
-  rawMeasurements_.clear();
-}
-
-
-void TrackPoint::setFitterInfo(genfit::AbsFitterInfo* fitterInfo) {
-  assert (fitterInfo != nullptr);
-  if (hasFitterInfo(fitterInfo->getRep()))
-    delete fitterInfos_[fitterInfo->getRep()];
-
-  fitterInfos_[fitterInfo->getRep()] = fitterInfo;
-}
-
-
-void TrackPoint::Print(const Option_t*) const {
-  printOut << "genfit::TrackPoint, belonging to Track " << track_ << "; sorting parameter = " << sortingParameter_ << "\n";
-  printOut << "contains " << rawMeasurements_.size() << " rawMeasurements and " << getFitterInfos().size() << " fitterInfos for " << fitterInfos_.size() << " TrackReps.\n";
-
-  for (unsigned int i=0; i<rawMeasurements_.size(); ++i) {
-    printOut << "RawMeasurement Nr. " << i << "\n";
-    rawMeasurements_[i]->Print();
-    printOut << "............\n";
+  AbsFitterInfo* TrackPoint::getFitterInfo(const AbsTrackRep* rep) const
+  {
+    if (!rep)
+      rep = track_->getCardinalRep();
+    std::map<const AbsTrackRep*, AbsFitterInfo*>::const_iterator it = fitterInfos_.find(rep);
+    if (it == fitterInfos_.end())
+      return nullptr;
+    return fitterInfos_.at(rep);
   }
 
-  for (std::map< const AbsTrackRep*, AbsFitterInfo* >::const_iterator it = fitterInfos_.begin(); it != fitterInfos_.end();  ++it ) {
-    printOut << "FitterInfo for TrackRep " << it->first << "\n";
-    it->second->Print();
-    printOut << "............\n";
+
+  KalmanFitterInfo* TrackPoint::getKalmanFitterInfo(const AbsTrackRep* rep) const
+  {
+    return dynamic_cast<KalmanFitterInfo*>(getFitterInfo(rep));
   }
 
-  if (thinScatterer_)
-    thinScatterer_->Print();
 
-}
+
+  void TrackPoint::deleteRawMeasurements()
+  {
+    for (size_t i = 0; i < rawMeasurements_.size(); ++i)
+      delete rawMeasurements_[i];
+
+    rawMeasurements_.clear();
+  }
+
+
+  void TrackPoint::setFitterInfo(genfit::AbsFitterInfo* fitterInfo)
+  {
+    assert(fitterInfo != nullptr);
+    if (hasFitterInfo(fitterInfo->getRep()))
+      delete fitterInfos_[fitterInfo->getRep()];
+
+    fitterInfos_[fitterInfo->getRep()] = fitterInfo;
+  }
+
+
+  void TrackPoint::Print(const Option_t*) const
+  {
+    printOut << "genfit::TrackPoint, belonging to Track " << track_ << "; sorting parameter = " << sortingParameter_ << "\n";
+    printOut << "contains " << rawMeasurements_.size() << " rawMeasurements and " << getFitterInfos().size() << " fitterInfos for " <<
+             fitterInfos_.size() << " TrackReps.\n";
+
+    for (unsigned int i = 0; i < rawMeasurements_.size(); ++i) {
+      printOut << "RawMeasurement Nr. " << i << "\n";
+      rawMeasurements_[i]->Print();
+      printOut << "............\n";
+    }
+
+    for (std::map< const AbsTrackRep*, AbsFitterInfo* >::const_iterator it = fitterInfos_.begin(); it != fitterInfos_.end();  ++it) {
+      printOut << "FitterInfo for TrackRep " << it->first << "\n";
+      it->second->Print();
+      printOut << "............\n";
+    }
+
+    if (thinScatterer_)
+      thinScatterer_->Print();
+
+  }
 
 
 //
 // This is modified from the auto-generated Streamer.
 //
-void TrackPoint::Streamer(TBuffer &R__b)
-{
-   // Stream an object of class genfit::TrackPoint.
-   //This works around a msvc bug and should be harmless on other platforms
-   typedef ::genfit::TrackPoint thisClass;
-   UInt_t R__s, R__c;
-   if (R__b.IsReading()) {
-      Version_t R__v = R__b.ReadVersion(&R__s, &R__c); if (R__v) { }
+  void TrackPoint::Streamer(TBuffer& R__b)
+  {
+    // Stream an object of class genfit::TrackPoint.
+    //This works around a msvc bug and should be harmless on other platforms
+    typedef ::genfit::TrackPoint thisClass;
+    UInt_t R__s, R__c;
+    if (R__b.IsReading()) {
+      Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+      if (R__v) { }
       //TObject::Streamer(R__b);
       R__b >> sortingParameter_;
       {
-        std::vector<genfit::AbsMeasurement*,std::allocator<genfit::AbsMeasurement*> > &R__stl =  rawMeasurements_;
+        std::vector<genfit::AbsMeasurement*, std::allocator<genfit::AbsMeasurement*> >& R__stl =  rawMeasurements_;
         R__stl.clear();
-        TClass *R__tcl1 = TBuffer::GetClass(typeid(genfit::AbsMeasurement));
-        if (R__tcl1==0) {
-          Error("rawMeasurements_ streamer","Missing the TClass object for genfit::AbsMeasurement!");
+        TClass* R__tcl1 = TBuffer::GetClass(typeid(genfit::AbsMeasurement));
+        if (R__tcl1 == 0) {
+          Error("rawMeasurements_ streamer", "Missing the TClass object for genfit::AbsMeasurement!");
           return;
         }
         int R__i, R__n;
@@ -266,7 +280,7 @@ void TrackPoint::Streamer(TBuffer &R__b)
       char flag;
       R__b >> flag;
       if (flag) {
-        genfit::ThinScatterer *scatterer = 0;
+        genfit::ThinScatterer* scatterer = 0;
         R__b >> scatterer;
         thinScatterer_.reset(new ThinScatterer(*scatterer));
       }
@@ -282,16 +296,16 @@ void TrackPoint::Streamer(TBuffer &R__b)
         if (fitterInfo)
           fitterInfo->setTrackPoint(this);
       }
-   } else {
+    } else {
       R__c = R__b.WriteVersion(thisClass::IsA(), kTRUE);
       //TObject::Streamer(R__b);
       R__b << sortingParameter_;
       {
-        std::vector<genfit::AbsMeasurement*,std::allocator<genfit::AbsMeasurement*> > &R__stl = rawMeasurements_;
-        int R__n= int(R__stl.size());
+        std::vector<genfit::AbsMeasurement*, std::allocator<genfit::AbsMeasurement*> >& R__stl = rawMeasurements_;
+        int R__n = int(R__stl.size());
         R__b << R__n;
-        if(R__n) {
-          std::vector<genfit::AbsMeasurement*,std::allocator<genfit::AbsMeasurement*> >::iterator R__k;
+        if (R__n) {
+          std::vector<genfit::AbsMeasurement*, std::allocator<genfit::AbsMeasurement*> >::iterator R__k;
           for (R__k = R__stl.begin(); R__k != R__stl.end(); ++R__k) {
             R__b << (*R__k);
           }
@@ -299,8 +313,7 @@ void TrackPoint::Streamer(TBuffer &R__b)
       }
       R__b << fitterInfos_.size();
       for (std::map<const AbsTrackRep*, AbsFitterInfo*>::const_iterator it = fitterInfos_.begin();
-          it != fitterInfos_.end(); ++it)
-      {
+           it != fitterInfos_.end(); ++it) {
         int id = track_->getIdForRep(it->first);
         R__b << id;
         R__b << it->second;
@@ -312,26 +325,26 @@ void TrackPoint::Streamer(TBuffer &R__b)
         R__b << (char)0;
       }
       R__b.SetByteCount(R__c, kTRUE);
-   }
-}
-
-
-void TrackPoint::fixupRepsForReading()
-{
-  for (auto& trackRepIDWithFitterInfo : vFitterInfos_) {
-    // The map is filled such that i corresponds to the id of the TrackRep.
-    const unsigned int id = trackRepIDWithFitterInfo.first;
-    AbsFitterInfo* fitterInfo = trackRepIDWithFitterInfo.second;
-
-    // May not have FitterInfos for all reps.
-    if (!fitterInfo)
-      continue;
-    AbsTrackRep* trackRep = track_->getTrackRep(id);
-
-    fitterInfos_[trackRep] = fitterInfo;
-    fitterInfos_[trackRep]->setRep(trackRep);
+    }
   }
-  vFitterInfos_.clear();
-}
+
+
+  void TrackPoint::fixupRepsForReading()
+  {
+    for (auto& trackRepIDWithFitterInfo : vFitterInfos_) {
+      // The map is filled such that i corresponds to the id of the TrackRep.
+      const unsigned int id = trackRepIDWithFitterInfo.first;
+      AbsFitterInfo* fitterInfo = trackRepIDWithFitterInfo.second;
+
+      // May not have FitterInfos for all reps.
+      if (!fitterInfo)
+        continue;
+      AbsTrackRep* trackRep = track_->getTrackRep(id);
+
+      fitterInfos_[trackRep] = fitterInfo;
+      fitterInfos_[trackRep]->setRep(trackRep);
+    }
+    vFitterInfos_.clear();
+  }
 
 } /* End of namespace genfit */

--- a/eventDisplay/include/EventDisplay.h
+++ b/eventDisplay/include/EventDisplay.h
@@ -38,44 +38,44 @@
 
 namespace genfit {
 
-enum eFitterType {
-  SimpleKalman,
-  RefKalman,
-  DafSimple,
-  DafRef
-};
+  enum eFitterType {
+    SimpleKalman,
+    RefKalman,
+    DafSimple,
+    DafRef
+  };
 
-/** @brief Event display designed to run with Genfit.
- *
- *  @author Karl Bicker (Technische Universit&auml;t M&uuml;nchen, original author)
- * 
- * The EventDisplay class is a singelton used to visualize the events processed with Genfit. The
- * event display uses the EVE event visualization package to visualize Tracks which are bundled
- * in a vector and which form one event. The information about the tracks is supplied in Track
- * objects. To use the event display, the geometry (TGeoManager)and magnetic field (FieldManager)
- * have to be initialized and gApplication and gEve have to exist.
- *
- */
-class EventDisplay : public TNamed {
-	private:
-		EventDisplay();
-	
-	public:
-		~EventDisplay();
-		static EventDisplay* getInstance();
+  /** @brief Event display designed to run with Genfit.
+   *
+   *  @author Karl Bicker (Technische Universit&auml;t M&uuml;nchen, original author)
+   *
+   * The EventDisplay class is a singelton used to visualize the events processed with Genfit. The
+   * event display uses the EVE event visualization package to visualize Tracks which are bundled
+   * in a vector and which form one event. The information about the tracks is supplied in Track
+   * objects. To use the event display, the geometry (TGeoManager)and magnetic field (FieldManager)
+   * have to be initialized and gApplication and gEve have to exist.
+   *
+   */
+  class EventDisplay : public TNamed {
+  private:
+    EventDisplay();
 
-		/** @brief Drop all events.*/
-		void reset();
+  public:
+    ~EventDisplay();
+    static EventDisplay* getInstance();
 
-		/** @brief Add new event
-		 *
-		 * Add a new event. An event is a collection of Tracks which are displayed at the
-		 * the same time.
-		 * The tracks are copied.
-		 *
-		 */
-		void addEvent(std::vector<genfit::Track*>& tracks);
-		void addEvent(std::vector<const genfit::Track*>& tracks);
+    /** @brief Drop all events.*/
+    void reset();
+
+    /** @brief Add new event
+     *
+     * Add a new event. An event is a collection of Tracks which are displayed at the
+     * the same time.
+     * The tracks are copied.
+     *
+     */
+    void addEvent(std::vector<genfit::Track*>& tracks);
+    void addEvent(std::vector<const genfit::Track*>& tracks);
 
     /** @brief Add new event
      *
@@ -84,72 +84,72 @@ class EventDisplay : public TNamed {
      */
     void addEvent(const Track* tr);
 
-		/** @brief Go to the next event or step a certain number of events ahead.*/
-		void next(unsigned int stp = 1);
+    /** @brief Go to the next event or step a certain number of events ahead.*/
+    void next(unsigned int stp = 1);
 
-		/** @brief Go to the previous event or step a certain number of events back.*/
-		void prev(unsigned int stp = 1);
+    /** @brief Go to the previous event or step a certain number of events back.*/
+    void prev(unsigned int stp = 1);
 
-		/** @brief Go to event with index id.*/
-		void gotoEvent(unsigned int id);
+    /** @brief Go to event with index id.*/
+    void gotoEvent(unsigned int id);
 
-		/** @brief Get the total number of events stored.*/
-		int getNEvents();
+    /** @brief Get the total number of events stored.*/
+    int getNEvents();
 
-		/** @brief Set the display options.
-		 *
-		 * The option string lets you steer the way the events are displayed. The following
-		 * options are available:\n
-		 * \n
-		 * 'A': Autoscale errors. The representation of hits are scaled with the error found
-		 *      their covariance matrix. This can lead to hits not being displayed beause the
-		 *      errors are too small. Autoscaling ensures that the errors are scaled up
-		 *      sufficiently to ensure all hits are displayed. However, this can lead to unwanted
-		 *      results if there are only a few hits with very small errors, as all hits are scaled
-		 *      by the same factor to ensure consistency.\n\n
-		 * 'B': Draw Backward Fit (track segments start at updates and end at predictions)\n\n
-		 * 'D': Draw detectors. This causes a simple representation for all detectors to be drawn. For
-		 *      planar detectors, this is a plane with the same position and orientation of the real
-		 *      detector plane, but with different size. For wires, this is a tube whose diameter
-		 *      is equal to the value measured by the wire. Spacepoint hits are not affected by this
-		 *      option.\n\n
-		 * 'E': Draw Error cones (position and direction uncertainties) around the track.\n\n
+    /** @brief Set the display options.
+     *
+     * The option string lets you steer the way the events are displayed. The following
+     * options are available:\n
+     * \n
+     * 'A': Autoscale errors. The representation of hits are scaled with the error found
+     *      their covariance matrix. This can lead to hits not being displayed beause the
+     *      errors are too small. Autoscaling ensures that the errors are scaled up
+     *      sufficiently to ensure all hits are displayed. However, this can lead to unwanted
+     *      results if there are only a few hits with very small errors, as all hits are scaled
+     *      by the same factor to ensure consistency.\n\n
+     * 'B': Draw Backward Fit (track segments start at updates and end at predictions)\n\n
+     * 'D': Draw detectors. This causes a simple representation for all detectors to be drawn. For
+     *      planar detectors, this is a plane with the same position and orientation of the real
+     *      detector plane, but with different size. For wires, this is a tube whose diameter
+     *      is equal to the value measured by the wire. Spacepoint hits are not affected by this
+     *      option.\n\n
+     * 'E': Draw Error cones (position and direction uncertainties) around the track.\n\n
      * 'F': Draw Forward Fit (track segments start at updates and end at predictions)
-		 * 'H': Draw hits. This causes the hits to be visualized. Normally, the size of the hit
-		 *      representation is connected to the covariance matrix of the hit, scaled by the value
-		 *      set in setErrScale which is normally 1. See also option 'A' and 'S'. Normally used in
-		 *      connection with 'D'.\n\n
-		 * 'G': Draw geometry. Draw also the geometry in the gGeoManager. This feature is experimental
-		 *      and may lead to strang things being drawn.\n\n
-		 * 'M': Draw track markers. Draw the intersection points between the track and the virtual
-		 *      (and/or real) detector planes. Can only be used in connection with 'T'.\n\n
-		 * 'P': Draw detector planes. Draws the virtual (and/or real) detector planes.\n\n
-		 * 'S': Scale manually. This leads to the spacepoint hits (and only them up to now!) being drawn
-		 *      as spheres with radius 0.5 scaled with the error scale factor. Can be used if the scaling
-		 *      with errors leads to problems.\n\n
-		 * 'T': Draw Track. Draw the track as lines between the virtual (and/or real) detector
-		 *      planes.\n\n
-		 * 'X': Draw silent. Does not run the TApplication.
-		 *
-		 */
-		void setOptions(std::string opts);
+     * 'H': Draw hits. This causes the hits to be visualized. Normally, the size of the hit
+     *      representation is connected to the covariance matrix of the hit, scaled by the value
+     *      set in setErrScale which is normally 1. See also option 'A' and 'S'. Normally used in
+     *      connection with 'D'.\n\n
+     * 'G': Draw geometry. Draw also the geometry in the gGeoManager. This feature is experimental
+     *      and may lead to strang things being drawn.\n\n
+     * 'M': Draw track markers. Draw the intersection points between the track and the virtual
+     *      (and/or real) detector planes. Can only be used in connection with 'T'.\n\n
+     * 'P': Draw detector planes. Draws the virtual (and/or real) detector planes.\n\n
+     * 'S': Scale manually. This leads to the spacepoint hits (and only them up to now!) being drawn
+     *      as spheres with radius 0.5 scaled with the error scale factor. Can be used if the scaling
+     *      with errors leads to problems.\n\n
+     * 'T': Draw Track. Draw the track as lines between the virtual (and/or real) detector
+     *      planes.\n\n
+     * 'X': Draw silent. Does not run the TApplication.
+     *
+     */
+    void setOptions(std::string opts);
 
-		/** @brief Set the scaling factor for the visualization of the errors.*/
-		void setErrScale(double errScale = 1.);
+    /** @brief Set the scaling factor for the visualization of the errors.*/
+    void setErrScale(double errScale = 1.);
 
-		/** @brief Get the error scaling factor.*/
-		double getErrScale();
+    /** @brief Get the error scaling factor.*/
+    double getErrScale();
 
-		/** @brief Open the event display.*/
-		void open();
-	
-	  void guiGoto();
-	  void guiGoto2();
-		void guiSetDrawParams();
-		void guiSelectFitterId(int val);
-		void guiSelectMmHandling(int val);
+    /** @brief Open the event display.*/
+    void open();
 
-	private:
+    void guiGoto();
+    void guiGoto2();
+    void guiSetDrawParams();
+    void guiSelectFitterId(int val);
+    void guiSelectMmHandling(int val);
+
+  private:
     /** @brief Build the buttons for event navigation.*/
     void makeGui();
 
@@ -162,7 +162,7 @@ class EventDisplay : public TNamed {
     TEveBox* boxCreator(TVector3 o, TVector3 u, TVector3 v, float ud, float vd, float depth);
 
     void makeLines(const StateOnPlane* prevState, const StateOnPlane* state, const AbsTrackRep* rep,
-                     const Color_t& color, const Style_t& style, bool drawMarkers, bool drawErrors, double lineWidth = 2, int markerPos = 1);
+                   const Color_t& color, const Style_t& style, bool drawMarkers, bool drawErrors, double lineWidth = 2, int markerPos = 1);
 
 
     static EventDisplay* eventDisplay_; //!
@@ -242,10 +242,10 @@ class EventDisplay : public TNamed {
     bool resort_;
 
 
-	public:
-		ClassDef(EventDisplay,1)
+  public:
+    ClassDef(EventDisplay, 1)
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/eventDisplay/src/EventDisplay.cc
+++ b/eventDisplay/src/EventDisplay.cc
@@ -59,539 +59,542 @@
 namespace genfit {
 
 
-EventDisplay* EventDisplay::eventDisplay_ = nullptr;
+  EventDisplay* EventDisplay::eventDisplay_ = nullptr;
 
-EventDisplay::EventDisplay() :
-  errorScale_(1.),
-  drawGeometry_(false),
-  drawDetectors_(true),
-  drawHits_(true),
-  drawErrors_(true),
-  drawPlanes_(true),
-  drawTrackMarkers_(true),
-  drawTrack_(true),
-  drawRefTrack_(true),
-  drawForward_(true),
-  drawBackward_(true),
-  drawAutoScale_(true),
-  drawScaleMan_(false),
-  drawSilent_(false),
-  drawCardinalRep_(true),
-  repId_(0),
-  drawAllTracks_(true),
-  trackId_(0),
-  refit_(false),
-  debugLvl_(0),
-  fitterId_(SimpleKalman),
-  mmHandling_(weightedAverage),
-  squareRootFormalism_(false),
-  dPVal_(1.E-3),
-  dRelChi2_(0.2),
-  dChi2Ref_(1.),
-  nMinIter_(2),
-  nMaxIter_(4),
-  nMaxFailed_(-1),
-  resort_(false)
-{
+  EventDisplay::EventDisplay() :
+    errorScale_(1.),
+    drawGeometry_(false),
+    drawDetectors_(true),
+    drawHits_(true),
+    drawErrors_(true),
+    drawPlanes_(true),
+    drawTrackMarkers_(true),
+    drawTrack_(true),
+    drawRefTrack_(true),
+    drawForward_(true),
+    drawBackward_(true),
+    drawAutoScale_(true),
+    drawScaleMan_(false),
+    drawSilent_(false),
+    drawCardinalRep_(true),
+    repId_(0),
+    drawAllTracks_(true),
+    trackId_(0),
+    refit_(false),
+    debugLvl_(0),
+    fitterId_(SimpleKalman),
+    mmHandling_(weightedAverage),
+    squareRootFormalism_(false),
+    dPVal_(1.E-3),
+    dRelChi2_(0.2),
+    dChi2Ref_(1.),
+    nMinIter_(2),
+    nMaxIter_(4),
+    nMaxFailed_(-1),
+    resort_(false)
+  {
 
-  if((!gApplication) || (gApplication && gApplication->TestBit(TApplication::kDefaultApplication))) {
-    std::cout << "In EventDisplay ctor: gApplication not found, creating..." << std::flush;
-    new TApplication("ROOT_application", 0, 0);
-    std::cout << "done!" << std::endl;
-  }
-  if(!gEve) {
-    std::cout << "In EventDisplay ctor: gEve not found, creating..." << std::flush;
-    TEveManager::Create();
-    std::cout << "done!" << std::endl;
-  }
-
-  eventId_ = 0;
-
-}
-
-void EventDisplay::setOptions(std::string opts) {
-
-  if(opts != "") {
-    for(size_t i = 0; i < opts.length(); ++i) {
-      if(opts[i] == 'A') drawAutoScale_ = true;
-      if(opts[i] == 'B') drawBackward_ = true;
-      if(opts[i] == 'D') drawDetectors_ = true;
-      if(opts[i] == 'E') drawErrors_ = true;
-      if(opts[i] == 'F') drawForward_ = true;
-      if(opts[i] == 'H') drawHits_ = true;
-      if(opts[i] == 'M') drawTrackMarkers_ = true;
-      if(opts[i] == 'P') drawPlanes_ = true;
-      if(opts[i] == 'S') drawScaleMan_ = true;
-      if(opts[i] == 'T') drawTrack_ = true;
-      if(opts[i] == 'X') drawSilent_ = true;
-      if(opts[i] == 'G') drawGeometry_ = true;
+    if ((!gApplication) || (gApplication && gApplication->TestBit(TApplication::kDefaultApplication))) {
+      std::cout << "In EventDisplay ctor: gApplication not found, creating..." << std::flush;
+      new TApplication("ROOT_application", 0, 0);
+      std::cout << "done!" << std::endl;
     }
-  }
-
-}
-
-void EventDisplay::setErrScale(double errScale) { errorScale_ = errScale; }
-
-double EventDisplay::getErrScale() { return errorScale_; }
-
-EventDisplay* EventDisplay::getInstance() {
-
-  if(eventDisplay_ == nullptr) {
-    eventDisplay_ = new EventDisplay();
-  }
-  return eventDisplay_;
-
-}
-
-EventDisplay::~EventDisplay() { reset(); }
-
-void EventDisplay::reset() {
-
-  for(unsigned int i = 0; i < events_.size(); i++) {
-
-    for(unsigned int j = 0; j < events_[i]->size(); j++) {
-
-      delete events_[i]->at(j);
-
+    if (!gEve) {
+      std::cout << "In EventDisplay ctor: gEve not found, creating..." << std::flush;
+      TEveManager::Create();
+      std::cout << "done!" << std::endl;
     }
-    delete events_[i];
+
+    eventId_ = 0;
+
   }
 
-  events_.clear();
-}
+  void EventDisplay::setOptions(std::string opts)
+  {
 
+    if (opts != "") {
+      for (size_t i = 0; i < opts.length(); ++i) {
+        if (opts[i] == 'A') drawAutoScale_ = true;
+        if (opts[i] == 'B') drawBackward_ = true;
+        if (opts[i] == 'D') drawDetectors_ = true;
+        if (opts[i] == 'E') drawErrors_ = true;
+        if (opts[i] == 'F') drawForward_ = true;
+        if (opts[i] == 'H') drawHits_ = true;
+        if (opts[i] == 'M') drawTrackMarkers_ = true;
+        if (opts[i] == 'P') drawPlanes_ = true;
+        if (opts[i] == 'S') drawScaleMan_ = true;
+        if (opts[i] == 'T') drawTrack_ = true;
+        if (opts[i] == 'X') drawSilent_ = true;
+        if (opts[i] == 'G') drawGeometry_ = true;
+      }
+    }
 
-void EventDisplay::addEvent(std::vector<Track*>& tracks) {
-
-  std::vector<Track*>* vec = new std::vector<Track*>;
-
-  for(unsigned int i = 0; i < tracks.size(); i++) {
-    vec->push_back(new Track(*(tracks[i])));
   }
 
-  events_.push_back(vec);
-}
+  void EventDisplay::setErrScale(double errScale) { errorScale_ = errScale; }
 
+  double EventDisplay::getErrScale() { return errorScale_; }
 
-void EventDisplay::addEvent(std::vector<const Track*>& tracks) {
+  EventDisplay* EventDisplay::getInstance()
+  {
 
-  std::vector<Track*>* vec = new std::vector<Track*>;
+    if (eventDisplay_ == nullptr) {
+      eventDisplay_ = new EventDisplay();
+    }
+    return eventDisplay_;
 
-  for(unsigned int i = 0; i < tracks.size(); i++) {
-    vec->push_back(new Track(*(tracks[i])));
   }
 
-  events_.push_back(vec);
-}
+  EventDisplay::~EventDisplay() { reset(); }
 
+  void EventDisplay::reset()
+  {
 
-void EventDisplay::addEvent(const Track* tr) {
+    for (unsigned int i = 0; i < events_.size(); i++) {
 
-  std::vector<Track*>* vec = new std::vector<Track*>;
-  vec->push_back(new Track(*tr));
-  events_.push_back(vec);
-}
+      for (unsigned int j = 0; j < events_[i]->size(); j++) {
 
+        delete events_[i]->at(j);
 
-void EventDisplay::next(unsigned int stp) {
+      }
+      delete events_[i];
+    }
 
-  gotoEvent(eventId_ + stp);
-
-}
-
-void EventDisplay::prev(unsigned int stp) {
-
-  if(events_.size() == 0) return;
-  if(eventId_ < stp) {
-    gotoEvent(0);
-  } else {
-    gotoEvent(eventId_ - stp);
+    events_.clear();
   }
 
-}
 
-int EventDisplay::getNEvents() { return events_.size(); }
+  void EventDisplay::addEvent(std::vector<Track*>& tracks)
+  {
 
+    std::vector<Track*>* vec = new std::vector<Track*>;
 
-void EventDisplay::gotoEvent(unsigned int id) {
+    for (unsigned int i = 0; i < tracks.size(); i++) {
+      vec->push_back(new Track(*(tracks[i])));
+    }
 
-  if (events_.size() == 0)
-    return;
-  else if(id >= events_.size())
-    id = events_.size() - 1;
-
-  bool resetCam = true;
-
-  if (id == eventId_)
-    resetCam = false;
-
-  eventId_ = id;
-
-  std::cout << "At event " << id << std::endl;
-  if (gEve->GetCurrentEvent()) {
-    gEve->GetCurrentEvent()->DestroyElements();
+    events_.push_back(vec);
   }
-  double old_error_scale = errorScale_;
-  drawEvent(eventId_, resetCam);
-  if(old_error_scale != errorScale_) {
+
+
+  void EventDisplay::addEvent(std::vector<const Track*>& tracks)
+  {
+
+    std::vector<Track*>* vec = new std::vector<Track*>;
+
+    for (unsigned int i = 0; i < tracks.size(); i++) {
+      vec->push_back(new Track(*(tracks[i])));
+    }
+
+    events_.push_back(vec);
+  }
+
+
+  void EventDisplay::addEvent(const Track* tr)
+  {
+
+    std::vector<Track*>* vec = new std::vector<Track*>;
+    vec->push_back(new Track(*tr));
+    events_.push_back(vec);
+  }
+
+
+  void EventDisplay::next(unsigned int stp)
+  {
+
+    gotoEvent(eventId_ + stp);
+
+  }
+
+  void EventDisplay::prev(unsigned int stp)
+  {
+
+    if (events_.size() == 0) return;
+    if (eventId_ < stp) {
+      gotoEvent(0);
+    } else {
+      gotoEvent(eventId_ - stp);
+    }
+
+  }
+
+  int EventDisplay::getNEvents() { return events_.size(); }
+
+
+  void EventDisplay::gotoEvent(unsigned int id)
+  {
+
+    if (events_.size() == 0)
+      return;
+    else if (id >= events_.size())
+      id = events_.size() - 1;
+
+    bool resetCam = true;
+
+    if (id == eventId_)
+      resetCam = false;
+
+    eventId_ = id;
+
+    std::cout << "At event " << id << std::endl;
     if (gEve->GetCurrentEvent()) {
       gEve->GetCurrentEvent()->DestroyElements();
     }
-    drawEvent(eventId_, resetCam); // if autoscaling changed the error, draw again.
-  }
-  errorScale_ = old_error_scale;
-
-}
-
-void EventDisplay::open() {
-
-  std::cout << "EventDisplay::open(); " << getNEvents() << " events loaded" << std::endl;
-
-  if(getNEvents() > 0) {
     double old_error_scale = errorScale_;
-    drawEvent(0);
-    if(old_error_scale != errorScale_) {
-      std::cout << "autoscaling changed the error, draw again." << std::endl;
-      gotoEvent(0); // if autoscaling changed the error, draw again.
+    drawEvent(eventId_, resetCam);
+    if (old_error_scale != errorScale_) {
+      if (gEve->GetCurrentEvent()) {
+        gEve->GetCurrentEvent()->DestroyElements();
+      }
+      drawEvent(eventId_, resetCam); // if autoscaling changed the error, draw again.
     }
     errorScale_ = old_error_scale;
+
   }
 
+  void EventDisplay::open()
+  {
 
-  if(!drawSilent_) {
-    makeGui();
-    gApplication->Run(kTRUE);
-  }
+    std::cout << "EventDisplay::open(); " << getNEvents() << " events loaded" << std::endl;
 
-  std::cout << "opened" << std::endl;
-
-}
-
-
-void EventDisplay::drawEvent(unsigned int id, bool resetCam) {
-
-  std::cout << "EventDisplay::drawEvent(" << id << ")" << std::endl;
-
-
-  // draw the geometry, does not really work yet. If it's fixed, the docu in the header file should be changed.
-  if(drawGeometry_) {
-    TGeoNode* top_node = gGeoManager->GetTopNode();
-    assert(top_node != nullptr);
-
-    //Set transparency & color of geometry
-    TObjArray* volumes = gGeoManager->GetListOfVolumes();
-    for(int i = 0; i < volumes->GetEntriesFast(); i++) {
-      TGeoVolume* volume = dynamic_cast<TGeoVolume*>(volumes->At(i));
-      assert(volume != nullptr);
-      volume->SetLineColor(12);
-      volume->SetTransparency(50);
+    if (getNEvents() > 0) {
+      double old_error_scale = errorScale_;
+      drawEvent(0);
+      if (old_error_scale != errorScale_) {
+        std::cout << "autoscaling changed the error, draw again." << std::endl;
+        gotoEvent(0); // if autoscaling changed the error, draw again.
+      }
+      errorScale_ = old_error_scale;
     }
 
-    TEveGeoTopNode* eve_top_node = new TEveGeoTopNode(gGeoManager, top_node);
-    eve_top_node->IncDenyDestroy();
-    gEve->AddElement(eve_top_node);
+
+    if (!drawSilent_) {
+      makeGui();
+      gApplication->Run(kTRUE);
+    }
+
+    std::cout << "opened" << std::endl;
+
   }
 
 
-  for(unsigned int i = 0; i < events_.at(id)->size(); i++) { // loop over all tracks in an event
+  void EventDisplay::drawEvent(unsigned int id, bool resetCam)
+  {
 
-    if (!drawAllTracks_ && trackId_ != i)
-      continue;
+    std::cout << "EventDisplay::drawEvent(" << id << ")" << std::endl;
 
-    Track* track = events_[id]->at(i);
-    try {
-      track->checkConsistency();
-    } catch (genfit::Exception& e) {
-      std::cerr<< e.getExcString() <<std::endl;
-      continue;
+
+    // draw the geometry, does not really work yet. If it's fixed, the docu in the header file should be changed.
+    if (drawGeometry_) {
+      TGeoNode* top_node = gGeoManager->GetTopNode();
+      assert(top_node != nullptr);
+
+      //Set transparency & color of geometry
+      TObjArray* volumes = gGeoManager->GetListOfVolumes();
+      for (int i = 0; i < volumes->GetEntriesFast(); i++) {
+        TGeoVolume* volume = dynamic_cast<TGeoVolume*>(volumes->At(i));
+        assert(volume != nullptr);
+        volume->SetLineColor(12);
+        volume->SetTransparency(50);
+      }
+
+      TEveGeoTopNode* eve_top_node = new TEveGeoTopNode(gGeoManager, top_node);
+      eve_top_node->IncDenyDestroy();
+      gEve->AddElement(eve_top_node);
     }
 
-    std::unique_ptr<Track> refittedTrack(nullptr);
-    if (refit_) {
 
-      std::cout << "Refit track:" << std::endl;
+    for (unsigned int i = 0; i < events_.at(id)->size(); i++) { // loop over all tracks in an event
 
-      std::unique_ptr<AbsKalmanFitter> fitter;
-      switch (fitterId_) {
-        case SimpleKalman:
-          fitter.reset(new KalmanFitter(nMaxIter_, dPVal_));
-          fitter->setMultipleMeasurementHandling(mmHandling_);
-          (static_cast<KalmanFitter*>(fitter.get()))->useSquareRootFormalism(squareRootFormalism_);
-          break;
-
-        case RefKalman:
-          fitter.reset(new KalmanFitterRefTrack(nMaxIter_, dPVal_));
-          fitter->setMultipleMeasurementHandling(mmHandling_);
-          static_cast<KalmanFitterRefTrack*>(fitter.get())->setDeltaChi2Ref(dChi2Ref_);
-          break;
-
-        case DafSimple:
-          fitter.reset(new DAF(false));
-          ( static_cast<KalmanFitter*>( (static_cast<DAF*>(fitter.get()))->getKalman() ) )->useSquareRootFormalism(squareRootFormalism_);
-          break;
-        case DafRef:
-          fitter.reset(new DAF());
-          ( static_cast<KalmanFitterRefTrack*>( (static_cast<DAF*>(fitter.get()))->getKalman() ) )->setDeltaChi2Ref(dChi2Ref_);
-          break;
-
-      }
-      fitter->setDebugLvl(std::max(0, (int)debugLvl_-1));
-      fitter->setMinIterations(nMinIter_);
-      fitter->setMaxIterations(nMaxIter_);
-      fitter->setRelChi2Change(dRelChi2_);
-      fitter->setMaxFailedHits(nMaxFailed_);
-
-
-      refittedTrack.reset(new Track(*track));
-      refittedTrack->deleteFitterInfo();
-
-      if (debugLvl_>0)
-        refittedTrack->Print("C");
-
-      timeval startcputime, endcputime;
-
-      try{
-        gettimeofday(&startcputime, nullptr);
-        fitter->processTrack(refittedTrack.get(), resort_);
-        gettimeofday(&endcputime, nullptr);
-      }
-      catch(genfit::Exception& e){
-        std::cerr << e.what();
-        std::cerr << "Exception, could not refit track" << std::endl;
+      if (!drawAllTracks_ && trackId_ != i)
         continue;
-      }
 
-      int microseconds = 1000000*(endcputime.tv_sec - startcputime.tv_sec) + (endcputime.tv_usec - startcputime.tv_usec);
-      std::cout << "it took " << double(microseconds) /  1000 << " ms of CPU to fit the track\n";
-
+      Track* track = events_[id]->at(i);
       try {
-        refittedTrack->checkConsistency();
+        track->checkConsistency();
       } catch (genfit::Exception& e) {
-        std::cerr<< e.getExcString() <<std::endl;
+        std::cerr << e.getExcString() << std::endl;
         continue;
       }
 
-      track = refittedTrack.get();
-    }
+      std::unique_ptr<Track> refittedTrack(nullptr);
+      if (refit_) {
+
+        std::cout << "Refit track:" << std::endl;
+
+        std::unique_ptr<AbsKalmanFitter> fitter;
+        switch (fitterId_) {
+          case SimpleKalman:
+            fitter.reset(new KalmanFitter(nMaxIter_, dPVal_));
+            fitter->setMultipleMeasurementHandling(mmHandling_);
+            (static_cast<KalmanFitter*>(fitter.get()))->useSquareRootFormalism(squareRootFormalism_);
+            break;
+
+          case RefKalman:
+            fitter.reset(new KalmanFitterRefTrack(nMaxIter_, dPVal_));
+            fitter->setMultipleMeasurementHandling(mmHandling_);
+            static_cast<KalmanFitterRefTrack*>(fitter.get())->setDeltaChi2Ref(dChi2Ref_);
+            break;
+
+          case DafSimple:
+            fitter.reset(new DAF(false));
+            (static_cast<KalmanFitter*>((static_cast<DAF*>(fitter.get()))->getKalman()))->useSquareRootFormalism(squareRootFormalism_);
+            break;
+          case DafRef:
+            fitter.reset(new DAF());
+            (static_cast<KalmanFitterRefTrack*>((static_cast<DAF*>(fitter.get()))->getKalman()))->setDeltaChi2Ref(dChi2Ref_);
+            break;
+
+        }
+        fitter->setDebugLvl(std::max(0, (int)debugLvl_ - 1));
+        fitter->setMinIterations(nMinIter_);
+        fitter->setMaxIterations(nMaxIter_);
+        fitter->setRelChi2Change(dRelChi2_);
+        fitter->setMaxFailedHits(nMaxFailed_);
 
 
+        refittedTrack.reset(new Track(*track));
+        refittedTrack->deleteFitterInfo();
 
+        if (debugLvl_ > 0)
+          refittedTrack->Print("C");
 
-    AbsTrackRep* rep;
+        timeval startcputime, endcputime;
 
-    if (drawCardinalRep_) {
-      rep = track->getCardinalRep();
-      std::cout << "Draw cardinal rep" << std::endl;
-    }
-    else {
-      if (repId_ >= track->getNumReps())
-        repId_ = track->getNumReps() - 1;
-       rep = track->getTrackRep(repId_);
-       std::cout << "Draw rep" << repId_ << std::endl;
-    }
-
-    if (debugLvl_>0) {
-      std::cout << "track " << i << std::endl;
-      //track->Print();
-      track->Print("C");
-      track->getFitStatus(rep)->Print();
-
-      if (track->getFitStatus(rep)->isFitted()) {
         try {
-          std::cout << "fitted state: \n";
-          track->getFittedState().Print();
-        }
-        catch (Exception& e) {
+          gettimeofday(&startcputime, nullptr);
+          fitter->processTrack(refittedTrack.get(), resort_);
+          gettimeofday(&endcputime, nullptr);
+        } catch (genfit::Exception& e) {
           std::cerr << e.what();
-        }
-      }
-    }
-
-
-
-    rep->setPropDir(0);
-
-    unsigned int numhits = track->getNumPointsWithMeasurement();
-
-    KalmanFitterInfo* fi;
-    KalmanFitterInfo* prevFi = 0;
-    const MeasuredStateOnPlane* fittedState(nullptr);
-    const MeasuredStateOnPlane* prevFittedState(nullptr);
-
-    for(unsigned int j = 0; j < numhits; j++) { // loop over all hits in the track
-
-      fittedState = nullptr;
-
-      TrackPoint* tp = track->getPointWithMeasurement(j);
-      if (! tp->hasRawMeasurements()) {
-        std::cerr<<"trackPoint has no raw measurements"<<std::endl;
-        continue;
-      }
-
-      const AbsMeasurement* m = tp->getRawMeasurement();
-      int hit_coords_dim = m->getDim();
-
-      // check if multiple AbsMeasurements are of same type
-      if (tp->getNumRawMeasurements() > 1) {
-        bool sameTypes(true);
-        for (unsigned int iM=1; iM<tp->getNumRawMeasurements(); ++iM) {
-	  auto& rawMeasurement = *(tp->getRawMeasurement(iM));
-          if (typeid(rawMeasurement) != typeid(*m))
-            sameTypes = false;
-        }
-        if (!sameTypes) {
-          std::cerr<<"cannot draw trackpoint containing multiple Measurements of differend types"<<std::endl;
+          std::cerr << "Exception, could not refit track" << std::endl;
           continue;
         }
-      }
 
+        int microseconds = 1000000 * (endcputime.tv_sec - startcputime.tv_sec) + (endcputime.tv_usec - startcputime.tv_usec);
+        std::cout << "it took " << double(microseconds) /  1000 << " ms of CPU to fit the track\n";
 
-
-      // get the fitter infos ------------------------------------------------------------------
-      if (! tp->hasFitterInfo(rep)) {
-        std::cerr<<"trackPoint has no fitterInfo for rep"<<std::endl;
-        continue;
-      }
-
-      AbsFitterInfo* fitterInfo = tp->getFitterInfo(rep);
-
-      fi = dynamic_cast<KalmanFitterInfo*>(fitterInfo);
-      if(fi == nullptr) {
-        std::cerr<<"can only display KalmanFitterInfo"<<std::endl;
-        continue;
-      }
-      if (! fi->hasPredictionsAndUpdates()) {
-        std::cerr<<"KalmanFitterInfo does not have all predictions and updates"<<std::endl;
-        //continue;
-      }
-      else {
         try {
-          fittedState = &(fi->getFittedState(true));
+          refittedTrack->checkConsistency();
+        } catch (genfit::Exception& e) {
+          std::cerr << e.getExcString() << std::endl;
+          continue;
         }
-        catch (Exception& e) {
-          std::cerr << e.what();
-          std::cerr<<"can not get fitted state"<<std::endl;
-          fittedState = nullptr;
+
+        track = refittedTrack.get();
+      }
+
+
+
+
+      AbsTrackRep* rep;
+
+      if (drawCardinalRep_) {
+        rep = track->getCardinalRep();
+        std::cout << "Draw cardinal rep" << std::endl;
+      } else {
+        if (repId_ >= track->getNumReps())
+          repId_ = track->getNumReps() - 1;
+        rep = track->getTrackRep(repId_);
+        std::cout << "Draw rep" << repId_ << std::endl;
+      }
+
+      if (debugLvl_ > 0) {
+        std::cout << "track " << i << std::endl;
+        //track->Print();
+        track->Print("C");
+        track->getFitStatus(rep)->Print();
+
+        if (track->getFitStatus(rep)->isFitted()) {
+          try {
+            std::cout << "fitted state: \n";
+            track->getFittedState().Print();
+          } catch (Exception& e) {
+            std::cerr << e.what();
+          }
+        }
+      }
+
+
+
+      rep->setPropDir(0);
+
+      unsigned int numhits = track->getNumPointsWithMeasurement();
+
+      KalmanFitterInfo* fi;
+      KalmanFitterInfo* prevFi = 0;
+      const MeasuredStateOnPlane* fittedState(nullptr);
+      const MeasuredStateOnPlane* prevFittedState(nullptr);
+
+      for (unsigned int j = 0; j < numhits; j++) { // loop over all hits in the track
+
+        fittedState = nullptr;
+
+        TrackPoint* tp = track->getPointWithMeasurement(j);
+        if (! tp->hasRawMeasurements()) {
+          std::cerr << "trackPoint has no raw measurements" << std::endl;
+          continue;
+        }
+
+        const AbsMeasurement* m = tp->getRawMeasurement();
+        int hit_coords_dim = m->getDim();
+
+        // check if multiple AbsMeasurements are of same type
+        if (tp->getNumRawMeasurements() > 1) {
+          bool sameTypes(true);
+          for (unsigned int iM = 1; iM < tp->getNumRawMeasurements(); ++iM) {
+            auto& rawMeasurement = *(tp->getRawMeasurement(iM));
+            if (typeid(rawMeasurement) != typeid(*m))
+              sameTypes = false;
+          }
+          if (!sameTypes) {
+            std::cerr << "cannot draw trackpoint containing multiple Measurements of differend types" << std::endl;
+            continue;
+          }
+        }
+
+
+
+        // get the fitter infos ------------------------------------------------------------------
+        if (! tp->hasFitterInfo(rep)) {
+          std::cerr << "trackPoint has no fitterInfo for rep" << std::endl;
+          continue;
+        }
+
+        AbsFitterInfo* fitterInfo = tp->getFitterInfo(rep);
+
+        fi = dynamic_cast<KalmanFitterInfo*>(fitterInfo);
+        if (fi == nullptr) {
+          std::cerr << "can only display KalmanFitterInfo" << std::endl;
+          continue;
+        }
+        if (! fi->hasPredictionsAndUpdates()) {
+          std::cerr << "KalmanFitterInfo does not have all predictions and updates" << std::endl;
+          //continue;
+        } else {
+          try {
+            fittedState = &(fi->getFittedState(true));
+          } catch (Exception& e) {
+            std::cerr << e.what();
+            std::cerr << "can not get fitted state" << std::endl;
+            fittedState = nullptr;
+            prevFi = fi;
+            prevFittedState = fittedState;
+            continue;
+          }
+        }
+
+        if (fittedState == nullptr) {
+          if (fi->hasForwardUpdate()) {
+            fittedState = fi->getForwardUpdate();
+          } else if (fi->hasBackwardUpdate()) {
+            fittedState = fi->getBackwardUpdate();
+          } else if (fi->hasForwardPrediction()) {
+            fittedState = fi->getForwardPrediction();
+          } else if (fi->hasBackwardPrediction()) {
+            fittedState = fi->getBackwardPrediction();
+          }
+        }
+
+        if (fittedState == nullptr) {
+          std::cout << "cannot get any state from fitterInfo, continue.\n";
           prevFi = fi;
           prevFittedState = fittedState;
           continue;
         }
-      }
 
-      if (fittedState == nullptr) {
-        if (fi->hasForwardUpdate()) {
-          fittedState = fi->getForwardUpdate();
+        TVector3 track_pos = fittedState->getPos();
+        double charge = fittedState->getCharge();
+
+        //std::cout << "trackPos: "; track_pos.Print();
+
+
+        // determine measurement type
+        bool full_hit = (dynamic_cast<const FullMeasurement*>(m) != nullptr);
+        bool planar_hit = (dynamic_cast<const PlanarMeasurement*>(m) != nullptr);
+        bool planar_pixel_hit = planar_hit && hit_coords_dim == 2;
+        bool space_hit = (dynamic_cast<const SpacepointMeasurement*>(m) != nullptr);
+        bool wire_hit = m && m->isLeftRightMeasurement();
+        bool wirepoint_hit = wire_hit && (dynamic_cast<const WirePointMeasurement*>(m) != nullptr);
+        if (!full_hit && !planar_hit && !planar_pixel_hit && !space_hit && !wire_hit && !wirepoint_hit) {
+          std::cout << "Track " << i << ", Hit " << j << ": Unknown measurement type: skipping hit!" << std::endl;
+          continue;
         }
-        else if (fi->hasBackwardUpdate()) {
-          fittedState = fi->getBackwardUpdate();
-        }
-        else if (fi->hasForwardPrediction()) {
-          fittedState = fi->getForwardPrediction();
-        }
-        else if (fi->hasBackwardPrediction()) {
-          fittedState = fi->getBackwardPrediction();
-        }
-      }
-
-      if (fittedState == nullptr) {
-        std::cout << "cannot get any state from fitterInfo, continue.\n";
-        prevFi = fi;
-        prevFittedState = fittedState;
-        continue;
-      }
-
-      TVector3 track_pos = fittedState->getPos();
-      double charge = fittedState->getCharge();
-
-      //std::cout << "trackPos: "; track_pos.Print();
 
 
-      // determine measurement type
-      bool full_hit =  (dynamic_cast<const FullMeasurement*>(m) != nullptr);
-      bool planar_hit = (dynamic_cast<const PlanarMeasurement*>(m) != nullptr);
-      bool planar_pixel_hit = planar_hit && hit_coords_dim == 2;
-      bool space_hit = (dynamic_cast<const SpacepointMeasurement*>(m) != nullptr);
-      bool wire_hit = m && m->isLeftRightMeasurement();
-      bool wirepoint_hit = wire_hit &&  (dynamic_cast<const WirePointMeasurement*>(m) != nullptr);
-      if (!full_hit && !planar_hit && !planar_pixel_hit && !space_hit && !wire_hit && !wirepoint_hit) {
-        std::cout << "Track " << i << ", Hit " << j << ": Unknown measurement type: skipping hit!" << std::endl;
-        continue;
-      }
+        // loop over MeasurementOnPlanes
+        unsigned int nMeas = fi->getNumMeasurements();
+        for (unsigned int iMeas = 0; iMeas < nMeas; ++iMeas) {
 
+          if (iMeas > 0 && wire_hit)
+            break;
 
-      // loop over MeasurementOnPlanes
-      unsigned int nMeas = fi->getNumMeasurements();
-      for (unsigned int iMeas = 0; iMeas < nMeas; ++iMeas) {
+          const MeasurementOnPlane* mop = fi->getMeasurementOnPlane(iMeas);
+          const TVectorT<double>& hit_coords = mop->getState();
+          const TMatrixTSym<double>& hit_cov = mop->getCov();
 
-        if (iMeas > 0 && wire_hit)
-          break;
+          // finished getting the hit infos -----------------------------------------------------
 
-        const MeasurementOnPlane* mop = fi->getMeasurementOnPlane(iMeas);
-        const TVectorT<double>& hit_coords = mop->getState();
-        const TMatrixTSym<double>& hit_cov = mop->getCov();
+          // sort hit infos into variables ------------------------------------------------------
+          TVector3 o = fittedState->getPlane()->getO();
+          TVector3 u = fittedState->getPlane()->getU();
+          TVector3 v = fittedState->getPlane()->getV();
 
-        // finished getting the hit infos -----------------------------------------------------
+          double_t hit_u = 0;
+          double_t hit_v = 0;
+          double_t plane_size = 4;
+          TVector2 stripDir(1, 0);
 
-        // sort hit infos into variables ------------------------------------------------------
-        TVector3 o = fittedState->getPlane()->getO();
-        TVector3 u = fittedState->getPlane()->getU();
-        TVector3 v = fittedState->getPlane()->getV();
-
-        double_t hit_u = 0;
-        double_t hit_v = 0;
-        double_t plane_size = 4;
-        TVector2 stripDir(1,0);
-
-        if(planar_hit) {
-          if(!planar_pixel_hit) {
-            if (dynamic_cast<RKTrackRep*>(rep) != nullptr) {
-              const TMatrixD& H = mop->getHMatrix()->getMatrix();
-              stripDir.Set(H(0,3), H(0,4));
+          if (planar_hit) {
+            if (!planar_pixel_hit) {
+              if (dynamic_cast<RKTrackRep*>(rep) != nullptr) {
+                const TMatrixD& H = mop->getHMatrix()->getMatrix();
+                stripDir.Set(H(0, 3), H(0, 4));
+              }
+              hit_u = hit_coords(0);
+            } else {
+              hit_u = hit_coords(0);
+              hit_v = hit_coords(1);
             }
-            hit_u = hit_coords(0);
-          } else {
-            hit_u = hit_coords(0);
-            hit_v = hit_coords(1);
+          } else if (wire_hit) {
+            hit_u = fabs(hit_coords(0));
+            hit_v = v * (track_pos - o); // move the covariance tube so that the track goes through it
+            if (wirepoint_hit) {
+              hit_v = hit_coords(1);
+            }
           }
-        } else if (wire_hit) {
-          hit_u = fabs(hit_coords(0));
-          hit_v = v*(track_pos-o); // move the covariance tube so that the track goes through it
-          if (wirepoint_hit) {
-            hit_v = hit_coords(1);
+
+          if (plane_size < 4) plane_size = 4;
+          // finished setting variables ---------------------------------------------------------
+
+          // draw planes if corresponding option is set -----------------------------------------
+          if (iMeas == 0 &&
+              (drawPlanes_ || (drawDetectors_ && planar_hit))) {
+            TVector3 move(0, 0, 0);
+            if (planar_hit) move = track_pos - o;
+            if (wire_hit) move = v * (v * (track_pos - o)); // move the plane along the wire until the track goes through it
+            TEveBox* box = boxCreator(o + move, u, v, plane_size, plane_size, 0.01);
+            if (drawDetectors_ && planar_hit) {
+              box->SetMainColor(kCyan);
+            } else {
+              box->SetMainColor(kGray);
+            }
+            box->SetMainTransparency(50);
+            gEve->AddElement(box);
           }
-        }
+          // finished drawing planes ------------------------------------------------------------
 
-        if(plane_size < 4) plane_size = 4;
-        // finished setting variables ---------------------------------------------------------
-
-        // draw planes if corresponding option is set -----------------------------------------
-        if(iMeas == 0 &&
-           (drawPlanes_ || (drawDetectors_ && planar_hit))) {
-          TVector3 move(0,0,0);
-          if (planar_hit) move = track_pos-o;
-          if (wire_hit) move = v*(v*(track_pos-o)); // move the plane along the wire until the track goes through it
-          TEveBox* box = boxCreator(o + move, u, v, plane_size, plane_size, 0.01);
-          if (drawDetectors_ && planar_hit) {
-            box->SetMainColor(kCyan);
-          } else {
-            box->SetMainColor(kGray);
-          }
-          box->SetMainTransparency(50);
-          gEve->AddElement(box);
-        }
-        // finished drawing planes ------------------------------------------------------------
-
-        // draw track if corresponding option is set ------------------------------------------
-        try {
+          // draw track if corresponding option is set ------------------------------------------
+          try {
             if (j == 0) {
               if (drawBackward_) {
-                  MeasuredStateOnPlane update ( *fi->getBackwardUpdate() );
-                  update.extrapolateBy(-3.);
-                  makeLines(&update, fi->getBackwardUpdate(), rep, kMagenta, 1, drawTrackMarkers_, drawErrors_, 1);
+                MeasuredStateOnPlane update(*fi->getBackwardUpdate());
+                update.extrapolateBy(-3.);
+                makeLines(&update, fi->getBackwardUpdate(), rep, kMagenta, 1, drawTrackMarkers_, drawErrors_, 1);
               }
             }
             if (j > 0 && prevFi != nullptr) {
-              if(drawTrack_) {
+              if (drawTrack_) {
                 makeLines(prevFittedState, fittedState, rep, charge > 0 ? kRed : kBlue, 1, drawTrackMarkers_, drawErrors_, 3);
                 if (drawErrors_) { // make sure to draw errors in both directions
                   makeLines(prevFittedState, fittedState, rep, charge > 0 ? kRed : kBlue, 1, false, drawErrors_, 0, 0);
@@ -599,8 +602,8 @@ void EventDisplay::drawEvent(unsigned int id, bool resetCam) {
               }
               if (drawForward_) {
                 makeLines(prevFi->getForwardUpdate(), fi->getForwardPrediction(), rep, kCyan, 1, drawTrackMarkers_, drawErrors_, 1, 0);
-                if (j == numhits-1) {
-                  MeasuredStateOnPlane update ( *fi->getForwardUpdate() );
+                if (j == numhits - 1) {
+                  MeasuredStateOnPlane update(*fi->getForwardUpdate());
                   update.extrapolateBy(3.);
                   makeLines(fi->getForwardUpdate(), &update, rep, kCyan, 1, drawTrackMarkers_, drawErrors_, 1, 0);
                 }
@@ -609,864 +612,863 @@ void EventDisplay::drawEvent(unsigned int id, bool resetCam) {
                 makeLines(prevFi->getBackwardPrediction(), fi->getBackwardUpdate(), rep, kMagenta, 1, drawTrackMarkers_, drawErrors_, 1);
               }
               // draw reference track if corresponding option is set ------------------------------------------
-              if(drawRefTrack_ && fi->hasReferenceState() && prevFi->hasReferenceState())
-                makeLines(prevFi->getReferenceState(), fi->getReferenceState(), rep, charge > 0 ? kRed + 2 : kBlue + 2, 2, drawTrackMarkers_, false, 3);
-            }
-            else if (j > 0 && prevFi == nullptr) {
+              if (drawRefTrack_ && fi->hasReferenceState() && prevFi->hasReferenceState())
+                makeLines(prevFi->getReferenceState(), fi->getReferenceState(), rep, charge > 0 ? kRed + 2 : kBlue + 2, 2, drawTrackMarkers_, false,
+                          3);
+            } else if (j > 0 && prevFi == nullptr) {
               std::cout << "previous FitterInfo == nullptr \n";
             }
-        }
-        catch (Exception& e) {
+          } catch (Exception& e) {
             std::cerr << "extrapolation failed, cannot draw track" << std::endl;
             std::cerr << e.what();
-        }
+          }
 
-        // draw detectors if option is set, only important for wire hits ----------------------
-        if(drawDetectors_) {
+          // draw detectors if option is set, only important for wire hits ----------------------
+          if (drawDetectors_) {
 
-          if(wire_hit) {
-            TEveGeoShape* det_shape = new TEveGeoShape("det_shape");
-            det_shape->IncDenyDestroy();
-            det_shape->SetShape(new TGeoTube(std::max(0., (double)(hit_u-0.0105/2.)), hit_u+0.0105/2., plane_size));
+            if (wire_hit) {
+              TEveGeoShape* det_shape = new TEveGeoShape("det_shape");
+              det_shape->IncDenyDestroy();
+              det_shape->SetShape(new TGeoTube(std::max(0., (double)(hit_u - 0.0105 / 2.)), hit_u + 0.0105 / 2., plane_size));
 
-            TVector3 norm = u.Cross(v);
-            TGeoRotation det_rot("det_rot", (u.Theta()*180)/TMath::Pi(), (u.Phi()*180)/TMath::Pi(),
-                (norm.Theta()*180)/TMath::Pi(), (norm.Phi()*180)/TMath::Pi(),
-                (v.Theta()*180)/TMath::Pi(), (v.Phi()*180)/TMath::Pi()); // move the tube to the right place and rotate it correctly
-            TVector3 move = v*(v*(track_pos-o)); // move the tube along the wire until the track goes through it
-            TGeoCombiTrans det_trans(o(0) + move.X(),
-                                     o(1) + move.Y(),
-                                     o(2) + move.Z(),
-                                     &det_rot);
-            det_shape->SetTransMatrix(det_trans);
-            det_shape->SetMainColor(kCyan);
-            det_shape->SetMainTransparency(25);
-            if((drawHits_ && (hit_u+0.0105/2 > 0)) || !drawHits_) {
-              gEve->AddElement(det_shape);
+              TVector3 norm = u.Cross(v);
+              TGeoRotation det_rot("det_rot", (u.Theta() * 180) / TMath::Pi(), (u.Phi() * 180) / TMath::Pi(),
+                                   (norm.Theta() * 180) / TMath::Pi(), (norm.Phi() * 180) / TMath::Pi(),
+                                   (v.Theta() * 180) / TMath::Pi(), (v.Phi() * 180) / TMath::Pi()); // move the tube to the right place and rotate it correctly
+              TVector3 move = v * (v * (track_pos - o)); // move the tube along the wire until the track goes through it
+              TGeoCombiTrans det_trans(o(0) + move.X(),
+                                       o(1) + move.Y(),
+                                       o(2) + move.Z(),
+                                       &det_rot);
+              det_shape->SetTransMatrix(det_trans);
+              det_shape->SetMainColor(kCyan);
+              det_shape->SetMainTransparency(25);
+              if ((drawHits_ && (hit_u + 0.0105 / 2 > 0)) || !drawHits_) {
+                gEve->AddElement(det_shape);
+              }
             }
+
           }
+          // finished drawing detectors ---------------------------------------------------------
 
-        }
-        // finished drawing detectors ---------------------------------------------------------
+          if (drawHits_) {
 
-        if(drawHits_) {
+            // draw planar hits, with distinction between strip and pixel hits ----------------
+            if (full_hit) {
 
-          // draw planar hits, with distinction between strip and pixel hits ----------------
-          if (full_hit) {
+              StateOnPlane dummy(rep);
+              StateOnPlane dummy2(TVectorD(rep->getDim()), static_cast<const FullMeasurement*>(m)->constructPlane(dummy), rep);
+              MeasuredStateOnPlane sop = *(static_cast<const FullMeasurement*>(m)->constructMeasurementsOnPlane(dummy2)[0]);
+              sop.getCov() *= errorScale_;
 
-            StateOnPlane dummy(rep);
-            StateOnPlane dummy2(TVectorD(rep->getDim()), static_cast<const FullMeasurement*>(m)->constructPlane(dummy), rep);
-            MeasuredStateOnPlane sop = *(static_cast<const FullMeasurement*>(m)->constructMeasurementsOnPlane(dummy2)[0]);
-            sop.getCov()*=errorScale_;
+              MeasuredStateOnPlane prevSop(sop);
+              prevSop.extrapolateBy(-3);
+              makeLines(&sop, &prevSop, rep, kYellow, 1, false, true, 0, 0);
 
-            MeasuredStateOnPlane prevSop(sop);
-            prevSop.extrapolateBy(-3);
-            makeLines(&sop, &prevSop, rep, kYellow, 1, false, true, 0, 0);
+              prevSop = sop;
+              prevSop.extrapolateBy(3);
+              makeLines(&sop, &prevSop, rep, kYellow, 1, false, true, 0, 0);
+            }
 
-            prevSop = sop;
-            prevSop.extrapolateBy(3);
-            makeLines(&sop, &prevSop, rep, kYellow, 1, false, true, 0, 0);
-          }
+            if (planar_hit) {
+              if (!planar_pixel_hit) {
+                TEveBox* hit_box;
+                TVector3 stripDir3 = stripDir.X() * u + stripDir.Y() * v;
+                TVector3 stripDir3perp = stripDir.Y() * u - stripDir.X() * v;
+                TVector3 move = stripDir3perp * (stripDir3perp * (track_pos - o));
+                hit_box = boxCreator((o + move + hit_u * stripDir3), stripDir3, stripDir3perp, errorScale_ * std::sqrt(hit_cov(0, 0)), plane_size,
+                                     0.0105);
+                hit_box->SetMainColor(kYellow);
+                hit_box->SetMainTransparency(0);
+                gEve->AddElement(hit_box);
+              } else {
+                // calculate eigenvalues to draw error-ellipse ----------------------------
+                TMatrixDSymEigen eigen_values(hit_cov);
+                TEveGeoShape* cov_shape = new TEveGeoShape("cov_shape");
+                cov_shape->IncDenyDestroy();
+                TVectorT<double> ev = eigen_values.GetEigenValues();
+                TMatrixT<double> eVec = eigen_values.GetEigenVectors();
+                double pseudo_res_0 = errorScale_ * std::sqrt(ev(0));
+                double pseudo_res_1 = errorScale_ * std::sqrt(ev(1));
+                // finished calcluating, got the values -----------------------------------
 
-          if(planar_hit) {
-            if(!planar_pixel_hit) {
-              TEveBox* hit_box;
-              TVector3 stripDir3 = stripDir.X()*u + stripDir.Y()*v;
-              TVector3 stripDir3perp = stripDir.Y()*u - stripDir.X()*v;
-              TVector3 move = stripDir3perp*(stripDir3perp*(track_pos-o));
-              hit_box = boxCreator((o + move + hit_u*stripDir3), stripDir3, stripDir3perp, errorScale_*std::sqrt(hit_cov(0,0)), plane_size, 0.0105);
-              hit_box->SetMainColor(kYellow);
-              hit_box->SetMainTransparency(0);
-              gEve->AddElement(hit_box);
-            } else {
-              // calculate eigenvalues to draw error-ellipse ----------------------------
-              TMatrixDSymEigen eigen_values(hit_cov);
+                // do autoscaling if necessary --------------------------------------------
+                if (drawAutoScale_) {
+                  double min_cov = std::min(pseudo_res_0, pseudo_res_1);
+                  if (min_cov < 1e-5) {
+                    std::cout << "Track " << i << ", Hit " << j << ": Invalid covariance matrix (Eigenvalue < 1e-5), autoscaling not possible!" <<
+                              std::endl;
+                  } else {
+                    if (min_cov < 0.049) {
+                      double cor = 0.05 / min_cov;
+                      std::cout << "Track " << i << ", Hit " << j << ": Pixel covariance too small, rescaling by " << cor;
+                      errorScale_ *= cor;
+                      pseudo_res_0 *= cor;
+                      pseudo_res_1 *= cor;
+                      std::cout << " to " << errorScale_ << std::endl;
+                    }
+                  }
+                }
+                // finished autoscaling ---------------------------------------------------
+
+                // calculate the semiaxis of the error ellipse ----------------------------
+                cov_shape->SetShape(new TGeoEltu(pseudo_res_0, pseudo_res_1, 0.0105));
+                TVector3 pix_pos = o + hit_u * u + hit_v * v;
+                TVector3 u_semiaxis = (pix_pos + eVec(0, 0) * u + eVec(1, 0) * v) - pix_pos;
+                TVector3 v_semiaxis = (pix_pos + eVec(0, 1) * u + eVec(1, 1) * v) - pix_pos;
+                TVector3 norm = u.Cross(v);
+                // finished calculating ---------------------------------------------------
+
+                // rotate and translate everything correctly ------------------------------
+                TGeoRotation det_rot("det_rot", (u_semiaxis.Theta() * 180) / TMath::Pi(), (u_semiaxis.Phi() * 180) / TMath::Pi(),
+                                     (v_semiaxis.Theta() * 180) / TMath::Pi(), (v_semiaxis.Phi() * 180) / TMath::Pi(),
+                                     (norm.Theta() * 180) / TMath::Pi(), (norm.Phi() * 180) / TMath::Pi());
+                TGeoCombiTrans det_trans(pix_pos(0), pix_pos(1), pix_pos(2), &det_rot);
+                cov_shape->SetTransMatrix(det_trans);
+                // finished rotating and translating --------------------------------------
+
+                cov_shape->SetMainColor(kYellow);
+                cov_shape->SetMainTransparency(0);
+                gEve->AddElement(cov_shape);
+              }
+            }
+            // finished drawing planar hits ---------------------------------------------------
+
+            // draw spacepoint hits -----------------------------------------------------------
+            if (space_hit) {
+              {
+                // get eigenvalues of covariance to know how to draw the ellipsoid ------------
+                TMatrixDSymEigen eigen_values(m->getRawHitCov());
+                TEveGeoShape* cov_shape = new TEveGeoShape("cov_shape");
+                cov_shape->IncDenyDestroy();
+                cov_shape->SetShape(new TGeoSphere(0., 1.));
+                TVectorT<double> ev = eigen_values.GetEigenValues();
+                TMatrixT<double> eVec = eigen_values.GetEigenVectors();
+                TVector3 eVec1(eVec(0, 0), eVec(1, 0), eVec(2, 0));
+                TVector3 eVec2(eVec(0, 1), eVec(1, 1), eVec(2, 1));
+                TVector3 eVec3(eVec(0, 2), eVec(1, 2), eVec(2, 2));
+                const TVector3 norm = u.Cross(v);
+                // got everything we need -----------------------------------------------------
+
+                static const double radDeg(180. / TMath::Pi());
+                TGeoRotation det_rot("det_rot", eVec1.Theta()*radDeg, eVec1.Phi()*radDeg,
+                                     eVec2.Theta()*radDeg, eVec2.Phi()*radDeg,
+                                     eVec3.Theta()*radDeg, eVec3.Phi()*radDeg);
+
+                if (! det_rot.IsValid()) {
+                  // hackish fix if eigenvectors are not orthonogonal
+                  if (fabs(eVec2 * eVec3) > 1.e-10)
+                    eVec3 = eVec1.Cross(eVec2);
+
+                  det_rot.SetAngles(eVec1.Theta()*radDeg, eVec1.Phi()*radDeg,
+                                    eVec2.Theta()*radDeg, eVec2.Phi()*radDeg,
+                                    eVec3.Theta()*radDeg, eVec3.Phi()*radDeg);
+                }
+
+                // set the scaled eigenvalues -------------------------------------------------
+                double pseudo_res_0 = errorScale_ * std::sqrt(ev(0));
+                double pseudo_res_1 = errorScale_ * std::sqrt(ev(1));
+                double pseudo_res_2 = errorScale_ * std::sqrt(ev(2));
+                if (drawScaleMan_) { // override again if necessary
+                  pseudo_res_0 = errorScale_ * 0.5;
+                  pseudo_res_1 = errorScale_ * 0.5;
+                  pseudo_res_2 = errorScale_ * 0.5;
+                }
+                // finished scaling -----------------------------------------------------------
+
+                // autoscale if necessary -----------------------------------------------------
+                if (drawAutoScale_) {
+                  double min_cov = std::min(pseudo_res_0, std::min(pseudo_res_1, pseudo_res_2));
+                  if (min_cov < 1e-5) {
+                    std::cout << "Track " << i << ", Hit " << j << ": Invalid covariance matrix (Eigenvalue < 1e-5), autoscaling not possible!" <<
+                              std::endl;
+                  } else {
+                    if (min_cov <= 0.149) {
+                      double cor = 0.15 / min_cov;
+                      std::cout << "Track " << i << ", Hit " << j << ": Space hit covariance too small, rescaling by " << cor;
+                      errorScale_ *= cor;
+                      pseudo_res_0 *= cor;
+                      pseudo_res_1 *= cor;
+                      pseudo_res_2 *= cor;
+                      std::cout << " to " << errorScale_ << std::endl;
+
+                    }
+                  }
+                }
+                // finished autoscaling -------------------------------------------------------
+
+                // rotate and translate -------------------------------------------------------
+                TGeoGenTrans det_trans(o(0), o(1), o(2),
+                                       //std::sqrt(pseudo_res_0/pseudo_res_1/pseudo_res_2), std::sqrt(pseudo_res_1/pseudo_res_0/pseudo_res_2), std::sqrt(pseudo_res_2/pseudo_res_0/pseudo_res_1), // this workaround is necessary due to the "normalization" performed in  TGeoGenTrans::SetScale
+                                       //1/(pseudo_res_0),1/(pseudo_res_1),1/(pseudo_res_2),
+                                       pseudo_res_0, pseudo_res_1, pseudo_res_2,
+                                       &det_rot);
+                cov_shape->SetTransMatrix(det_trans);
+                // finished rotating and translating ------------------------------------------
+
+                cov_shape->SetMainColor(kYellow);
+                cov_shape->SetMainTransparency(10);
+                gEve->AddElement(cov_shape);
+              }
+
+
+              {
+                // calculate eigenvalues to draw error-ellipse ----------------------------
+                TMatrixDSymEigen eigen_values(hit_cov);
+                TEveGeoShape* cov_shape = new TEveGeoShape("cov_shape");
+                cov_shape->IncDenyDestroy();
+                TVectorT<double> ev = eigen_values.GetEigenValues();
+                TMatrixT<double> eVec = eigen_values.GetEigenVectors();
+                double pseudo_res_0 = errorScale_ * std::sqrt(ev(0));
+                double pseudo_res_1 = errorScale_ * std::sqrt(ev(1));
+                // finished calcluating, got the values -----------------------------------
+
+                // do autoscaling if necessary --------------------------------------------
+                if (drawAutoScale_) {
+                  double min_cov = std::min(pseudo_res_0, pseudo_res_1);
+                  if (min_cov < 1e-5) {
+                    std::cout << "Track " << i << ", Hit " << j << ": Invalid covariance matrix (Eigenvalue < 1e-5), autoscaling not possible!" <<
+                              std::endl;
+                  } else {
+                    if (min_cov < 0.049) {
+                      double cor = 0.05 / min_cov;
+                      std::cout << "Track " << i << ", Hit " << j << ": Pixel covariance too small, rescaling by " << cor;
+                      errorScale_ *= cor;
+                      pseudo_res_0 *= cor;
+                      pseudo_res_1 *= cor;
+                      std::cout << " to " << errorScale_ << std::endl;
+                    }
+                  }
+                }
+                // finished autoscaling ---------------------------------------------------
+
+                // calculate the semiaxis of the error ellipse ----------------------------
+                cov_shape->SetShape(new TGeoEltu(pseudo_res_0, pseudo_res_1, 0.0105));
+                TVector3 pix_pos = o + hit_u * u + hit_v * v;
+                TVector3 u_semiaxis = (pix_pos + eVec(0, 0) * u + eVec(1, 0) * v) - pix_pos;
+                TVector3 v_semiaxis = (pix_pos + eVec(0, 1) * u + eVec(1, 1) * v) - pix_pos;
+                TVector3 norm = u.Cross(v);
+                // finished calculating ---------------------------------------------------
+
+                // rotate and translate everything correctly ------------------------------
+                static const double radDeg(180. / TMath::Pi());
+                TGeoRotation det_rot("det_rot", u_semiaxis.Theta()*radDeg, u_semiaxis.Phi()*radDeg,
+                                     v_semiaxis.Theta()*radDeg, v_semiaxis.Phi()*radDeg,
+                                     norm.Theta()*radDeg, norm.Phi()*radDeg);
+                /*if (! det_rot.IsValid()){
+                  u_semiaxis.Print();
+                  v_semiaxis.Print();
+                  norm.Print();
+                }*/
+                TGeoCombiTrans det_trans(pix_pos(0), pix_pos(1), pix_pos(2), &det_rot);
+                cov_shape->SetTransMatrix(det_trans);
+                // finished rotating and translating --------------------------------------
+
+                cov_shape->SetMainColor(kYellow);
+                cov_shape->SetMainTransparency(0);
+                gEve->AddElement(cov_shape);
+              }
+            }
+            // finished drawing spacepoint hits -----------------------------------------------
+
+            // draw wire hits -----------------------------------------------------------------
+            if (wire_hit) {
               TEveGeoShape* cov_shape = new TEveGeoShape("cov_shape");
               cov_shape->IncDenyDestroy();
-              TVectorT<double> ev = eigen_values.GetEigenValues();
-              TMatrixT<double> eVec = eigen_values.GetEigenVectors();
-              double pseudo_res_0 = errorScale_*std::sqrt(ev(0));
-              double pseudo_res_1 = errorScale_*std::sqrt(ev(1));
-              // finished calcluating, got the values -----------------------------------
+              double pseudo_res_0 = errorScale_ * std::sqrt(hit_cov(0, 0));
+              double pseudo_res_1 = plane_size;
+              if (wirepoint_hit) pseudo_res_1 = errorScale_ * std::sqrt(hit_cov(1, 1));
 
-              // do autoscaling if necessary --------------------------------------------
-              if(drawAutoScale_) {
-                double min_cov = std::min(pseudo_res_0,pseudo_res_1);
-                if(min_cov < 1e-5) {
-                  std::cout << "Track " << i << ", Hit " << j << ": Invalid covariance matrix (Eigenvalue < 1e-5), autoscaling not possible!" << std::endl;
+              // autoscale if necessary -----------------------------------------------------
+              if (drawAutoScale_) {
+                if (pseudo_res_0 < 1e-5) {
+                  std::cout << "Track " << i << ", Hit " << j << ": Invalid wire resolution (< 1e-5), autoscaling not possible!" << std::endl;
                 } else {
-                  if(min_cov < 0.049) {
-                    double cor = 0.05 / min_cov;
-                    std::cout << "Track " << i << ", Hit " << j << ": Pixel covariance too small, rescaling by " << cor;
+                  if (pseudo_res_0 < 0.0049) {
+                    double cor = 0.005 / pseudo_res_0;
+                    std::cout << "Track " << i << ", Hit " << j << ": Wire covariance too small, rescaling by " << cor;
                     errorScale_ *= cor;
                     pseudo_res_0 *= cor;
-                    pseudo_res_1 *= cor;
                     std::cout << " to " << errorScale_ << std::endl;
                   }
                 }
-              }
-              // finished autoscaling ---------------------------------------------------
 
-              // calculate the semiaxis of the error ellipse ----------------------------
-              cov_shape->SetShape(new TGeoEltu(pseudo_res_0, pseudo_res_1, 0.0105));
-              TVector3 pix_pos = o + hit_u*u + hit_v*v;
-              TVector3 u_semiaxis = (pix_pos + eVec(0,0)*u + eVec(1,0)*v)-pix_pos;
-              TVector3 v_semiaxis = (pix_pos + eVec(0,1)*u + eVec(1,1)*v)-pix_pos;
-              TVector3 norm = u.Cross(v);
-              // finished calculating ---------------------------------------------------
-
-              // rotate and translate everything correctly ------------------------------
-              TGeoRotation det_rot("det_rot", (u_semiaxis.Theta()*180)/TMath::Pi(), (u_semiaxis.Phi()*180)/TMath::Pi(),
-                  (v_semiaxis.Theta()*180)/TMath::Pi(), (v_semiaxis.Phi()*180)/TMath::Pi(),
-                  (norm.Theta()*180)/TMath::Pi(), (norm.Phi()*180)/TMath::Pi());
-              TGeoCombiTrans det_trans(pix_pos(0),pix_pos(1),pix_pos(2), &det_rot);
-              cov_shape->SetTransMatrix(det_trans);
-              // finished rotating and translating --------------------------------------
-
-              cov_shape->SetMainColor(kYellow);
-              cov_shape->SetMainTransparency(0);
-              gEve->AddElement(cov_shape);
-            }
-          }
-          // finished drawing planar hits ---------------------------------------------------
-
-          // draw spacepoint hits -----------------------------------------------------------
-          if(space_hit) {
-            {
-              // get eigenvalues of covariance to know how to draw the ellipsoid ------------
-              TMatrixDSymEigen eigen_values(m->getRawHitCov());
-              TEveGeoShape* cov_shape = new TEveGeoShape("cov_shape");
-              cov_shape->IncDenyDestroy();
-              cov_shape->SetShape(new TGeoSphere(0.,1.));
-              TVectorT<double> ev = eigen_values.GetEigenValues();
-              TMatrixT<double> eVec = eigen_values.GetEigenVectors();
-              TVector3 eVec1(eVec(0,0),eVec(1,0),eVec(2,0));
-              TVector3 eVec2(eVec(0,1),eVec(1,1),eVec(2,1));
-              TVector3 eVec3(eVec(0,2),eVec(1,2),eVec(2,2));
-              const TVector3 norm = u.Cross(v);
-              // got everything we need -----------------------------------------------------
-
-              static const double radDeg(180./TMath::Pi());
-              TGeoRotation det_rot("det_rot", eVec1.Theta()*radDeg, eVec1.Phi()*radDeg,
-                  eVec2.Theta()*radDeg, eVec2.Phi()*radDeg,
-                  eVec3.Theta()*radDeg, eVec3.Phi()*radDeg);
-
-              if (! det_rot.IsValid()){
-                // hackish fix if eigenvectors are not orthonogonal
-                if (fabs(eVec2*eVec3) > 1.e-10)
-                  eVec3 = eVec1.Cross(eVec2);
-
-                det_rot.SetAngles(eVec1.Theta()*radDeg, eVec1.Phi()*radDeg,
-                    eVec2.Theta()*radDeg, eVec2.Phi()*radDeg,
-                    eVec3.Theta()*radDeg, eVec3.Phi()*radDeg);
-              }
-
-              // set the scaled eigenvalues -------------------------------------------------
-              double pseudo_res_0 = errorScale_*std::sqrt(ev(0));
-              double pseudo_res_1 = errorScale_*std::sqrt(ev(1));
-              double pseudo_res_2 = errorScale_*std::sqrt(ev(2));
-              if(drawScaleMan_) { // override again if necessary
-                pseudo_res_0 = errorScale_*0.5;
-                pseudo_res_1 = errorScale_*0.5;
-                pseudo_res_2 = errorScale_*0.5;
-              }
-              // finished scaling -----------------------------------------------------------
-
-              // autoscale if necessary -----------------------------------------------------
-              if(drawAutoScale_) {
-                double min_cov = std::min(pseudo_res_0,std::min(pseudo_res_1,pseudo_res_2));
-                if(min_cov < 1e-5) {
-                  std::cout << "Track " << i << ", Hit " << j << ": Invalid covariance matrix (Eigenvalue < 1e-5), autoscaling not possible!" << std::endl;
+                if (wirepoint_hit && pseudo_res_1 < 1e-5) {
+                  std::cout << "Track " << i << ", Hit " << j << ": Invalid wire resolution (< 1e-5), autoscaling not possible!" << std::endl;
                 } else {
-                  if(min_cov <= 0.149) {
-                    double cor = 0.15 / min_cov;
-                    std::cout << "Track " << i << ", Hit " << j << ": Space hit covariance too small, rescaling by " << cor;
+                  if (pseudo_res_1 < 0.0049) {
+                    double cor = 0.005 / pseudo_res_1;
+                    std::cout << "Track " << i << ", Hit " << j << ": Wire covariance too small, rescaling by " << cor;
                     errorScale_ *= cor;
-                    pseudo_res_0 *= cor;
                     pseudo_res_1 *= cor;
-                    pseudo_res_2 *= cor;
                     std::cout << " to " << errorScale_ << std::endl;
-
                   }
                 }
               }
               // finished autoscaling -------------------------------------------------------
 
-              // rotate and translate -------------------------------------------------------
-              TGeoGenTrans det_trans(o(0),o(1),o(2),
-                                     //std::sqrt(pseudo_res_0/pseudo_res_1/pseudo_res_2), std::sqrt(pseudo_res_1/pseudo_res_0/pseudo_res_2), std::sqrt(pseudo_res_2/pseudo_res_0/pseudo_res_1), // this workaround is necessary due to the "normalization" performed in  TGeoGenTrans::SetScale
-                                     //1/(pseudo_res_0),1/(pseudo_res_1),1/(pseudo_res_2),
-                                     pseudo_res_0, pseudo_res_1, pseudo_res_2,
-                                     &det_rot);
-              cov_shape->SetTransMatrix(det_trans);
-              // finished rotating and translating ------------------------------------------
+              TEveBox* hit_box;
+              TVector3 move = v * (v * (track_pos - o));
+              hit_box = boxCreator((o + move + hit_u * u), u, v, errorScale_ * std::sqrt(hit_cov(0, 0)), pseudo_res_1, 0.0105);
+              hit_box->SetMainColor(kYellow);
+              hit_box->SetMainTransparency(0);
+              gEve->AddElement(hit_box);
 
-              cov_shape->SetMainColor(kYellow);
-              cov_shape->SetMainTransparency(10);
-              gEve->AddElement(cov_shape);
+              hit_box = boxCreator((o + move - hit_u * u), u, v, errorScale_ * std::sqrt(hit_cov(0, 0)), pseudo_res_1, 0.0105);
+              hit_box->SetMainColor(kYellow);
+              hit_box->SetMainTransparency(0);
+              gEve->AddElement(hit_box);
             }
+            // finished drawing wire hits -----------------------------------------------------
+
+          } // finished drawing hits
+
+        } // finished looping over MeasurmentOnPlanes
 
 
-            {
-              // calculate eigenvalues to draw error-ellipse ----------------------------
-              TMatrixDSymEigen eigen_values(hit_cov);
-              TEveGeoShape* cov_shape = new TEveGeoShape("cov_shape");
-              cov_shape->IncDenyDestroy();
-              TVectorT<double> ev = eigen_values.GetEigenValues();
-              TMatrixT<double> eVec = eigen_values.GetEigenVectors();
-              double pseudo_res_0 = errorScale_*std::sqrt(ev(0));
-              double pseudo_res_1 = errorScale_*std::sqrt(ev(1));
-              // finished calcluating, got the values -----------------------------------
+        prevFi = fi;
+        prevFittedState = fittedState;
 
-              // do autoscaling if necessary --------------------------------------------
-              if(drawAutoScale_) {
-                double min_cov = std::min(pseudo_res_0,pseudo_res_1);
-                if(min_cov < 1e-5) {
-                  std::cout << "Track " << i << ", Hit " << j << ": Invalid covariance matrix (Eigenvalue < 1e-5), autoscaling not possible!" << std::endl;
-                } else {
-                  if(min_cov < 0.049) {
-                    double cor = 0.05 / min_cov;
-                    std::cout << "Track " << i << ", Hit " << j << ": Pixel covariance too small, rescaling by " << cor;
-                    errorScale_ *= cor;
-                    pseudo_res_0 *= cor;
-                    pseudo_res_1 *= cor;
-                    std::cout << " to " << errorScale_ << std::endl;
-                  }
-                }
-              }
-              // finished autoscaling ---------------------------------------------------
-
-              // calculate the semiaxis of the error ellipse ----------------------------
-              cov_shape->SetShape(new TGeoEltu(pseudo_res_0, pseudo_res_1, 0.0105));
-              TVector3 pix_pos = o + hit_u*u + hit_v*v;
-              TVector3 u_semiaxis = (pix_pos + eVec(0,0)*u + eVec(1,0)*v)-pix_pos;
-              TVector3 v_semiaxis = (pix_pos + eVec(0,1)*u + eVec(1,1)*v)-pix_pos;
-              TVector3 norm = u.Cross(v);
-              // finished calculating ---------------------------------------------------
-
-              // rotate and translate everything correctly ------------------------------
-              static const double radDeg(180./TMath::Pi());
-              TGeoRotation det_rot("det_rot", u_semiaxis.Theta()*radDeg, u_semiaxis.Phi()*radDeg,
-                  v_semiaxis.Theta()*radDeg, v_semiaxis.Phi()*radDeg,
-                  norm.Theta()*radDeg, norm.Phi()*radDeg);
-              /*if (! det_rot.IsValid()){
-                u_semiaxis.Print();
-                v_semiaxis.Print();
-                norm.Print();
-              }*/
-              TGeoCombiTrans det_trans(pix_pos(0),pix_pos(1),pix_pos(2), &det_rot);
-              cov_shape->SetTransMatrix(det_trans);
-              // finished rotating and translating --------------------------------------
-
-              cov_shape->SetMainColor(kYellow);
-              cov_shape->SetMainTransparency(0);
-              gEve->AddElement(cov_shape);
-            }
-          }
-          // finished drawing spacepoint hits -----------------------------------------------
-
-          // draw wire hits -----------------------------------------------------------------
-          if(wire_hit) {
-            TEveGeoShape* cov_shape = new TEveGeoShape("cov_shape");
-            cov_shape->IncDenyDestroy();
-            double pseudo_res_0 = errorScale_*std::sqrt(hit_cov(0,0));
-            double pseudo_res_1 = plane_size;
-            if (wirepoint_hit) pseudo_res_1 = errorScale_*std::sqrt(hit_cov(1,1));
-
-            // autoscale if necessary -----------------------------------------------------
-            if(drawAutoScale_) {
-              if(pseudo_res_0 < 1e-5) {
-                std::cout << "Track " << i << ", Hit " << j << ": Invalid wire resolution (< 1e-5), autoscaling not possible!" << std::endl;
-              } else {
-                if(pseudo_res_0 < 0.0049) {
-                  double cor = 0.005 / pseudo_res_0;
-                  std::cout << "Track " << i << ", Hit " << j << ": Wire covariance too small, rescaling by " << cor;
-                  errorScale_ *= cor;
-                  pseudo_res_0 *= cor;
-                  std::cout << " to " << errorScale_ << std::endl;
-                }
-              }
-
-              if(wirepoint_hit && pseudo_res_1 < 1e-5) {
-                std::cout << "Track " << i << ", Hit " << j << ": Invalid wire resolution (< 1e-5), autoscaling not possible!" << std::endl;
-              } else {
-                if(pseudo_res_1 < 0.0049) {
-                  double cor = 0.005 / pseudo_res_1;
-                  std::cout << "Track " << i << ", Hit " << j << ": Wire covariance too small, rescaling by " << cor;
-                  errorScale_ *= cor;
-                  pseudo_res_1 *= cor;
-                  std::cout << " to " << errorScale_ << std::endl;
-                }
-              }
-            }
-            // finished autoscaling -------------------------------------------------------
-
-            TEveBox* hit_box;
-            TVector3 move = v*(v*(track_pos-o));
-            hit_box = boxCreator((o + move + hit_u*u), u, v, errorScale_*std::sqrt(hit_cov(0,0)), pseudo_res_1, 0.0105);
-            hit_box->SetMainColor(kYellow);
-            hit_box->SetMainTransparency(0);
-            gEve->AddElement(hit_box);
-
-            hit_box = boxCreator((o + move - hit_u*u), u, v, errorScale_*std::sqrt(hit_cov(0,0)), pseudo_res_1, 0.0105);
-            hit_box->SetMainColor(kYellow);
-            hit_box->SetMainTransparency(0);
-            gEve->AddElement(hit_box);
-          }
-          // finished drawing wire hits -----------------------------------------------------
-
-        } // finished drawing hits
-
-      } // finished looping over MeasurmentOnPlanes
-
-
-      prevFi = fi;
-      prevFittedState = fittedState;
+      }
 
     }
 
+    gEve->Redraw3D(resetCam);
+
   }
 
-  gEve->Redraw3D(resetCam);
-
-}
 
 
 
+  TEveBox* EventDisplay::boxCreator(TVector3 o, TVector3 u, TVector3 v, float ud, float vd, float depth)
+  {
 
-TEveBox* EventDisplay::boxCreator(TVector3 o, TVector3 u, TVector3 v, float ud, float vd, float depth) {
+    TEveBox* box = new TEveBox("detPlane_shape");
+    float vertices[24];
 
-  TEveBox* box = new TEveBox("detPlane_shape");
-  float vertices[24];
+    TVector3 norm = u.Cross(v);
+    u *= (0.5 * ud);
+    v *= (0.5 * vd);
+    norm *= (0.5 * depth);
 
-  TVector3 norm = u.Cross(v);
-  u *= (0.5*ud);
-  v *= (0.5*vd);
-  norm *= (0.5*depth);
+    vertices[0] = o(0) - u(0) - v(0) - norm(0);
+    vertices[1] = o(1) - u(1) - v(1) - norm(1);
+    vertices[2] = o(2) - u(2) - v(2) - norm(2);
 
-  vertices[0] = o(0) - u(0) - v(0) - norm(0);
-  vertices[1] = o(1) - u(1) - v(1) - norm(1);
-  vertices[2] = o(2) - u(2) - v(2) - norm(2);
+    vertices[3] = o(0) + u(0) - v(0) - norm(0);
+    vertices[4] = o(1) + u(1) - v(1) - norm(1);
+    vertices[5] = o(2) + u(2) - v(2) - norm(2);
 
-  vertices[3] = o(0) + u(0) - v(0) - norm(0);
-  vertices[4] = o(1) + u(1) - v(1) - norm(1);
-  vertices[5] = o(2) + u(2) - v(2) - norm(2);
+    vertices[6] = o(0) + u(0) - v(0) + norm(0);
+    vertices[7] = o(1) + u(1) - v(1) + norm(1);
+    vertices[8] = o(2) + u(2) - v(2) + norm(2);
 
-  vertices[6] = o(0) + u(0) - v(0) + norm(0);
-  vertices[7] = o(1) + u(1) - v(1) + norm(1);
-  vertices[8] = o(2) + u(2) - v(2) + norm(2);
+    vertices[9] = o(0) - u(0) - v(0) + norm(0);
+    vertices[10] = o(1) - u(1) - v(1) + norm(1);
+    vertices[11] = o(2) - u(2) - v(2) + norm(2);
 
-  vertices[9] = o(0) - u(0) - v(0) + norm(0);
-  vertices[10] = o(1) - u(1) - v(1) + norm(1);
-  vertices[11] = o(2) - u(2) - v(2) + norm(2);
+    vertices[12] = o(0) - u(0) + v(0) - norm(0);
+    vertices[13] = o(1) - u(1) + v(1) - norm(1);
+    vertices[14] = o(2) - u(2) + v(2) - norm(2);
 
-  vertices[12] = o(0) - u(0) + v(0) - norm(0);
-  vertices[13] = o(1) - u(1) + v(1) - norm(1);
-  vertices[14] = o(2) - u(2) + v(2) - norm(2);
+    vertices[15] = o(0) + u(0) + v(0) - norm(0);
+    vertices[16] = o(1) + u(1) + v(1) - norm(1);
+    vertices[17] = o(2) + u(2) + v(2) - norm(2);
 
-  vertices[15] = o(0) + u(0) + v(0) - norm(0);
-  vertices[16] = o(1) + u(1) + v(1) - norm(1);
-  vertices[17] = o(2) + u(2) + v(2) - norm(2);
+    vertices[18] = o(0) + u(0) + v(0) + norm(0);
+    vertices[19] = o(1) + u(1) + v(1) + norm(1);
+    vertices[20] = o(2) + u(2) + v(2) + norm(2);
 
-  vertices[18] = o(0) + u(0) + v(0) + norm(0);
-  vertices[19] = o(1) + u(1) + v(1) + norm(1);
-  vertices[20] = o(2) + u(2) + v(2) + norm(2);
-
-  vertices[21] = o(0) - u(0) + v(0) + norm(0);
-  vertices[22] = o(1) - u(1) + v(1) + norm(1);
-  vertices[23] = o(2) - u(2) + v(2) + norm(2);
-
-
-  for(int k = 0; k < 24; k += 3) box->SetVertex((k/3), vertices[k], vertices[k+1], vertices[k+2]);
-
-  return box;
-
-}
+    vertices[21] = o(0) - u(0) + v(0) + norm(0);
+    vertices[22] = o(1) - u(1) + v(1) + norm(1);
+    vertices[23] = o(2) - u(2) + v(2) + norm(2);
 
 
-void EventDisplay::makeLines(const StateOnPlane* prevState, const StateOnPlane* state, const AbsTrackRep* rep,
-    const Color_t& color, const Style_t& style, bool drawMarkers, bool drawErrors, double lineWidth, int markerPos)
-{
-  if (prevState == nullptr || state == nullptr) {
-    std::cerr << "prevState == nullptr || state == nullptr\n";
-    return;
+    for (int k = 0; k < 24; k += 3) box->SetVertex((k / 3), vertices[k], vertices[k + 1], vertices[k + 2]);
+
+    return box;
+
   }
 
-  TVector3 pos, dir, oldPos, oldDir;
-  rep->getPosDir(*state, pos, dir);
-  rep->getPosDir(*prevState, oldPos, oldDir);
 
-  double distA = (pos-oldPos).Mag();
-  double distB = distA;
-  if ((pos-oldPos)*oldDir < 0)
-    distA *= -1.;
-  if ((pos-oldPos)*dir < 0)
-    distB *= -1.;
-  TVector3 intermediate1 = oldPos + 0.3 * distA * oldDir;
-  TVector3 intermediate2 = pos - 0.3 * distB * dir;
-  TEveStraightLineSet* lineSet = new TEveStraightLineSet;
-  lineSet->AddLine(oldPos(0), oldPos(1), oldPos(2), intermediate1(0), intermediate1(1), intermediate1(2));
-  lineSet->AddLine(intermediate1(0), intermediate1(1), intermediate1(2), intermediate2(0), intermediate2(1), intermediate2(2));
-  lineSet->AddLine(intermediate2(0), intermediate2(1), intermediate2(2), pos(0), pos(1), pos(2));
-  lineSet->SetLineColor(color);
-  lineSet->SetLineStyle(style);
-  lineSet->SetLineWidth(lineWidth);
-  if (drawMarkers) {
-    if (markerPos == 0)
-      lineSet->AddMarker(oldPos(0), oldPos(1), oldPos(2));
-    else
-      lineSet->AddMarker(pos(0), pos(1), pos(2));
-  }
+  void EventDisplay::makeLines(const StateOnPlane* prevState, const StateOnPlane* state, const AbsTrackRep* rep,
+                               const Color_t& color, const Style_t& style, bool drawMarkers, bool drawErrors, double lineWidth, int markerPos)
+  {
+    if (prevState == nullptr || state == nullptr) {
+      std::cerr << "prevState == nullptr || state == nullptr\n";
+      return;
+    }
 
-  if (lineWidth > 0)
-    gEve->AddElement(lineSet);
+    TVector3 pos, dir, oldPos, oldDir;
+    rep->getPosDir(*state, pos, dir);
+    rep->getPosDir(*prevState, oldPos, oldDir);
+
+    double distA = (pos - oldPos).Mag();
+    double distB = distA;
+    if ((pos - oldPos)*oldDir < 0)
+      distA *= -1.;
+    if ((pos - oldPos)*dir < 0)
+      distB *= -1.;
+    TVector3 intermediate1 = oldPos + 0.3 * distA * oldDir;
+    TVector3 intermediate2 = pos - 0.3 * distB * dir;
+    TEveStraightLineSet* lineSet = new TEveStraightLineSet;
+    lineSet->AddLine(oldPos(0), oldPos(1), oldPos(2), intermediate1(0), intermediate1(1), intermediate1(2));
+    lineSet->AddLine(intermediate1(0), intermediate1(1), intermediate1(2), intermediate2(0), intermediate2(1), intermediate2(2));
+    lineSet->AddLine(intermediate2(0), intermediate2(1), intermediate2(2), pos(0), pos(1), pos(2));
+    lineSet->SetLineColor(color);
+    lineSet->SetLineStyle(style);
+    lineSet->SetLineWidth(lineWidth);
+    if (drawMarkers) {
+      if (markerPos == 0)
+        lineSet->AddMarker(oldPos(0), oldPos(1), oldPos(2));
+      else
+        lineSet->AddMarker(pos(0), pos(1), pos(2));
+    }
+
+    if (lineWidth > 0)
+      gEve->AddElement(lineSet);
 
 
-  if (drawErrors) {
-    const MeasuredStateOnPlane* measuredState;
-    if (markerPos == 0)
-      measuredState = dynamic_cast<const MeasuredStateOnPlane*>(prevState);
-    else
-      measuredState = dynamic_cast<const MeasuredStateOnPlane*>(state);
+    if (drawErrors) {
+      const MeasuredStateOnPlane* measuredState;
+      if (markerPos == 0)
+        measuredState = dynamic_cast<const MeasuredStateOnPlane*>(prevState);
+      else
+        measuredState = dynamic_cast<const MeasuredStateOnPlane*>(state);
 
-    if (measuredState != nullptr) {
+      if (measuredState != nullptr) {
 
-      // step for evaluate at a distance from the original plane
-      TVector3 eval;
-      if (markerPos == 0) {
-        if (fabs(distA) < 1.) {
-          distA < 0 ? distA = -1 : distA = 1;
+        // step for evaluate at a distance from the original plane
+        TVector3 eval;
+        if (markerPos == 0) {
+          if (fabs(distA) < 1.) {
+            distA < 0 ? distA = -1 : distA = 1;
+          }
+          eval = 0.2 * distA * oldDir;
+        } else {
+          if (fabs(distB) < 1.) {
+            distB < 0 ? distB = -1 : distB = 1;
+          }
+          eval = -0.2 * distB * dir;
         }
-        eval = 0.2 * distA * oldDir;
-      }
-      else {
-        if (fabs(distB) < 1.) {
-          distB < 0 ? distB = -1 : distB = 1;
+
+
+        // get cov at first plane
+        TMatrixDSym cov;
+        TVector3 position, direction;
+        rep->getPosMomCov(*measuredState, position, direction, cov);
+
+        // get eigenvalues & -vectors
+        TMatrixDSymEigen eigen_values(cov.GetSub(0, 2, 0, 2));
+        TVectorT<double> ev = eigen_values.GetEigenValues();
+        TMatrixT<double> eVec = eigen_values.GetEigenVectors();
+        TVector3 eVec1, eVec2;
+        // limit
+        static const double maxErr = 1000.;
+        double ev0 = std::min(ev(0), maxErr);
+        double ev1 = std::min(ev(1), maxErr);
+        double ev2 = std::min(ev(2), maxErr);
+
+        // get two largest eigenvalues/-vectors
+        if (ev0 < ev1 && ev0 < ev2) {
+          eVec1.SetXYZ(eVec(0, 1), eVec(1, 1), eVec(2, 1));
+          eVec1 *= sqrt(ev1);
+          eVec2.SetXYZ(eVec(0, 2), eVec(1, 2), eVec(2, 2));
+          eVec2 *= sqrt(ev2);
+        } else if (ev1 < ev0 && ev1 < ev2) {
+          eVec1.SetXYZ(eVec(0, 0), eVec(1, 0), eVec(2, 0));
+          eVec1 *= sqrt(ev0);
+          eVec2.SetXYZ(eVec(0, 2), eVec(1, 2), eVec(2, 2));
+          eVec2 *= sqrt(ev2);
+        } else {
+          eVec1.SetXYZ(eVec(0, 0), eVec(1, 0), eVec(2, 0));
+          eVec1 *= sqrt(ev0);
+          eVec2.SetXYZ(eVec(0, 1), eVec(1, 1), eVec(2, 1));
+          eVec2 *= sqrt(ev1);
         }
-        eval = -0.2 * distB * dir;
+
+        if (eVec1.Cross(eVec2)*eval < 0)
+          eVec2 *= -1;
+        //assert(eVec1.Cross(eVec2)*eval > 0);
+
+        const TVector3 oldEVec1(eVec1);
+        const TVector3 oldEVec2(eVec2);
+
+        const int nEdges = 24;
+        std::vector<TVector3> vertices;
+
+        vertices.push_back(position);
+
+        // vertices at plane
+        for (int i = 0; i < nEdges; ++i) {
+          const double angle = 2 * TMath::Pi() / nEdges * i;
+          vertices.push_back(position + cos(angle)*eVec1 + sin(angle)*eVec2);
+        }
+
+
+
+        DetPlane* newPlane = new DetPlane(*(measuredState->getPlane()));
+        newPlane->setO(position + eval);
+
+        MeasuredStateOnPlane stateCopy(*measuredState);
+        try {
+          rep->extrapolateToPlane(stateCopy, SharedPlanePtr(newPlane));
+        } catch (Exception& e) {
+          std::cerr << e.what();
+          return;
+        }
+
+        // get cov at 2nd plane
+        rep->getPosMomCov(stateCopy, position, direction, cov);
+
+        // get eigenvalues & -vectors
+        TMatrixDSymEigen eigen_values2(cov.GetSub(0, 2, 0, 2));
+        ev = eigen_values2.GetEigenValues();
+        eVec = eigen_values2.GetEigenVectors();
+        // limit
+        ev0 = std::min(ev(0), maxErr);
+        ev1 = std::min(ev(1), maxErr);
+        ev2 = std::min(ev(2), maxErr);
+
+        // get two largest eigenvalues/-vectors
+        if (ev0 < ev1 && ev0 < ev2) {
+          eVec1.SetXYZ(eVec(0, 1), eVec(1, 1), eVec(2, 1));
+          eVec1 *= sqrt(ev1);
+          eVec2.SetXYZ(eVec(0, 2), eVec(1, 2), eVec(2, 2));
+          eVec2 *= sqrt(ev2);
+        } else if (ev1 < ev0 && ev1 < ev2) {
+          eVec1.SetXYZ(eVec(0, 0), eVec(1, 0), eVec(2, 0));
+          eVec1 *= sqrt(ev0);
+          eVec2.SetXYZ(eVec(0, 2), eVec(1, 2), eVec(2, 2));
+          eVec2 *= sqrt(ev2);
+        } else {
+          eVec1.SetXYZ(eVec(0, 0), eVec(1, 0), eVec(2, 0));
+          eVec1 *= sqrt(ev0);
+          eVec2.SetXYZ(eVec(0, 1), eVec(1, 1), eVec(2, 1));
+          eVec2 *= sqrt(ev1);
+        }
+
+        if (eVec1.Cross(eVec2)*eval < 0)
+          eVec2 *= -1;
+        //assert(eVec1.Cross(eVec2)*eval > 0);
+
+        if (oldEVec1 * eVec1 < 0) {
+          eVec1 *= -1;
+          eVec2 *= -1;
+        }
+
+        // vertices at 2nd plane
+        double angle0 = eVec1.Angle(oldEVec1);
+        if (eVec1 * (eval.Cross(oldEVec1)) < 0)
+          angle0 *= -1;
+        for (int i = 0; i < nEdges; ++i) {
+          const double angle = 2 * TMath::Pi() / nEdges * i - angle0;
+          vertices.push_back(position + cos(angle)*eVec1 + sin(angle)*eVec2);
+        }
+
+        vertices.push_back(position);
+
+
+        TEveTriangleSet* error_shape = new TEveTriangleSet(vertices.size(), nEdges * 2);
+        for (unsigned int k = 0; k < vertices.size(); ++k) {
+          error_shape->SetVertex(k, vertices[k].X(), vertices[k].Y(), vertices[k].Z());
+        }
+
+        assert(vertices.size() == 2 * nEdges + 2);
+
+        int iTri(0);
+        for (int i = 0; i < nEdges; ++i) {
+          //error_shape->SetTriangle(iTri++,  0,             i+1,        (i+1)%nEdges+1);
+          error_shape->SetTriangle(iTri++,  i + 1,           i + 1 + nEdges, (i + 1) % nEdges + 1);
+          error_shape->SetTriangle(iTri++, (i + 1) % nEdges + 1, i + 1 + nEdges, (i + 1) % nEdges + 1 + nEdges);
+          //error_shape->SetTriangle(iTri++,  2*nEdges+1,    i+1+nEdges, (i+1)%nEdges+1+nEdges);
+        }
+
+        //assert(iTri == nEdges*4);
+
+        error_shape->SetMainColor(color);
+        error_shape->SetMainTransparency(25);
+        gEve->AddElement(error_shape);
       }
-
-
-      // get cov at first plane
-      TMatrixDSym cov;
-      TVector3 position, direction;
-      rep->getPosMomCov(*measuredState, position, direction, cov);
-
-      // get eigenvalues & -vectors
-      TMatrixDSymEigen eigen_values(cov.GetSub(0,2, 0,2));
-      TVectorT<double> ev = eigen_values.GetEigenValues();
-      TMatrixT<double> eVec = eigen_values.GetEigenVectors();
-      TVector3 eVec1, eVec2;
-      // limit
-      static const double maxErr = 1000.;
-      double ev0 = std::min(ev(0), maxErr);
-      double ev1 = std::min(ev(1), maxErr);
-      double ev2 = std::min(ev(2), maxErr);
-
-      // get two largest eigenvalues/-vectors
-      if (ev0 < ev1 && ev0 < ev2) {
-        eVec1.SetXYZ(eVec(0,1),eVec(1,1),eVec(2,1));
-        eVec1 *= sqrt(ev1);
-        eVec2.SetXYZ(eVec(0,2),eVec(1,2),eVec(2,2));
-        eVec2 *= sqrt(ev2);
-      }
-      else if (ev1 < ev0 && ev1 < ev2) {
-        eVec1.SetXYZ(eVec(0,0),eVec(1,0),eVec(2,0));
-        eVec1 *= sqrt(ev0);
-        eVec2.SetXYZ(eVec(0,2),eVec(1,2),eVec(2,2));
-        eVec2 *= sqrt(ev2);
-      }
-      else {
-        eVec1.SetXYZ(eVec(0,0),eVec(1,0),eVec(2,0));
-        eVec1 *= sqrt(ev0);
-        eVec2.SetXYZ(eVec(0,1),eVec(1,1),eVec(2,1));
-        eVec2 *= sqrt(ev1);
-      }
-
-      if (eVec1.Cross(eVec2)*eval < 0)
-        eVec2 *= -1;
-      //assert(eVec1.Cross(eVec2)*eval > 0);
-
-      const TVector3 oldEVec1(eVec1);
-      const TVector3 oldEVec2(eVec2);
-
-      const int nEdges = 24;
-      std::vector<TVector3> vertices;
-
-      vertices.push_back(position);
-
-      // vertices at plane
-      for (int i=0; i<nEdges; ++i) {
-        const double angle = 2*TMath::Pi()/nEdges * i;
-        vertices.push_back(position + cos(angle)*eVec1 + sin(angle)*eVec2);
-      }
-
-
-
-      DetPlane* newPlane = new DetPlane(*(measuredState->getPlane()));
-      newPlane->setO(position + eval);
-
-      MeasuredStateOnPlane stateCopy(*measuredState);
-      try{
-        rep->extrapolateToPlane(stateCopy, SharedPlanePtr(newPlane));
-      }
-      catch(Exception& e){
-        std::cerr<<e.what();
-        return;
-      }
-
-      // get cov at 2nd plane
-      rep->getPosMomCov(stateCopy, position, direction, cov);
-
-      // get eigenvalues & -vectors
-      TMatrixDSymEigen eigen_values2(cov.GetSub(0,2, 0,2));
-      ev = eigen_values2.GetEigenValues();
-      eVec = eigen_values2.GetEigenVectors();
-      // limit
-      ev0 = std::min(ev(0), maxErr);
-      ev1 = std::min(ev(1), maxErr);
-      ev2 = std::min(ev(2), maxErr);
-
-      // get two largest eigenvalues/-vectors
-      if (ev0 < ev1 && ev0 < ev2) {
-        eVec1.SetXYZ(eVec(0,1),eVec(1,1),eVec(2,1));
-        eVec1 *= sqrt(ev1);
-        eVec2.SetXYZ(eVec(0,2),eVec(1,2),eVec(2,2));
-        eVec2 *= sqrt(ev2);
-      }
-      else if (ev1 < ev0 && ev1 < ev2) {
-        eVec1.SetXYZ(eVec(0,0),eVec(1,0),eVec(2,0));
-        eVec1 *= sqrt(ev0);
-        eVec2.SetXYZ(eVec(0,2),eVec(1,2),eVec(2,2));
-        eVec2 *= sqrt(ev2);
-      }
-      else {
-        eVec1.SetXYZ(eVec(0,0),eVec(1,0),eVec(2,0));
-        eVec1 *= sqrt(ev0);
-        eVec2.SetXYZ(eVec(0,1),eVec(1,1),eVec(2,1));
-        eVec2 *= sqrt(ev1);
-      }
-
-      if (eVec1.Cross(eVec2)*eval < 0)
-        eVec2 *= -1;
-      //assert(eVec1.Cross(eVec2)*eval > 0);
-
-      if (oldEVec1*eVec1 < 0) {
-        eVec1 *= -1;
-        eVec2 *= -1;
-      }
-
-      // vertices at 2nd plane
-      double angle0 = eVec1.Angle(oldEVec1);
-      if (eVec1*(eval.Cross(oldEVec1)) < 0)
-        angle0 *= -1;
-      for (int i=0; i<nEdges; ++i) {
-        const double angle = 2*TMath::Pi()/nEdges * i - angle0;
-        vertices.push_back(position + cos(angle)*eVec1 + sin(angle)*eVec2);
-      }
-
-      vertices.push_back(position);
-
-
-      TEveTriangleSet* error_shape = new TEveTriangleSet(vertices.size(), nEdges*2);
-      for(unsigned int k = 0; k < vertices.size(); ++k) {
-        error_shape->SetVertex(k, vertices[k].X(), vertices[k].Y(), vertices[k].Z());
-      }
-
-      assert(vertices.size() == 2*nEdges+2);
-
-      int iTri(0);
-      for (int i=0; i<nEdges; ++i) {
-        //error_shape->SetTriangle(iTri++,  0,             i+1,        (i+1)%nEdges+1);
-        error_shape->SetTriangle(iTri++,  i+1,           i+1+nEdges, (i+1)%nEdges+1);
-        error_shape->SetTriangle(iTri++, (i+1)%nEdges+1, i+1+nEdges, (i+1)%nEdges+1+nEdges);
-        //error_shape->SetTriangle(iTri++,  2*nEdges+1,    i+1+nEdges, (i+1)%nEdges+1+nEdges);
-      }
-
-      //assert(iTri == nEdges*4);
-
-      error_shape->SetMainColor(color);
-      error_shape->SetMainTransparency(25);
-      gEve->AddElement(error_shape);
     }
   }
-}
 
 
-void EventDisplay::makeGui() {
+  void EventDisplay::makeGui()
+  {
 
-  TEveBrowser* browser = gEve->GetBrowser();
-  browser->StartEmbedding(TRootBrowser::kLeft);
+    TEveBrowser* browser = gEve->GetBrowser();
+    browser->StartEmbedding(TRootBrowser::kLeft);
 
-  TGMainFrame* frmMain = new TGMainFrame(gClient->GetRoot(), 1000, 600);
-  frmMain->SetWindowName("XX GUI");
-  frmMain->SetCleanup(kDeepCleanup);
+    TGMainFrame* frmMain = new TGMainFrame(gClient->GetRoot(), 1000, 600);
+    frmMain->SetWindowName("XX GUI");
+    frmMain->SetCleanup(kDeepCleanup);
 
-  TGLabel* lbl = 0;
-  TGTextButton* tb = 0;
-  EventDisplay*  fh = EventDisplay::getInstance();
+    TGLabel* lbl = 0;
+    TGTextButton* tb = 0;
+    EventDisplay*  fh = EventDisplay::getInstance();
 
-  TGHorizontalFrame* hf = new TGHorizontalFrame(frmMain); {
-    // evt number entry
-    lbl = new TGLabel(hf, "Go to event: ");
-    hf->AddFrame(lbl);
-    guiEvent = new TGNumberEntry(hf, 0, 9,999, TGNumberFormat::kNESInteger,
-                          TGNumberFormat::kNEANonNegative,
-                          TGNumberFormat::kNELLimitMinMax,
-                          0, 99999);
-    hf->AddFrame(guiEvent);
-    guiEvent->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiGoto()");
+    TGHorizontalFrame* hf = new TGHorizontalFrame(frmMain); {
+      // evt number entry
+      lbl = new TGLabel(hf, "Go to event: ");
+      hf->AddFrame(lbl);
+      guiEvent = new TGNumberEntry(hf, 0, 9, 999, TGNumberFormat::kNESInteger,
+                                   TGNumberFormat::kNEANonNegative,
+                                   TGNumberFormat::kNELLimitMinMax,
+                                   0, 99999);
+      hf->AddFrame(guiEvent);
+      guiEvent->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiGoto()");
 
-    // redraw button
-    tb = new TGTextButton(hf, "Redraw Event");
-    hf->AddFrame(tb);
-    tb->Connect("Clicked()", "genfit::EventDisplay", fh, "guiGoto()");
-  }
-  frmMain->AddFrame(hf);
+      // redraw button
+      tb = new TGTextButton(hf, "Redraw Event");
+      hf->AddFrame(tb);
+      tb->Connect("Clicked()", "genfit::EventDisplay", fh, "guiGoto()");
+    }
+    frmMain->AddFrame(hf);
 
-  // draw options
-  hf = new TGHorizontalFrame(frmMain); {
-    lbl = new TGLabel(hf, "\n Draw Options");
-    hf->AddFrame(lbl);
-  }
-  frmMain->AddFrame(hf);
+    // draw options
+    hf = new TGHorizontalFrame(frmMain); {
+      lbl = new TGLabel(hf, "\n Draw Options");
+      hf->AddFrame(lbl);
+    }
+    frmMain->AddFrame(hf);
 
-  hf = new TGHorizontalFrame(frmMain); {
-    guiDrawGeometry_ =  new TGCheckButton(hf, "Draw geometry");
-    if(drawGeometry_) guiDrawGeometry_->Toggle();
-    hf->AddFrame(guiDrawGeometry_);
-    guiDrawGeometry_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-  }
-  frmMain->AddFrame(hf);
+    hf = new TGHorizontalFrame(frmMain); {
+      guiDrawGeometry_ =  new TGCheckButton(hf, "Draw geometry");
+      if (drawGeometry_) guiDrawGeometry_->Toggle();
+      hf->AddFrame(guiDrawGeometry_);
+      guiDrawGeometry_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+    }
+    frmMain->AddFrame(hf);
 
-  hf = new TGHorizontalFrame(frmMain); {
-    guiDrawDetectors_ =  new TGCheckButton(hf, "Draw detectors");
-    if(drawDetectors_) guiDrawDetectors_->Toggle();
-    hf->AddFrame(guiDrawDetectors_);
-    guiDrawDetectors_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-  }
-  frmMain->AddFrame(hf);
+    hf = new TGHorizontalFrame(frmMain); {
+      guiDrawDetectors_ =  new TGCheckButton(hf, "Draw detectors");
+      if (drawDetectors_) guiDrawDetectors_->Toggle();
+      hf->AddFrame(guiDrawDetectors_);
+      guiDrawDetectors_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+    }
+    frmMain->AddFrame(hf);
 
-  hf = new TGHorizontalFrame(frmMain); {
-    guiDrawHits_ =  new TGCheckButton(hf, "Draw hits");
-    if(drawHits_) guiDrawHits_->Toggle();
-    hf->AddFrame(guiDrawHits_);
-    guiDrawHits_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-  }
-  frmMain->AddFrame(hf);
-
-
-
-  hf = new TGHorizontalFrame(frmMain); {
-    guiDrawPlanes_ =  new TGCheckButton(hf, "Draw planes");
-    if(drawPlanes_) guiDrawPlanes_->Toggle();
-    hf->AddFrame(guiDrawPlanes_);
-    guiDrawPlanes_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-  }
-  frmMain->AddFrame(hf);
-
-  hf = new TGHorizontalFrame(frmMain); {
-    guiDrawTrackMarkers_ =  new TGCheckButton(hf, "Draw track markers");
-    if(drawTrackMarkers_) guiDrawTrackMarkers_->Toggle();
-    hf->AddFrame(guiDrawTrackMarkers_);
-    guiDrawTrackMarkers_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-  }
-  frmMain->AddFrame(hf);
-
-
-  hf = new TGHorizontalFrame(frmMain); {
-    guiDrawTrack_ =  new TGCheckButton(hf, "Draw track");
-    if(drawTrack_) guiDrawTrack_->Toggle();
-    hf->AddFrame(guiDrawTrack_);
-    guiDrawTrack_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-  }
-  frmMain->AddFrame(hf);
-
-  hf = new TGHorizontalFrame(frmMain); {
-    guiDrawRefTrack_ =  new TGCheckButton(hf, "Draw reference track");
-    if(drawRefTrack_) guiDrawRefTrack_->Toggle();
-    hf->AddFrame(guiDrawRefTrack_);
-    guiDrawRefTrack_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-  }
-  frmMain->AddFrame(hf);
-
-  hf = new TGHorizontalFrame(frmMain); {
-    guiDrawErrors_ =  new TGCheckButton(hf, "Draw track errors");
-    if(drawErrors_) guiDrawErrors_->Toggle();
-    hf->AddFrame(guiDrawErrors_);
-    guiDrawErrors_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-  }
-  frmMain->AddFrame(hf);
-
-  hf = new TGHorizontalFrame(frmMain); {
-    guiDrawForward_ =  new TGCheckButton(hf, "Draw forward fit");
-    if(drawForward_) guiDrawForward_->Toggle();
-    hf->AddFrame(guiDrawForward_);
-    guiDrawForward_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-  }
-  frmMain->AddFrame(hf);
-
-  hf = new TGHorizontalFrame(frmMain); {
-    guiDrawBackward_ =  new TGCheckButton(hf, "Draw backward fit");
-    if(drawBackward_) guiDrawBackward_->Toggle();
-    hf->AddFrame(guiDrawBackward_);
-    guiDrawBackward_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-  }
-  frmMain->AddFrame(hf);
-
-
-  hf = new TGHorizontalFrame(frmMain); {
-    guiDrawAutoScale_ =  new TGCheckButton(hf, "Auto-scale errors");
-    if(drawAutoScale_) guiDrawAutoScale_->Toggle();
-    hf->AddFrame(guiDrawAutoScale_);
-    guiDrawAutoScale_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-  }
-  frmMain->AddFrame(hf);
-
-  hf = new TGHorizontalFrame(frmMain); {
-    guiDrawScaleMan_ =  new TGCheckButton(hf, "Manually scale errors");
-    if(drawScaleMan_) guiDrawScaleMan_->Toggle();
-    hf->AddFrame(guiDrawScaleMan_);
-    guiDrawScaleMan_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-  }
-  frmMain->AddFrame(hf);
-
-  hf = new TGHorizontalFrame(frmMain); {
-    guiErrorScale_ = new TGNumberEntry(hf, errorScale_, 6,999, TGNumberFormat::kNESReal,
-                          TGNumberFormat::kNEANonNegative,
-                          TGNumberFormat::kNELLimitMinMax,
-                          1.E-4, 1.E5);
-    hf->AddFrame(guiErrorScale_);
-    guiErrorScale_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-    lbl = new TGLabel(hf, "Error scale");
-    hf->AddFrame(lbl);
-  }
-  frmMain->AddFrame(hf);
+    hf = new TGHorizontalFrame(frmMain); {
+      guiDrawHits_ =  new TGCheckButton(hf, "Draw hits");
+      if (drawHits_) guiDrawHits_->Toggle();
+      hf->AddFrame(guiDrawHits_);
+      guiDrawHits_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+    }
+    frmMain->AddFrame(hf);
 
 
 
-  hf = new TGHorizontalFrame(frmMain); {
-    lbl = new TGLabel(hf, "\n TrackRep options");
-    hf->AddFrame(lbl);
-  }
-  frmMain->AddFrame(hf);
+    hf = new TGHorizontalFrame(frmMain); {
+      guiDrawPlanes_ =  new TGCheckButton(hf, "Draw planes");
+      if (drawPlanes_) guiDrawPlanes_->Toggle();
+      hf->AddFrame(guiDrawPlanes_);
+      guiDrawPlanes_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+    }
+    frmMain->AddFrame(hf);
 
-  hf = new TGHorizontalFrame(frmMain); {
-    guiDrawCardinalRep_ =  new TGCheckButton(hf, "Draw cardinal rep");
-    if(drawCardinalRep_) guiDrawCardinalRep_->Toggle();
-    hf->AddFrame(guiDrawCardinalRep_);
-    guiDrawCardinalRep_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-  }
-  frmMain->AddFrame(hf);
-
-  hf = new TGHorizontalFrame(frmMain); {
-    guiRepId_ = new TGNumberEntry(hf, repId_, 6,999, TGNumberFormat::kNESInteger,
-                          TGNumberFormat::kNEANonNegative,
-                          TGNumberFormat::kNELLimitMinMax,
-                          0, 99);
-    hf->AddFrame(guiRepId_);
-    guiRepId_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-    lbl = new TGLabel(hf, "Else draw rep with id");
-    hf->AddFrame(lbl);
-  }
-  frmMain->AddFrame(hf);
-
-  hf = new TGHorizontalFrame(frmMain); {
-    guiDrawAllTracks_ =  new TGCheckButton(hf, "Draw all tracks");
-    if(drawAllTracks_) guiDrawAllTracks_->Toggle();
-    hf->AddFrame(guiDrawAllTracks_);
-    guiDrawAllTracks_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-  }
-  frmMain->AddFrame(hf);
-
-  hf = new TGHorizontalFrame(frmMain); {
-    guiTrackId_ = new TGNumberEntry(hf, trackId_, 6,999, TGNumberFormat::kNESInteger,
-                          TGNumberFormat::kNEANonNegative,
-                          TGNumberFormat::kNELLimitMinMax,
-                          0, 99);
-    hf->AddFrame(guiTrackId_);
-    guiTrackId_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-    lbl = new TGLabel(hf, "Else draw track nr. ");
-    hf->AddFrame(lbl);
-  }
-  frmMain->AddFrame(hf);
+    hf = new TGHorizontalFrame(frmMain); {
+      guiDrawTrackMarkers_ =  new TGCheckButton(hf, "Draw track markers");
+      if (drawTrackMarkers_) guiDrawTrackMarkers_->Toggle();
+      hf->AddFrame(guiDrawTrackMarkers_);
+      guiDrawTrackMarkers_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+    }
+    frmMain->AddFrame(hf);
 
 
+    hf = new TGHorizontalFrame(frmMain); {
+      guiDrawTrack_ =  new TGCheckButton(hf, "Draw track");
+      if (drawTrack_) guiDrawTrack_->Toggle();
+      hf->AddFrame(guiDrawTrack_);
+      guiDrawTrack_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+    }
+    frmMain->AddFrame(hf);
 
-  frmMain->MapSubwindows();
-  frmMain->Resize();
-  frmMain->MapWindow();
+    hf = new TGHorizontalFrame(frmMain); {
+      guiDrawRefTrack_ =  new TGCheckButton(hf, "Draw reference track");
+      if (drawRefTrack_) guiDrawRefTrack_->Toggle();
+      hf->AddFrame(guiDrawRefTrack_);
+      guiDrawRefTrack_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+    }
+    frmMain->AddFrame(hf);
 
-  browser->StopEmbedding();
-  browser->SetTabTitle("Draw Control", 0);
+    hf = new TGHorizontalFrame(frmMain); {
+      guiDrawErrors_ =  new TGCheckButton(hf, "Draw track errors");
+      if (drawErrors_) guiDrawErrors_->Toggle();
+      hf->AddFrame(guiDrawErrors_);
+      guiDrawErrors_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+    }
+    frmMain->AddFrame(hf);
+
+    hf = new TGHorizontalFrame(frmMain); {
+      guiDrawForward_ =  new TGCheckButton(hf, "Draw forward fit");
+      if (drawForward_) guiDrawForward_->Toggle();
+      hf->AddFrame(guiDrawForward_);
+      guiDrawForward_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+    }
+    frmMain->AddFrame(hf);
+
+    hf = new TGHorizontalFrame(frmMain); {
+      guiDrawBackward_ =  new TGCheckButton(hf, "Draw backward fit");
+      if (drawBackward_) guiDrawBackward_->Toggle();
+      hf->AddFrame(guiDrawBackward_);
+      guiDrawBackward_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+    }
+    frmMain->AddFrame(hf);
 
 
-  browser->StartEmbedding(TRootBrowser::kLeft);
-  TGMainFrame* frmMain2 = new TGMainFrame(gClient->GetRoot(), 1000, 600);
-  frmMain2->SetWindowName("XX GUI");
-  frmMain2->SetCleanup(kDeepCleanup);
+    hf = new TGHorizontalFrame(frmMain); {
+      guiDrawAutoScale_ =  new TGCheckButton(hf, "Auto-scale errors");
+      if (drawAutoScale_) guiDrawAutoScale_->Toggle();
+      hf->AddFrame(guiDrawAutoScale_);
+      guiDrawAutoScale_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+    }
+    frmMain->AddFrame(hf);
 
-  hf = new TGHorizontalFrame(frmMain2); {
-    // evt number entry
-    lbl = new TGLabel(hf, "Go to event: ");
-    hf->AddFrame(lbl);
-    guiEvent2 = new TGNumberEntry(hf, 0, 9,999, TGNumberFormat::kNESInteger,
-                          TGNumberFormat::kNEANonNegative,
-                          TGNumberFormat::kNELLimitMinMax,
-                          0, 99999);
-    hf->AddFrame(guiEvent2);
-    guiEvent2->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiGoto2()");
+    hf = new TGHorizontalFrame(frmMain); {
+      guiDrawScaleMan_ =  new TGCheckButton(hf, "Manually scale errors");
+      if (drawScaleMan_) guiDrawScaleMan_->Toggle();
+      hf->AddFrame(guiDrawScaleMan_);
+      guiDrawScaleMan_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+    }
+    frmMain->AddFrame(hf);
 
-    // redraw button
-    tb = new TGTextButton(hf, "Redraw Event");
-    hf->AddFrame(tb);
-    tb->Connect("Clicked()", "genfit::EventDisplay", fh, "guiGoto()");
-  }
-  frmMain2->AddFrame(hf);
+    hf = new TGHorizontalFrame(frmMain); {
+      guiErrorScale_ = new TGNumberEntry(hf, errorScale_, 6, 999, TGNumberFormat::kNESReal,
+                                         TGNumberFormat::kNEANonNegative,
+                                         TGNumberFormat::kNELLimitMinMax,
+                                         1.E-4, 1.E5);
+      hf->AddFrame(guiErrorScale_);
+      guiErrorScale_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+      lbl = new TGLabel(hf, "Error scale");
+      hf->AddFrame(lbl);
+    }
+    frmMain->AddFrame(hf);
 
-  hf = new TGHorizontalFrame(frmMain2); {
-    lbl = new TGLabel(hf, "\n Fitting options");
-    hf->AddFrame(lbl);
-  }
-  frmMain2->AddFrame(hf);
 
-  hf = new TGHorizontalFrame(frmMain2); {
-    guiRefit_ =  new TGCheckButton(hf, "Refit");
-    if(refit_) guiRefit_->Toggle();
-    hf->AddFrame(guiRefit_);
-    guiRefit_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-  }
-  frmMain2->AddFrame(hf);
 
-  hf = new TGHorizontalFrame(frmMain2); {
-    guiDebugLvl_ = new TGNumberEntry(hf, debugLvl_, 6,999, TGNumberFormat::kNESInteger,
-                          TGNumberFormat::kNEANonNegative,
-                          TGNumberFormat::kNELLimitMinMax,
-                          0, 999);
-    hf->AddFrame(guiDebugLvl_);
-    guiDebugLvl_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-    lbl = new TGLabel(hf, "debug level");
-    hf->AddFrame(lbl);
-  }
-  frmMain2->AddFrame(hf);
+    hf = new TGHorizontalFrame(frmMain); {
+      lbl = new TGLabel(hf, "\n TrackRep options");
+      hf->AddFrame(lbl);
+    }
+    frmMain->AddFrame(hf);
 
-  hf = new TGHorizontalFrame(frmMain2); {
-    guiFitterId_ = new TGButtonGroup(hf,"Fitter type:");
-    guiFitterId_->Connect("Clicked(Int_t)","genfit::EventDisplay", fh, "guiSelectFitterId(int)");
-    hf->AddFrame(guiFitterId_, new TGLayoutHints(kLHintsTop));
+    hf = new TGHorizontalFrame(frmMain); {
+      guiDrawCardinalRep_ =  new TGCheckButton(hf, "Draw cardinal rep");
+      if (drawCardinalRep_) guiDrawCardinalRep_->Toggle();
+      hf->AddFrame(guiDrawCardinalRep_);
+      guiDrawCardinalRep_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+    }
+    frmMain->AddFrame(hf);
+
+    hf = new TGHorizontalFrame(frmMain); {
+      guiRepId_ = new TGNumberEntry(hf, repId_, 6, 999, TGNumberFormat::kNESInteger,
+                                    TGNumberFormat::kNEANonNegative,
+                                    TGNumberFormat::kNELLimitMinMax,
+                                    0, 99);
+      hf->AddFrame(guiRepId_);
+      guiRepId_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+      lbl = new TGLabel(hf, "Else draw rep with id");
+      hf->AddFrame(lbl);
+    }
+    frmMain->AddFrame(hf);
+
+    hf = new TGHorizontalFrame(frmMain); {
+      guiDrawAllTracks_ =  new TGCheckButton(hf, "Draw all tracks");
+      if (drawAllTracks_) guiDrawAllTracks_->Toggle();
+      hf->AddFrame(guiDrawAllTracks_);
+      guiDrawAllTracks_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+    }
+    frmMain->AddFrame(hf);
+
+    hf = new TGHorizontalFrame(frmMain); {
+      guiTrackId_ = new TGNumberEntry(hf, trackId_, 6, 999, TGNumberFormat::kNESInteger,
+                                      TGNumberFormat::kNEANonNegative,
+                                      TGNumberFormat::kNELLimitMinMax,
+                                      0, 99);
+      hf->AddFrame(guiTrackId_);
+      guiTrackId_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+      lbl = new TGLabel(hf, "Else draw track nr. ");
+      hf->AddFrame(lbl);
+    }
+    frmMain->AddFrame(hf);
+
+
+
+    frmMain->MapSubwindows();
+    frmMain->Resize();
+    frmMain->MapWindow();
+
+    browser->StopEmbedding();
+    browser->SetTabTitle("Draw Control", 0);
+
+
+    browser->StartEmbedding(TRootBrowser::kLeft);
+    TGMainFrame* frmMain2 = new TGMainFrame(gClient->GetRoot(), 1000, 600);
+    frmMain2->SetWindowName("XX GUI");
+    frmMain2->SetCleanup(kDeepCleanup);
+
+    hf = new TGHorizontalFrame(frmMain2); {
+      // evt number entry
+      lbl = new TGLabel(hf, "Go to event: ");
+      hf->AddFrame(lbl);
+      guiEvent2 = new TGNumberEntry(hf, 0, 9, 999, TGNumberFormat::kNESInteger,
+                                    TGNumberFormat::kNEANonNegative,
+                                    TGNumberFormat::kNELLimitMinMax,
+                                    0, 99999);
+      hf->AddFrame(guiEvent2);
+      guiEvent2->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiGoto2()");
+
+      // redraw button
+      tb = new TGTextButton(hf, "Redraw Event");
+      hf->AddFrame(tb);
+      tb->Connect("Clicked()", "genfit::EventDisplay", fh, "guiGoto()");
+    }
+    frmMain2->AddFrame(hf);
+
+    hf = new TGHorizontalFrame(frmMain2); {
+      lbl = new TGLabel(hf, "\n Fitting options");
+      hf->AddFrame(lbl);
+    }
+    frmMain2->AddFrame(hf);
+
+    hf = new TGHorizontalFrame(frmMain2); {
+      guiRefit_ =  new TGCheckButton(hf, "Refit");
+      if (refit_) guiRefit_->Toggle();
+      hf->AddFrame(guiRefit_);
+      guiRefit_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+    }
+    frmMain2->AddFrame(hf);
+
+    hf = new TGHorizontalFrame(frmMain2); {
+      guiDebugLvl_ = new TGNumberEntry(hf, debugLvl_, 6, 999, TGNumberFormat::kNESInteger,
+                                       TGNumberFormat::kNEANonNegative,
+                                       TGNumberFormat::kNELLimitMinMax,
+                                       0, 999);
+      hf->AddFrame(guiDebugLvl_);
+      guiDebugLvl_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+      lbl = new TGLabel(hf, "debug level");
+      hf->AddFrame(lbl);
+    }
+    frmMain2->AddFrame(hf);
+
+    hf = new TGHorizontalFrame(frmMain2); {
+      guiFitterId_ = new TGButtonGroup(hf, "Fitter type:");
+      guiFitterId_->Connect("Clicked(Int_t)", "genfit::EventDisplay", fh, "guiSelectFitterId(int)");
+      hf->AddFrame(guiFitterId_, new TGLayoutHints(kLHintsTop));
       TGRadioButton* fitterId_button = new TGRadioButton(guiFitterId_, "Simple Kalman");
       new TGRadioButton(guiFitterId_, "Reference Kalman");
       new TGRadioButton(guiFitterId_, "DAF w/ simple Kalman");
       new TGRadioButton(guiFitterId_, "DAF w/ reference Kalman");
       fitterId_button->SetDown(true, false);
       guiFitterId_->Show();
-  }
-  frmMain2->AddFrame(hf);
+    }
+    frmMain2->AddFrame(hf);
 
-  hf = new TGHorizontalFrame(frmMain2); {
-    guiMmHandling_ = new TGButtonGroup(hf,"Multiple measurement handling in Kalman:");
-    guiMmHandling_->Connect("Clicked(Int_t)","genfit::EventDisplay", fh, "guiSelectMmHandling(int)");
-    hf->AddFrame(guiMmHandling_, new TGLayoutHints(kLHintsTop));
+    hf = new TGHorizontalFrame(frmMain2); {
+      guiMmHandling_ = new TGButtonGroup(hf, "Multiple measurement handling in Kalman:");
+      guiMmHandling_->Connect("Clicked(Int_t)", "genfit::EventDisplay", fh, "guiSelectMmHandling(int)");
+      hf->AddFrame(guiMmHandling_, new TGLayoutHints(kLHintsTop));
       TGRadioButton* mmHandling_button = new TGRadioButton(guiMmHandling_, "weighted average");
       new TGRadioButton(guiMmHandling_, "unweighted average");
       new TGRadioButton(guiMmHandling_, "weighted, closest to reference");
@@ -1479,174 +1481,179 @@ void EventDisplay::makeGui() {
       new TGRadioButton(guiMmHandling_, "unweighted, closest to prediction for WireMeasurements, unweighted average else");
       mmHandling_button->SetDown(true, false);
       guiMmHandling_->Show();
+    }
+    frmMain2->AddFrame(hf);
+
+    hf = new TGHorizontalFrame(frmMain2); {
+      guiSquareRootFormalism_ =  new TGCheckButton(hf, "Use square root formalism (simple Kalman/simple DAF)");
+      if (squareRootFormalism_) guiSquareRootFormalism_->Toggle();
+      hf->AddFrame(guiSquareRootFormalism_);
+      guiSquareRootFormalism_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+    }
+    frmMain2->AddFrame(hf);
+
+    hf = new TGHorizontalFrame(frmMain2); {
+      guiDPVal_ = new TGNumberEntry(hf, dPVal_, 6, 9999, TGNumberFormat::kNESReal,
+                                    TGNumberFormat::kNEANonNegative,
+                                    TGNumberFormat::kNELLimitMinMax,
+                                    0, 999);
+      hf->AddFrame(guiDPVal_);
+      guiDPVal_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+      lbl = new TGLabel(hf, "delta pVal (convergence criterium)");
+      hf->AddFrame(lbl);
+    }
+    frmMain2->AddFrame(hf);
+
+    hf = new TGHorizontalFrame(frmMain2); {
+      guiRelChi2_ = new TGNumberEntry(hf, dRelChi2_, 6, 9999, TGNumberFormat::kNESReal,
+                                      TGNumberFormat::kNEANonNegative,
+                                      TGNumberFormat::kNELLimitMinMax,
+                                      0, 999);
+      hf->AddFrame(guiRelChi2_);
+      guiRelChi2_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+      lbl = new TGLabel(hf, "rel chi^2 change (non-convergence criterium)");
+      hf->AddFrame(lbl);
+    }
+    frmMain2->AddFrame(hf);
+
+    hf = new TGHorizontalFrame(frmMain2); {
+      guiDChi2Ref_ = new TGNumberEntry(hf, dChi2Ref_, 6, 9999, TGNumberFormat::kNESReal,
+                                       TGNumberFormat::kNEANonNegative,
+                                       TGNumberFormat::kNELLimitMinMax,
+                                       0, 999);
+      hf->AddFrame(guiDChi2Ref_);
+      guiDChi2Ref_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+      lbl = new TGLabel(hf, "min chi^2 change for re-calculating reference track (Ref Kalman)");
+      hf->AddFrame(lbl);
+    }
+    frmMain2->AddFrame(hf);
+
+    hf = new TGHorizontalFrame(frmMain2); {
+      guiNMinIter_ = new TGNumberEntry(hf, nMinIter_, 6, 999, TGNumberFormat::kNESInteger,
+                                       TGNumberFormat::kNEANonNegative,
+                                       TGNumberFormat::kNELLimitMinMax,
+                                       1, 100);
+      hf->AddFrame(guiNMinIter_);
+      guiNMinIter_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+      lbl = new TGLabel(hf, "Minimum nr of iterations");
+      hf->AddFrame(lbl);
+    }
+    frmMain2->AddFrame(hf);
+
+    hf = new TGHorizontalFrame(frmMain2); {
+      guiNMaxIter_ = new TGNumberEntry(hf, nMaxIter_, 6, 999, TGNumberFormat::kNESInteger,
+                                       TGNumberFormat::kNEANonNegative,
+                                       TGNumberFormat::kNELLimitMinMax,
+                                       1, 100);
+      hf->AddFrame(guiNMaxIter_);
+      guiNMaxIter_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+      lbl = new TGLabel(hf, "Maximum nr of iterations");
+      hf->AddFrame(lbl);
+    }
+    frmMain2->AddFrame(hf);
+
+    hf = new TGHorizontalFrame(frmMain2); {
+      guiNMaxFailed_ = new TGNumberEntry(hf, nMaxFailed_, 6, 999, TGNumberFormat::kNESInteger,
+                                         TGNumberFormat::kNEAAnyNumber,
+                                         TGNumberFormat::kNELLimitMinMax,
+                                         -1, 1000);
+      hf->AddFrame(guiNMaxFailed_);
+      guiNMaxFailed_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+      lbl = new TGLabel(hf, "Maximum nr of failed hits");
+      hf->AddFrame(lbl);
+    }
+    frmMain2->AddFrame(hf);
+
+
+    hf = new TGHorizontalFrame(frmMain2); {
+      guiResort_ =  new TGCheckButton(hf, "Resort track");
+      if (resort_) guiResort_->Toggle();
+      hf->AddFrame(guiResort_);
+      guiResort_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+    }
+    frmMain2->AddFrame(hf);
+
+
+
+
+    frmMain2->MapSubwindows();
+    frmMain2->Resize();
+    frmMain2->MapWindow();
+
+    browser->StopEmbedding();
+    browser->SetTabTitle("Refit Control", 0);
   }
-  frmMain2->AddFrame(hf);
 
-  hf = new TGHorizontalFrame(frmMain2); {
-    guiSquareRootFormalism_ =  new TGCheckButton(hf, "Use square root formalism (simple Kalman/simple DAF)");
-    if(squareRootFormalism_) guiSquareRootFormalism_->Toggle();
-    hf->AddFrame(guiSquareRootFormalism_);
-    guiSquareRootFormalism_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
+
+  void EventDisplay::guiGoto()
+  {
+    Long_t n = guiEvent->GetNumberEntry()->GetIntNumber();
+    guiEvent2->SetIntNumber(n);
+    gotoEvent(n);
   }
-  frmMain2->AddFrame(hf);
 
-  hf = new TGHorizontalFrame(frmMain2); {
-    guiDPVal_ = new TGNumberEntry(hf, dPVal_, 6,9999, TGNumberFormat::kNESReal,
-                          TGNumberFormat::kNEANonNegative,
-                          TGNumberFormat::kNELLimitMinMax,
-                          0, 999);
-    hf->AddFrame(guiDPVal_);
-    guiDPVal_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-    lbl = new TGLabel(hf, "delta pVal (convergence criterium)");
-    hf->AddFrame(lbl);
+  void EventDisplay::guiGoto2()
+  {
+    Long_t n = guiEvent2->GetNumberEntry()->GetIntNumber();
+    guiEvent->SetIntNumber(n);
+    gotoEvent(n);
   }
-  frmMain2->AddFrame(hf);
 
-  hf = new TGHorizontalFrame(frmMain2); {
-    guiRelChi2_ = new TGNumberEntry(hf, dRelChi2_, 6,9999, TGNumberFormat::kNESReal,
-                          TGNumberFormat::kNEANonNegative,
-                          TGNumberFormat::kNELLimitMinMax,
-                          0, 999);
-    hf->AddFrame(guiRelChi2_);
-    guiRelChi2_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-    lbl = new TGLabel(hf, "rel chi^2 change (non-convergence criterium)");
-    hf->AddFrame(lbl);
+
+  void EventDisplay::guiSetDrawParams()
+  {
+
+    drawGeometry_ = guiDrawGeometry_->IsOn();
+    drawDetectors_ = guiDrawDetectors_->IsOn();
+    drawHits_ = guiDrawHits_->IsOn();
+    drawErrors_ = guiDrawErrors_->IsOn();
+
+    drawPlanes_ = guiDrawPlanes_->IsOn();
+    drawTrackMarkers_ = guiDrawTrackMarkers_->IsOn();
+    drawTrack_ = guiDrawTrack_->IsOn();
+    drawRefTrack_ = guiDrawRefTrack_->IsOn();
+    drawForward_ = guiDrawForward_->IsOn();
+    drawBackward_ = guiDrawBackward_->IsOn();
+
+    drawAutoScale_ = guiDrawAutoScale_->IsOn();
+    drawScaleMan_ = guiDrawScaleMan_->IsOn();
+
+    errorScale_ = guiErrorScale_->GetNumberEntry()->GetNumber();
+
+    drawCardinalRep_ = guiDrawCardinalRep_->IsOn();
+    repId_ = guiRepId_->GetNumberEntry()->GetNumber();
+
+    drawAllTracks_ = guiDrawAllTracks_->IsOn();
+    trackId_ = guiTrackId_->GetNumberEntry()->GetNumber();
+
+
+    refit_ = guiRefit_->IsOn();
+    debugLvl_ = guiDebugLvl_->GetNumberEntry()->GetNumber();
+
+    squareRootFormalism_ = guiSquareRootFormalism_->IsOn();
+    dPVal_ = guiDPVal_->GetNumberEntry()->GetNumber();
+    dRelChi2_ = guiRelChi2_->GetNumberEntry()->GetNumber();
+    dChi2Ref_ = guiDChi2Ref_->GetNumberEntry()->GetNumber();
+    nMinIter_ = guiNMinIter_->GetNumberEntry()->GetNumber();
+    nMaxIter_ = guiNMaxIter_->GetNumberEntry()->GetNumber();
+    nMaxFailed_ = guiNMaxFailed_->GetNumberEntry()->GetNumber();
+    resort_ = guiResort_->IsOn();
+
+    gotoEvent(eventId_);
   }
-  frmMain2->AddFrame(hf);
 
-  hf = new TGHorizontalFrame(frmMain2); {
-    guiDChi2Ref_ = new TGNumberEntry(hf, dChi2Ref_, 6,9999, TGNumberFormat::kNESReal,
-                          TGNumberFormat::kNEANonNegative,
-                          TGNumberFormat::kNELLimitMinMax,
-                          0, 999);
-    hf->AddFrame(guiDChi2Ref_);
-    guiDChi2Ref_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-    lbl = new TGLabel(hf, "min chi^2 change for re-calculating reference track (Ref Kalman)");
-    hf->AddFrame(lbl);
+
+  void EventDisplay::guiSelectFitterId(int val)
+  {
+    fitterId_ = eFitterType(val - 1);
+    gotoEvent(eventId_);
   }
-  frmMain2->AddFrame(hf);
 
-  hf = new TGHorizontalFrame(frmMain2); {
-    guiNMinIter_ = new TGNumberEntry(hf, nMinIter_, 6,999, TGNumberFormat::kNESInteger,
-                          TGNumberFormat::kNEANonNegative,
-                          TGNumberFormat::kNELLimitMinMax,
-                          1, 100);
-    hf->AddFrame(guiNMinIter_);
-    guiNMinIter_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-    lbl = new TGLabel(hf, "Minimum nr of iterations");
-    hf->AddFrame(lbl);
+  void EventDisplay::guiSelectMmHandling(int val)
+  {
+    mmHandling_ = eMultipleMeasurementHandling(val - 1);
+    gotoEvent(eventId_);
   }
-  frmMain2->AddFrame(hf);
-
-  hf = new TGHorizontalFrame(frmMain2); {
-    guiNMaxIter_ = new TGNumberEntry(hf, nMaxIter_, 6,999, TGNumberFormat::kNESInteger,
-                          TGNumberFormat::kNEANonNegative,
-                          TGNumberFormat::kNELLimitMinMax,
-                          1, 100);
-    hf->AddFrame(guiNMaxIter_);
-    guiNMaxIter_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-    lbl = new TGLabel(hf, "Maximum nr of iterations");
-    hf->AddFrame(lbl);
-  }
-  frmMain2->AddFrame(hf);
-
-  hf = new TGHorizontalFrame(frmMain2); {
-    guiNMaxFailed_ = new TGNumberEntry(hf, nMaxFailed_, 6,999, TGNumberFormat::kNESInteger,
-                          TGNumberFormat::kNEAAnyNumber,
-                          TGNumberFormat::kNELLimitMinMax,
-                          -1, 1000);
-    hf->AddFrame(guiNMaxFailed_);
-    guiNMaxFailed_->Connect("ValueSet(Long_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-    lbl = new TGLabel(hf, "Maximum nr of failed hits");
-    hf->AddFrame(lbl);
-  }
-  frmMain2->AddFrame(hf);
-
-
-  hf = new TGHorizontalFrame(frmMain2); {
-    guiResort_ =  new TGCheckButton(hf, "Resort track");
-    if(resort_) guiResort_->Toggle();
-    hf->AddFrame(guiResort_);
-    guiResort_->Connect("Toggled(Bool_t)", "genfit::EventDisplay", fh, "guiSetDrawParams()");
-  }
-  frmMain2->AddFrame(hf);
-
-
-
-
-  frmMain2->MapSubwindows();
-  frmMain2->Resize();
-  frmMain2->MapWindow();
-
-  browser->StopEmbedding();
-  browser->SetTabTitle("Refit Control", 0);
-}
-
-
-void EventDisplay::guiGoto(){
-  Long_t n = guiEvent->GetNumberEntry()->GetIntNumber();
-  guiEvent2->SetIntNumber(n);
-  gotoEvent(n);
-}
-
-void EventDisplay::guiGoto2(){
-  Long_t n = guiEvent2->GetNumberEntry()->GetIntNumber();
-  guiEvent->SetIntNumber(n);
-  gotoEvent(n);
-}
-
-
-void EventDisplay::guiSetDrawParams(){
-
-  drawGeometry_ = guiDrawGeometry_->IsOn();
-  drawDetectors_ = guiDrawDetectors_->IsOn();
-  drawHits_ = guiDrawHits_->IsOn();
-  drawErrors_ = guiDrawErrors_->IsOn();
-
-  drawPlanes_ = guiDrawPlanes_->IsOn();
-  drawTrackMarkers_ = guiDrawTrackMarkers_->IsOn();
-  drawTrack_ = guiDrawTrack_->IsOn();
-  drawRefTrack_ = guiDrawRefTrack_->IsOn();
-  drawForward_ = guiDrawForward_->IsOn();
-  drawBackward_ = guiDrawBackward_->IsOn();
-
-  drawAutoScale_ = guiDrawAutoScale_->IsOn();
-  drawScaleMan_ = guiDrawScaleMan_->IsOn();
-
-  errorScale_ = guiErrorScale_->GetNumberEntry()->GetNumber();
-
-  drawCardinalRep_ = guiDrawCardinalRep_->IsOn();
-  repId_ = guiRepId_->GetNumberEntry()->GetNumber();
-
-  drawAllTracks_ = guiDrawAllTracks_->IsOn();
-  trackId_ = guiTrackId_->GetNumberEntry()->GetNumber();
-
-
-  refit_ = guiRefit_->IsOn();
-  debugLvl_ = guiDebugLvl_->GetNumberEntry()->GetNumber();
-
-  squareRootFormalism_ = guiSquareRootFormalism_->IsOn();
-  dPVal_ = guiDPVal_->GetNumberEntry()->GetNumber();
-  dRelChi2_ = guiRelChi2_->GetNumberEntry()->GetNumber();
-  dChi2Ref_ = guiDChi2Ref_->GetNumberEntry()->GetNumber();
-  nMinIter_ = guiNMinIter_->GetNumberEntry()->GetNumber();
-  nMaxIter_ = guiNMaxIter_->GetNumberEntry()->GetNumber();
-  nMaxFailed_ = guiNMaxFailed_->GetNumberEntry()->GetNumber();
-  resort_ = guiResort_->IsOn();
-
-  gotoEvent(eventId_);
-}
-
-
-void EventDisplay::guiSelectFitterId(int val){
-  fitterId_ = eFitterType(val-1);
-  gotoEvent(eventId_);
-}
-
-void EventDisplay::guiSelectMmHandling(int val){
-  mmHandling_ = eMultipleMeasurementHandling(val-1);
-  gotoEvent(eventId_);
-}
 
 
 } // end of namespace genfit

--- a/fields/include/ConstField.h
+++ b/fields/include/ConstField.h
@@ -28,30 +28,30 @@
 
 namespace genfit {
 
-/** @brief Constant Magnetic field
- *
- *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
- *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
- * 
- */
-class ConstField : public AbsBField {
- public:
-  //! define the constant field in this ctor
-  ConstField(double b1, double b2, double b3)
-    : field_(b1, b2, b3)
-  { ; }
+  /** @brief Constant Magnetic field
+   *
+   *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
+   *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
+   *
+   */
+  class ConstField : public AbsBField {
+  public:
+    //! define the constant field in this ctor
+    ConstField(double b1, double b2, double b3)
+      : field_(b1, b2, b3)
+    { ; }
 
-  ConstField(const TVector3& field)
-    : field_(field)
-  { ; }
+    ConstField(const TVector3& field)
+      : field_(field)
+    { ; }
 
-  //! return value at position
-  TVector3 get(const TVector3& pos) const;
-  void get(const double& posX, const double& posY, const double& posZ, double& Bx, double& By, double& Bz) const;
+    //! return value at position
+    TVector3 get(const TVector3& pos) const;
+    void get(const double& posX, const double& posY, const double& posZ, double& Bx, double& By, double& Bz) const;
 
- private:
-  TVector3 field_;
-};
+  private:
+    TVector3 field_;
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/fields/src/ConstField.cc
+++ b/fields/src/ConstField.cc
@@ -20,14 +20,16 @@
 
 namespace genfit {
 
-TVector3 ConstField::get(const TVector3&) const {
-  return field_;
-}
+  TVector3 ConstField::get(const TVector3&) const
+  {
+    return field_;
+  }
 
-void ConstField::get(const double&, const double&, const double&, double& Bx, double& By, double& Bz) const {
-  Bx = field_.X();
-  By = field_.Y();
-  Bz = field_.Z();
-}
+  void ConstField::get(const double&, const double&, const double&, double& Bx, double& By, double& Bz) const
+  {
+    Bx = field_.X();
+    By = field_.Y();
+    Bz = field_.Z();
+  }
 
 } /* End of namespace genfit */

--- a/finitePlanes/include/RectangularFinitePlane.h
+++ b/finitePlanes/include/RectangularFinitePlane.h
@@ -28,35 +28,36 @@
 
 namespace genfit {
 
-/**
- * @brief Rectangular finite plane.
- */
-class RectangularFinitePlane : public AbsFinitePlane {
+  /**
+   * @brief Rectangular finite plane.
+   */
+  class RectangularFinitePlane : public AbsFinitePlane {
 
- public:
+  public:
 
-  //! give dimensions of finite rectangle: u1,u2, v1,v2
-  RectangularFinitePlane(const double&, const double&, const double&, const double&);
-  RectangularFinitePlane();
-  virtual ~RectangularFinitePlane();
+    //! give dimensions of finite rectangle: u1,u2, v1,v2
+    RectangularFinitePlane(const double&, const double&, const double&, const double&);
+    RectangularFinitePlane();
+    virtual ~RectangularFinitePlane();
 
-  //override inActive & Print methods
-  bool isInActive(double u, double v) const;
-  void Print(const Option_t* = "") const;
+    //override inActive & Print methods
+    bool isInActive(double u, double v) const;
+    void Print(const Option_t* = "") const;
 
-  RectangularFinitePlane* clone() const {
-    return new RectangularFinitePlane(*this);
-  }
+    RectangularFinitePlane* clone() const
+    {
+      return new RectangularFinitePlane(*this);
+    }
 
- private:
+  private:
 
-  double uMin_, uMax_, vMin_, vMax_;
+    double uMin_, uMax_, vMin_, vMax_;
 
- public:
+  public:
 
-  ClassDef(RectangularFinitePlane,1)
+    ClassDef(RectangularFinitePlane, 1)
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/finitePlanes/src/RectangularFinitePlane.cc
+++ b/finitePlanes/src/RectangularFinitePlane.cc
@@ -25,30 +25,33 @@
 
 namespace genfit {
 
-RectangularFinitePlane::RectangularFinitePlane(const double& umin,const double& umax,
-             const double& vmin,const double& vmax)
-  : uMin_(umin),uMax_(umax),vMin_(vmin),vMax_(vmax)
-{
-  assert(umin<umax);
-  assert(vmin<vmax);
-}
+  RectangularFinitePlane::RectangularFinitePlane(const double& umin, const double& umax,
+                                                 const double& vmin, const double& vmax)
+    : uMin_(umin), uMax_(umax), vMin_(vmin), vMax_(vmax)
+  {
+    assert(umin < umax);
+    assert(vmin < vmax);
+  }
 
-RectangularFinitePlane::RectangularFinitePlane()
-  : uMin_(1.),uMax_(-1.),vMin_(1.),vMax_(-1.)//for this default ctor inActive always false
-{}
+  RectangularFinitePlane::RectangularFinitePlane()
+    : uMin_(1.), uMax_(-1.), vMin_(1.), vMax_(-1.) //for this default ctor inActive always false
+  {}
 
 
-RectangularFinitePlane::~RectangularFinitePlane(){
+  RectangularFinitePlane::~RectangularFinitePlane()
+  {
 
-}
+  }
 
-bool RectangularFinitePlane::isInActive(double u, double v) const{
-  return (u>=uMin_ && u<=uMax_ && v>=vMin_ && v<=vMax_);
-}
+  bool RectangularFinitePlane::isInActive(double u, double v) const
+  {
+    return (u >= uMin_ && u <= uMax_ && v >= vMin_ && v <= vMax_);
+  }
 
-void RectangularFinitePlane::Print(const Option_t*) const{
-  printOut << "Rectangular Finite Plane Umin=" << uMin_ << ", Umax="
-      << uMax_ << ", Vmin=" << vMin_ << ", Vmax=" << vMax_ << std::endl;
-}
+  void RectangularFinitePlane::Print(const Option_t*) const
+  {
+    printOut << "Rectangular Finite Plane Umin=" << uMin_ << ", Umax="
+             << uMax_ << ", Vmin=" << vMin_ << ", Vmax=" << vMax_ << std::endl;
+  }
 
 } /* End of namespace genfit */

--- a/fitters/include/AbsKalmanFitter.h
+++ b/fitters/include/AbsKalmanFitter.h
@@ -30,152 +30,153 @@
 
 namespace genfit {
 
-class KalmanFitterInfo;
+  class KalmanFitterInfo;
 
-enum eMultipleMeasurementHandling {
-  weightedAverage, /**<  weighted average between measurements; used by DAF */
-  unweightedAverage, /**<  average between measurements, all weighted with 1 */
-  weightedClosestToReference, /**<  closest to reference, weighted with its weight_ */
-  unweightedClosestToReference, /**<  closest to reference, weighted with 1 */
-  weightedClosestToPrediction, /**<  closest to prediction, weighted with its weight_ */
-  unweightedClosestToPrediction, /**<  closest to prediction, weighted with 1 */
-  weightedClosestToReferenceWire, /**<  if corresponding TrackPoint has one WireMeasurement, select closest to reference, weighted with its weight_. Otherwise use weightedAverage. */
-  unweightedClosestToReferenceWire, /**<  if corresponding TrackPoint has one WireMeasurement, select closest to reference, weighted with 1. Otherwise use unweightedAverage. */
-  weightedClosestToPredictionWire, /**<  if corresponding TrackPoint has one WireMeasurement, select closest to prediction, weighted with its weight_. Otherwise use weightedAverage. */
-  unweightedClosestToPredictionWire /**<  if corresponding TrackPoint has one WireMeasurement, select closest to prediction, weighted with 1. Otherwise use unweightedAverage. Recommended for KalmanFitter to 'resolve' l/r ambiguities */
-};
-
-/**
- * @brief Abstract base class for Kalman fitter and derived fitting algorithms
- */
-class AbsKalmanFitter : public AbsFitter {
-
- public:
-
-  AbsKalmanFitter(unsigned int maxIterations = 4, double deltaPval = 1e-3, double blowUpFactor = 1e3)
-    : AbsFitter(), minIterations_(2), maxIterations_(maxIterations), deltaPval_(deltaPval), relChi2Change_(0.2),
-      blowUpFactor_(blowUpFactor), resetOffDiagonals_(true), blowUpMaxVal_(1.E6),
-      multipleMeasurementHandling_(unweightedClosestToPredictionWire),
-      maxFailedHits_(-1) {
-    if (minIterations_ > maxIterations_)
-      minIterations_ = maxIterations_;
-  }
-
-  virtual ~AbsKalmanFitter() {;}
-
-  //virtual void fitTrack(Track* tr, const AbsTrackRep* rep, double& chi2, double& ndf, int direction) = 0;
-
-  void getChiSquNdf(const Track* tr, const AbsTrackRep* rep, double& bChi2, double& fChi2, double& bNdf,  double& fNdf) const;
-  double getChiSqu(const Track* tr, const AbsTrackRep* rep, int direction = -1) const;
-  double getNdf(const Track* tr, const AbsTrackRep* rep, int direction = -1) const;
-  double getRedChiSqu(const Track* tr, const AbsTrackRep* rep, int direction = -1) const;
-  double getPVal(const Track* tr, const AbsTrackRep* rep, int direction = -1) const;
-
-  unsigned int getMinIterations() const {return minIterations_;}
-  unsigned int getMaxIterations() const {return maxIterations_;}
-  double getDeltaPval() const {return deltaPval_;}
-  double getRelChi2Change() const {return relChi2Change_;}
-  double getBlowUpFactor() const {return blowUpFactor_;}
-  bool getResetOffDiagonals() const {return resetOffDiagonals_;}
-  double getBlowUpMaxVal() const {return blowUpMaxVal_;}
-  eMultipleMeasurementHandling getMultipleMeasurementHandling() const {return multipleMeasurementHandling_;}
-  int getMaxFailedHits() const {return maxFailedHits_;}
-
-  //! Set the minimum number of iterations
-  virtual void setMinIterations(unsigned int n) {minIterations_ = std::max((unsigned int)1,n); if (maxIterations_ < minIterations_) maxIterations_ = minIterations_;}
-  //! Set the maximum number of iterations
-  virtual void setMaxIterations(unsigned int n) {maxIterations_ = n; if (minIterations_ > maxIterations_) minIterations_ = maxIterations_;}
+  enum eMultipleMeasurementHandling {
+    weightedAverage, /**<  weighted average between measurements; used by DAF */
+    unweightedAverage, /**<  average between measurements, all weighted with 1 */
+    weightedClosestToReference, /**<  closest to reference, weighted with its weight_ */
+    unweightedClosestToReference, /**<  closest to reference, weighted with 1 */
+    weightedClosestToPrediction, /**<  closest to prediction, weighted with its weight_ */
+    unweightedClosestToPrediction, /**<  closest to prediction, weighted with 1 */
+    weightedClosestToReferenceWire, /**<  if corresponding TrackPoint has one WireMeasurement, select closest to reference, weighted with its weight_. Otherwise use weightedAverage. */
+    unweightedClosestToReferenceWire, /**<  if corresponding TrackPoint has one WireMeasurement, select closest to reference, weighted with 1. Otherwise use unweightedAverage. */
+    weightedClosestToPredictionWire, /**<  if corresponding TrackPoint has one WireMeasurement, select closest to prediction, weighted with its weight_. Otherwise use weightedAverage. */
+    unweightedClosestToPredictionWire /**<  if corresponding TrackPoint has one WireMeasurement, select closest to prediction, weighted with 1. Otherwise use unweightedAverage. Recommended for KalmanFitter to 'resolve' l/r ambiguities */
+  };
 
   /**
-   * @brief Set Convergence criterion
-   *
-   * if track total P-value changes less than this between consecutive iterations, consider the track converged.
-   * chi² from the backwards fit is used.
+   * @brief Abstract base class for Kalman fitter and derived fitting algorithms
    */
-  void setDeltaPval(double deltaPval) {deltaPval_ = deltaPval;}
+  class AbsKalmanFitter : public AbsFitter {
 
-  /**
-   * @ brief Set Non-convergence criterion
-   *
-   * if the relative chi^2 between two iterations is larger than relChi2Change_, the fit is NOT converged and
-   * further iterations will be done, even if the deltaPval_ convergence criterium is met.
-   * This is especially useful for fits which have a p-value of almost 0 (possibly due to bad start values),
-   * where the p-value from one iteration to the next might not change much. However, a significant change in
-   * chi^2 tells us, that the fit might not yet be converged.
-   */
-  void setRelChi2Change(double relChi2Change) {relChi2Change_ = relChi2Change;}
+  public:
 
-  void setBlowUpFactor(double blowUpFactor) {blowUpFactor_ = blowUpFactor;}
-  void setResetOffDiagonals(bool resetOffDiagonals) {resetOffDiagonals_ = resetOffDiagonals;}
-  //! Limit the cov entries to this maximum value when blowing up the cov. Set to negative value to disable. Default is 1.E6.
-  /**
-   * This is especially useful for fits where the measurements do not constrain one direction,
-   * e.g. parallel wire measurements. The fit will not be constrained along the wire direction.
-   * This also means that the covariance along the wire direction will not get smaller during the fit.
-   * However, it will be blown up before the next iteration, leading to an exponential growth of
-   * the covariance element(s) corresponding to the wire direction. This can then lead to numerical problems.
-   * To prevent this, the maximum value of the covariance elements after blowing up can be limited.
-   */
-  void setBlowUpMaxVal(double blowUpMaxVal) {blowUpMaxVal_= blowUpMaxVal;}
+    AbsKalmanFitter(unsigned int maxIterations = 4, double deltaPval = 1e-3, double blowUpFactor = 1e3)
+      : AbsFitter(), minIterations_(2), maxIterations_(maxIterations), deltaPval_(deltaPval), relChi2Change_(0.2),
+        blowUpFactor_(blowUpFactor), resetOffDiagonals_(true), blowUpMaxVal_(1.E6),
+        multipleMeasurementHandling_(unweightedClosestToPredictionWire),
+        maxFailedHits_(-1)
+    {
+      if (minIterations_ > maxIterations_)
+        minIterations_ = maxIterations_;
+    }
 
-  //! How should multiple measurements be handled?
-  void setMultipleMeasurementHandling(eMultipleMeasurementHandling mmh) {multipleMeasurementHandling_ = mmh;}
+    virtual ~AbsKalmanFitter() {;}
 
-  virtual void setMaxFailedHits(int val) {maxFailedHits_ = val;}
+    //virtual void fitTrack(Track* tr, const AbsTrackRep* rep, double& chi2, double& ndf, int direction) = 0;
 
-  bool isTrackPrepared(const Track* tr, const AbsTrackRep* rep) const;
-  bool isTrackFitted(const Track* tr, const AbsTrackRep* rep) const;
+    void getChiSquNdf(const Track* tr, const AbsTrackRep* rep, double& bChi2, double& fChi2, double& bNdf,  double& fNdf) const;
+    double getChiSqu(const Track* tr, const AbsTrackRep* rep, int direction = -1) const;
+    double getNdf(const Track* tr, const AbsTrackRep* rep, int direction = -1) const;
+    double getRedChiSqu(const Track* tr, const AbsTrackRep* rep, int direction = -1) const;
+    double getPVal(const Track* tr, const AbsTrackRep* rep, int direction = -1) const;
 
-  //! returns if the fitter can ignore the weights and handle the MeasurementOnPlanes as if they had weight 1.
-  bool canIgnoreWeights() const;
+    unsigned int getMinIterations() const {return minIterations_;}
+    unsigned int getMaxIterations() const {return maxIterations_;}
+    double getDeltaPval() const {return deltaPval_;}
+    double getRelChi2Change() const {return relChi2Change_;}
+    double getBlowUpFactor() const {return blowUpFactor_;}
+    bool getResetOffDiagonals() const {return resetOffDiagonals_;}
+    double getBlowUpMaxVal() const {return blowUpMaxVal_;}
+    eMultipleMeasurementHandling getMultipleMeasurementHandling() const {return multipleMeasurementHandling_;}
+    int getMaxFailedHits() const {return maxFailedHits_;}
 
- protected:
+    //! Set the minimum number of iterations
+    virtual void setMinIterations(unsigned int n) {minIterations_ = std::max((unsigned int)1, n); if (maxIterations_ < minIterations_) maxIterations_ = minIterations_;}
+    //! Set the maximum number of iterations
+    virtual void setMaxIterations(unsigned int n) {maxIterations_ = n; if (minIterations_ > maxIterations_) minIterations_ = maxIterations_;}
 
-  //! get the measurementsOnPlane taking the multipleMeasurementHandling_ into account
-  const std::vector<MeasurementOnPlane *> getMeasurements(const KalmanFitterInfo* fi, const TrackPoint* tp, int direction) const;
+    /**
+     * @brief Set Convergence criterion
+     *
+     * if track total P-value changes less than this between consecutive iterations, consider the track converged.
+     * chi² from the backwards fit is used.
+     */
+    void setDeltaPval(double deltaPval) {deltaPval_ = deltaPval;}
 
-  //! Minimum number of iterations to attempt.  Forward and backward are counted as one iteration.
-  unsigned int minIterations_;
+    /**
+     * @ brief Set Non-convergence criterion
+     *
+     * if the relative chi^2 between two iterations is larger than relChi2Change_, the fit is NOT converged and
+     * further iterations will be done, even if the deltaPval_ convergence criterium is met.
+     * This is especially useful for fits which have a p-value of almost 0 (possibly due to bad start values),
+     * where the p-value from one iteration to the next might not change much. However, a significant change in
+     * chi^2 tells us, that the fit might not yet be converged.
+     */
+    void setRelChi2Change(double relChi2Change) {relChi2Change_ = relChi2Change;}
 
-  //! Maximum number of iterations to attempt.  Forward and backward are counted as one iteration.
-  unsigned int maxIterations_;
-  /**
-   * @brief Convergence criterion
-   *
-   * if track total P-value changes less than this between consecutive iterations, consider the track converged.
-   * chi² from the backwards fit is used.
-   */
-  double deltaPval_;
-  /**
-   * @ brief Non-convergence criterion
-   *
-   * if the relative chi^2 between two iterations is larger than relChi2Change_, the fit is NOT converged and
-   * further iterations will be done, even if the deltaPval_ convergence criterium is met.
-   * This is especially useful for fits which have a p-value of almost 0 (possibly due to bad start values),
-   * where the p-value from one iteration to the next might not change much. However, a significant change in
-   * chi^2 tells us, that the fit might not yet be converged.
-   */
-  double relChi2Change_;
+    void setBlowUpFactor(double blowUpFactor) {blowUpFactor_ = blowUpFactor;}
+    void setResetOffDiagonals(bool resetOffDiagonals) {resetOffDiagonals_ = resetOffDiagonals;}
+    //! Limit the cov entries to this maximum value when blowing up the cov. Set to negative value to disable. Default is 1.E6.
+    /**
+     * This is especially useful for fits where the measurements do not constrain one direction,
+     * e.g. parallel wire measurements. The fit will not be constrained along the wire direction.
+     * This also means that the covariance along the wire direction will not get smaller during the fit.
+     * However, it will be blown up before the next iteration, leading to an exponential growth of
+     * the covariance element(s) corresponding to the wire direction. This can then lead to numerical problems.
+     * To prevent this, the maximum value of the covariance elements after blowing up can be limited.
+     */
+    void setBlowUpMaxVal(double blowUpMaxVal) {blowUpMaxVal_ = blowUpMaxVal;}
 
-  //! Blow up the covariance of the forward (backward) fit by this factor before seeding the backward (forward) fit.
-  double blowUpFactor_;
-  //! Reset the off-diagonals to 0 when blowing up the cov
-  bool resetOffDiagonals_;
-  //! Limit the cov entries to this maxuimum value when blowing up the cov.
-  double blowUpMaxVal_;
+    //! How should multiple measurements be handled?
+    void setMultipleMeasurementHandling(eMultipleMeasurementHandling mmh) {multipleMeasurementHandling_ = mmh;}
 
-  //! How to handle if there are multiple MeasurementsOnPlane
-  eMultipleMeasurementHandling multipleMeasurementHandling_;
+    virtual void setMaxFailedHits(int val) {maxFailedHits_ = val;}
 
-  //! after how many failed hits (exception during construction of plane, extrapolation etc.) should the fit be cancelled.
-  //! -1 means don't cancel
-  int maxFailedHits_;
+    bool isTrackPrepared(const Track* tr, const AbsTrackRep* rep) const;
+    bool isTrackFitted(const Track* tr, const AbsTrackRep* rep) const;
 
- public:
+    //! returns if the fitter can ignore the weights and handle the MeasurementOnPlanes as if they had weight 1.
+    bool canIgnoreWeights() const;
 
-  ClassDef(AbsKalmanFitter, 2)
+  protected:
 
-};
+    //! get the measurementsOnPlane taking the multipleMeasurementHandling_ into account
+    const std::vector<MeasurementOnPlane*> getMeasurements(const KalmanFitterInfo* fi, const TrackPoint* tp, int direction) const;
+
+    //! Minimum number of iterations to attempt.  Forward and backward are counted as one iteration.
+    unsigned int minIterations_;
+
+    //! Maximum number of iterations to attempt.  Forward and backward are counted as one iteration.
+    unsigned int maxIterations_;
+    /**
+     * @brief Convergence criterion
+     *
+     * if track total P-value changes less than this between consecutive iterations, consider the track converged.
+     * chi² from the backwards fit is used.
+     */
+    double deltaPval_;
+    /**
+     * @ brief Non-convergence criterion
+     *
+     * if the relative chi^2 between two iterations is larger than relChi2Change_, the fit is NOT converged and
+     * further iterations will be done, even if the deltaPval_ convergence criterium is met.
+     * This is especially useful for fits which have a p-value of almost 0 (possibly due to bad start values),
+     * where the p-value from one iteration to the next might not change much. However, a significant change in
+     * chi^2 tells us, that the fit might not yet be converged.
+     */
+    double relChi2Change_;
+
+    //! Blow up the covariance of the forward (backward) fit by this factor before seeding the backward (forward) fit.
+    double blowUpFactor_;
+    //! Reset the off-diagonals to 0 when blowing up the cov
+    bool resetOffDiagonals_;
+    //! Limit the cov entries to this maxuimum value when blowing up the cov.
+    double blowUpMaxVal_;
+
+    //! How to handle if there are multiple MeasurementsOnPlane
+    eMultipleMeasurementHandling multipleMeasurementHandling_;
+
+    //! after how many failed hits (exception during construction of plane, extrapolation etc.) should the fit be cancelled.
+    //! -1 means don't cancel
+    int maxFailedHits_;
+
+  public:
+
+    ClassDef(AbsKalmanFitter, 2)
+
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/fitters/include/DAF.h
+++ b/fitters/include/DAF.h
@@ -32,98 +32,98 @@
 
 namespace genfit {
 
-/** @brief Determinstic Annealing Filter (DAF) implementation.
- *
- * @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
- * @author Karl Bicker (Technische Universit&auml;t M&uuml;nchen)
- *
- * The DAF is an iterative Kalman filter with annealing. It is capable of
- * fitting tracks which are contaminated with noise hits. The algorithm is
- * taken from the references R. Fruehwirth & A. Strandlie, Computer Physics
- * Communications 120 (1999) 197-214 and CERN thesis: Dissertation by Matthias
- * Winkler.
- *
- * The weights which were assigned to the hits by the DAF are accessible in the MeasurementOnPlane objects
- * in the KalmanFitterInfo objects.
- */
-class DAF : public AbsKalmanFitter {
-
- private:
-
-  DAF(const DAF&);
-  DAF& operator=(genfit::DAF const&);
-
- public:
-
-  /**
-   * @brief Create DAF. Per default, use KalmanFitterRefTrack as fitter.
+  /** @brief Determinstic Annealing Filter (DAF) implementation.
    *
-   * @param useRefKalman If false, use KalmanFitter as fitter.
-   */
-  DAF(bool useRefKalman = true, double deltaPval = 1e-3, double deltaWeight = 1e-3);
-  /**
-   * @brief Create DAF. Use the provided AbsKalmanFitter as fitter.
-   */
-  DAF(AbsKalmanFitter* kalman, double deltaPval = 1e-3, double deltaWeight = 1e-3);
-  ~DAF() {};
-
-  //! Process a track using the DAF.
-  void processTrackWithRep(Track* tr, const AbsTrackRep* rep, bool resortHits = false) override;
-
-  /** @brief Set the probability cut for the weight calculation for the hits.
+   * @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
+   * @author Karl Bicker (Technische Universit&auml;t M&uuml;nchen)
    *
-   * By default the cut values for measurements of dimensionality from 1 to 5 are calculated.
-   * If you what to have cut values for an arbitrary measurement dimensionality use
-   * addProbCut(double prob_cut, int maxDim);
-   */
-  void setProbCut(const double prob_cut);
-
-  //! Set the probability cut for the weight calculation for the hits for a specific measurement dimensionality.
-  void addProbCut(const double prob_cut, const int measDim);
-
-  const std::vector<double>& getBetas() const {return betas_;}
-
-  /** @brief Configure the annealing scheme.
+   * The DAF is an iterative Kalman filter with annealing. It is capable of
+   * fitting tracks which are contaminated with noise hits. The algorithm is
+   * taken from the references R. Fruehwirth & A. Strandlie, Computer Physics
+   * Communications 120 (1999) 197-214 and CERN thesis: Dissertation by Matthias
+   * Winkler.
    *
-   * Set a start and end temperature and the number of steps. A logarithmic sequence of temperatures will be calculated.
-   * Also sets #minIterations_ and #maxIterations_.
+   * The weights which were assigned to the hits by the DAF are accessible in the MeasurementOnPlane objects
+   * in the KalmanFitterInfo objects.
    */
-  void setAnnealingScheme(double bStart, double bFinal, unsigned int nSteps);
+  class DAF : public AbsKalmanFitter {
 
-  void setMaxIterations(unsigned int n) override {maxIterations_ = n; betas_.resize(maxIterations_,betas_.back());}
+  private:
 
-  //! If all weights change less than delta between two iterations, the fit is regarded as converged.
-  void setConvergenceDeltaWeight(double delta) {deltaWeight_ = delta;}
+    DAF(const DAF&);
+    DAF& operator=(genfit::DAF const&);
 
-  AbsKalmanFitter* getKalman() const {return kalman_.get();}
+  public:
 
-  virtual void setMaxFailedHits(int val) override {getKalman()->setMaxFailedHits(val);}
+    /**
+     * @brief Create DAF. Per default, use KalmanFitterRefTrack as fitter.
+     *
+     * @param useRefKalman If false, use KalmanFitter as fitter.
+     */
+    DAF(bool useRefKalman = true, double deltaPval = 1e-3, double deltaWeight = 1e-3);
+    /**
+     * @brief Create DAF. Use the provided AbsKalmanFitter as fitter.
+     */
+    DAF(AbsKalmanFitter* kalman, double deltaPval = 1e-3, double deltaWeight = 1e-3);
+    ~DAF() {};
 
-  virtual void setDebugLvl(unsigned int lvl = 1) override {AbsFitter::setDebugLvl(lvl); if (lvl > 1) getKalman()->setDebugLvl(lvl-1);}
+    //! Process a track using the DAF.
+    void processTrackWithRep(Track* tr, const AbsTrackRep* rep, bool resortHits = false) override;
 
- private:
+    /** @brief Set the probability cut for the weight calculation for the hits.
+     *
+     * By default the cut values for measurements of dimensionality from 1 to 5 are calculated.
+     * If you what to have cut values for an arbitrary measurement dimensionality use
+     * addProbCut(double prob_cut, int maxDim);
+     */
+    void setProbCut(const double prob_cut);
 
-  /** @brief Calculate and set the weights for the next fitting pass.
-   * Return if convergence is met.
-   * The convergence criterium is the largest absolute change of all weights.
-    */
-  bool calcWeights(Track* trk, const AbsTrackRep* rep, double beta);
+    //! Set the probability cut for the weight calculation for the hits for a specific measurement dimensionality.
+    void addProbCut(const double prob_cut, const int measDim);
+
+    const std::vector<double>& getBetas() const {return betas_;}
+
+    /** @brief Configure the annealing scheme.
+     *
+     * Set a start and end temperature and the number of steps. A logarithmic sequence of temperatures will be calculated.
+     * Also sets #minIterations_ and #maxIterations_.
+     */
+    void setAnnealingScheme(double bStart, double bFinal, unsigned int nSteps);
+
+    void setMaxIterations(unsigned int n) override {maxIterations_ = n; betas_.resize(maxIterations_, betas_.back());}
+
+    //! If all weights change less than delta between two iterations, the fit is regarded as converged.
+    void setConvergenceDeltaWeight(double delta) {deltaWeight_ = delta;}
+
+    AbsKalmanFitter* getKalman() const {return kalman_.get();}
+
+    virtual void setMaxFailedHits(int val) override {getKalman()->setMaxFailedHits(val);}
+
+    virtual void setDebugLvl(unsigned int lvl = 1) override {AbsFitter::setDebugLvl(lvl); if (lvl > 1) getKalman()->setDebugLvl(lvl - 1);}
+
+  private:
+
+    /** @brief Calculate and set the weights for the next fitting pass.
+     * Return if convergence is met.
+     * The convergence criterium is the largest absolute change of all weights.
+      */
+    bool calcWeights(Track* trk, const AbsTrackRep* rep, double beta);
 
 
-  double deltaWeight_; // convergence criterium
-  std::vector<double> betas_;   // Temperatures, NOT inverse temperatures.
-  double chi2Cuts_[7];  // '7' assumes tracks are helices with one
-			// parameter, i.e. we're living in 3D space,
-			// where time may be used in the fit.  Zeroth
-			// entry is not used.
+    double deltaWeight_; // convergence criterium
+    std::vector<double> betas_;   // Temperatures, NOT inverse temperatures.
+    double chi2Cuts_[7];  // '7' assumes tracks are helices with one
+    // parameter, i.e. we're living in 3D space,
+    // where time may be used in the fit.  Zeroth
+    // entry is not used.
 
-  std::unique_ptr<AbsKalmanFitter> kalman_;
+    std::unique_ptr<AbsKalmanFitter> kalman_;
 
- public:
+  public:
 
-  ClassDefOverride(DAF,2)
+    ClassDefOverride(DAF, 2)
 
-};
+  };
 
 }  /* End of namespace genfit */
 /** @} */

--- a/fitters/include/KalmanFitStatus.h
+++ b/fitters/include/KalmanFitStatus.h
@@ -30,61 +30,61 @@
 
 namespace genfit {
 
-/**
- * @brief FitStatus for use with AbsKalmanFitter implementations
- */
-class KalmanFitStatus : public FitStatus {
+  /**
+   * @brief FitStatus for use with AbsKalmanFitter implementations
+   */
+  class KalmanFitStatus : public FitStatus {
 
- public:
+  public:
 
-  KalmanFitStatus() :
-    FitStatus(), numIterations_(0), fittedWithDaf_(false), fittedWithReferenceTrack_(false),
-    trackLen_(0), fChi2_(-1e99), fNdf_(-1e99), fPval_(-1e99) {;}
+    KalmanFitStatus() :
+      FitStatus(), numIterations_(0), fittedWithDaf_(false), fittedWithReferenceTrack_(false),
+      trackLen_(0), fChi2_(-1e99), fNdf_(-1e99), fPval_(-1e99) {;}
 
-  virtual ~KalmanFitStatus() {};
+    virtual ~KalmanFitStatus() {};
 
-  virtual FitStatus* clone() const override {return new KalmanFitStatus(*this);}
+    virtual FitStatus* clone() const override {return new KalmanFitStatus(*this);}
 
-  unsigned int getNumIterations() const {return numIterations_;}
-  bool isFittedWithDaf() const {return fittedWithDaf_;}
-  bool isFittedWithReferenceTrack() const {return fittedWithReferenceTrack_;}
-  double getTrackLen() const {return trackLen_;}
-  double getForwardChi2() const {return fChi2_;}
-  double getBackwardChi2() const {return FitStatus::getChi2();}
-  double getForwardNdf() const {return fNdf_;}
-  double getBackwardNdf() const {return FitStatus::getNdf();}
-  // virtual double getPVal() : not overridden, as it does the right thing.
-  double getForwardPVal() const {return std::max(0.,ROOT::Math::chisquared_cdf_c(fChi2_, fNdf_));}
-  double getBackwardPVal() const {return FitStatus::getPVal(); }
+    unsigned int getNumIterations() const {return numIterations_;}
+    bool isFittedWithDaf() const {return fittedWithDaf_;}
+    bool isFittedWithReferenceTrack() const {return fittedWithReferenceTrack_;}
+    double getTrackLen() const {return trackLen_;}
+    double getForwardChi2() const {return fChi2_;}
+    double getBackwardChi2() const {return FitStatus::getChi2();}
+    double getForwardNdf() const {return fNdf_;}
+    double getBackwardNdf() const {return FitStatus::getNdf();}
+    // virtual double getPVal() : not overridden, as it does the right thing.
+    double getForwardPVal() const {return std::max(0., ROOT::Math::chisquared_cdf_c(fChi2_, fNdf_));}
+    double getBackwardPVal() const {return FitStatus::getPVal(); }
 
-  void setNumIterations(unsigned int numIterations) {numIterations_ = numIterations;}
-  void setIsFittedWithDaf(bool fittedWithDaf = true) {fittedWithDaf_ = fittedWithDaf;}
-  void setIsFittedWithReferenceTrack(bool fittedWithReferenceTrack = true) {fittedWithReferenceTrack_ = fittedWithReferenceTrack;}
-  void setTrackLen(double trackLen) {trackLen_ = trackLen;}
-  void setForwardChi2(double fChi2) {fChi2_ = fChi2;}
-  void setBackwardChi2(double bChi2) {FitStatus::setChi2(bChi2);}
-  void setForwardNdf(double fNdf) {fNdf_ = fNdf;}
-  void setBackwardNdf(double bNdf) {FitStatus::setNdf(bNdf);}
+    void setNumIterations(unsigned int numIterations) {numIterations_ = numIterations;}
+    void setIsFittedWithDaf(bool fittedWithDaf = true) {fittedWithDaf_ = fittedWithDaf;}
+    void setIsFittedWithReferenceTrack(bool fittedWithReferenceTrack = true) {fittedWithReferenceTrack_ = fittedWithReferenceTrack;}
+    void setTrackLen(double trackLen) {trackLen_ = trackLen;}
+    void setForwardChi2(double fChi2) {fChi2_ = fChi2;}
+    void setBackwardChi2(double bChi2) {FitStatus::setChi2(bChi2);}
+    void setForwardNdf(double fNdf) {fNdf_ = fNdf;}
+    void setBackwardNdf(double bNdf) {FitStatus::setNdf(bNdf);}
 
-  virtual void Print(const Option_t* = "") const override;
+    virtual void Print(const Option_t* = "") const override;
 
- protected:
+  protected:
 
-  unsigned int numIterations_; // number of iterations that have been performed
-  bool fittedWithDaf_;
-  bool fittedWithReferenceTrack_;
+    unsigned int numIterations_; // number of iterations that have been performed
+    bool fittedWithDaf_;
+    bool fittedWithReferenceTrack_;
 
-  double trackLen_;
+    double trackLen_;
 
-  double fChi2_; // chi^2 of the forward fit
-  double fNdf_; // degrees of freedom of the forward fit
-  double fPval_; // p-value of the forward fit, set whenever either of chi2 or ndf changes
+    double fChi2_; // chi^2 of the forward fit
+    double fNdf_; // degrees of freedom of the forward fit
+    double fPval_; // p-value of the forward fit, set whenever either of chi2 or ndf changes
 
- public:
+  public:
 
-  ClassDefOverride(KalmanFitStatus, 1)
+    ClassDefOverride(KalmanFitStatus, 1)
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/fitters/include/KalmanFittedStateOnPlane.h
+++ b/fitters/include/KalmanFittedStateOnPlane.h
@@ -29,80 +29,87 @@
 namespace genfit {
 
 
-/**
- *  @brief #MeasuredStateOnPlane with additional info produced by a Kalman filter or DAF.
- */
-class KalmanFittedStateOnPlane : public MeasuredStateOnPlane {
+  /**
+   *  @brief #MeasuredStateOnPlane with additional info produced by a Kalman filter or DAF.
+   */
+  class KalmanFittedStateOnPlane : public MeasuredStateOnPlane {
 
- public:
+  public:
 
-  KalmanFittedStateOnPlane();
-  KalmanFittedStateOnPlane(const KalmanFittedStateOnPlane&) = default;
-  KalmanFittedStateOnPlane(const TVectorD& state, const TMatrixDSym& cov, const SharedPlanePtr& plane, const AbsTrackRep* rep, double chiSquareIncrement, double ndf);
-  KalmanFittedStateOnPlane(const TVectorD& state, const TMatrixDSym& cov, const SharedPlanePtr& plane, const AbsTrackRep* rep, const TVectorD& auxInfo, double chiSquareIncrement, double ndf);
-  KalmanFittedStateOnPlane(const MeasuredStateOnPlane& state, double chiSquareIncrement, double ndf);
+    KalmanFittedStateOnPlane();
+    KalmanFittedStateOnPlane(const KalmanFittedStateOnPlane&) = default;
+    KalmanFittedStateOnPlane(const TVectorD& state, const TMatrixDSym& cov, const SharedPlanePtr& plane, const AbsTrackRep* rep,
+                             double chiSquareIncrement, double ndf);
+    KalmanFittedStateOnPlane(const TVectorD& state, const TMatrixDSym& cov, const SharedPlanePtr& plane, const AbsTrackRep* rep,
+                             const TVectorD& auxInfo, double chiSquareIncrement, double ndf);
+    KalmanFittedStateOnPlane(const MeasuredStateOnPlane& state, double chiSquareIncrement, double ndf);
 
-  KalmanFittedStateOnPlane& operator=(KalmanFittedStateOnPlane other);
-  void swap(KalmanFittedStateOnPlane& other); // nothrow
+    KalmanFittedStateOnPlane& operator=(KalmanFittedStateOnPlane other);
+    void swap(KalmanFittedStateOnPlane& other); // nothrow
 
-  virtual ~KalmanFittedStateOnPlane() {}
+    virtual ~KalmanFittedStateOnPlane() {}
 
-  double getChiSquareIncrement() const {return chiSquareIncrement_;}
-  double getNdf() const {return ndf_;}
+    double getChiSquareIncrement() const {return chiSquareIncrement_;}
+    double getNdf() const {return ndf_;}
 
-  void setChiSquareIncrement(double chiSquareIncrement) {chiSquareIncrement_ = chiSquareIncrement;}
-  void setNdf(double ndf) {ndf_ = ndf;}
-
-
- protected:
-
-  double chiSquareIncrement_;
-  
-  //! Degrees of freedom. Needs to be a double because of DAF.
-  double ndf_;
+    void setChiSquareIncrement(double chiSquareIncrement) {chiSquareIncrement_ = chiSquareIncrement;}
+    void setNdf(double ndf) {ndf_ = ndf;}
 
 
- public:
+  protected:
 
-  ClassDef(KalmanFittedStateOnPlane,1)
+    double chiSquareIncrement_;
 
-};
+    //! Degrees of freedom. Needs to be a double because of DAF.
+    double ndf_;
 
 
-inline KalmanFittedStateOnPlane::KalmanFittedStateOnPlane() :
-  MeasuredStateOnPlane(), chiSquareIncrement_(0), ndf_(0)
-{
-  ;
-}
+  public:
 
-inline KalmanFittedStateOnPlane::KalmanFittedStateOnPlane(const TVectorD& state, const TMatrixDSym& cov, const SharedPlanePtr& plane, const AbsTrackRep* rep, double chiSquareIncrement, double ndf) :
-  MeasuredStateOnPlane(state, cov, plane, rep), chiSquareIncrement_(chiSquareIncrement), ndf_(ndf)
-{
-  ;
-}
+    ClassDef(KalmanFittedStateOnPlane, 1)
 
-inline KalmanFittedStateOnPlane::KalmanFittedStateOnPlane(const TVectorD& state, const TMatrixDSym& cov, const SharedPlanePtr& plane, const AbsTrackRep* rep, const TVectorD& auxInfo, double chiSquareIncrement, double ndf) :
-  MeasuredStateOnPlane(state, cov, plane, rep, auxInfo), chiSquareIncrement_(chiSquareIncrement), ndf_(ndf)
-{
-  ;
-}
+  };
 
-inline KalmanFittedStateOnPlane::KalmanFittedStateOnPlane(const MeasuredStateOnPlane& state, double chiSquareIncrement, double ndf) :
-  MeasuredStateOnPlane(state), chiSquareIncrement_(chiSquareIncrement), ndf_(ndf)
-{
-  ;
-}
 
-inline KalmanFittedStateOnPlane& KalmanFittedStateOnPlane::operator=(KalmanFittedStateOnPlane other) {
-  swap(other);
-  return *this;
-}
+  inline KalmanFittedStateOnPlane::KalmanFittedStateOnPlane() :
+    MeasuredStateOnPlane(), chiSquareIncrement_(0), ndf_(0)
+  {
+    ;
+  }
 
-inline void KalmanFittedStateOnPlane::swap(KalmanFittedStateOnPlane& other) {
-  MeasuredStateOnPlane::swap(other);
-  std::swap(this->chiSquareIncrement_, other.chiSquareIncrement_);
-  std::swap(this->ndf_, other.ndf_);
-}
+  inline KalmanFittedStateOnPlane::KalmanFittedStateOnPlane(const TVectorD& state, const TMatrixDSym& cov,
+                                                            const SharedPlanePtr& plane, const AbsTrackRep* rep, double chiSquareIncrement, double ndf) :
+    MeasuredStateOnPlane(state, cov, plane, rep), chiSquareIncrement_(chiSquareIncrement), ndf_(ndf)
+  {
+    ;
+  }
+
+  inline KalmanFittedStateOnPlane::KalmanFittedStateOnPlane(const TVectorD& state, const TMatrixDSym& cov,
+                                                            const SharedPlanePtr& plane, const AbsTrackRep* rep, const TVectorD& auxInfo, double chiSquareIncrement, double ndf) :
+    MeasuredStateOnPlane(state, cov, plane, rep, auxInfo), chiSquareIncrement_(chiSquareIncrement), ndf_(ndf)
+  {
+    ;
+  }
+
+  inline KalmanFittedStateOnPlane::KalmanFittedStateOnPlane(const MeasuredStateOnPlane& state, double chiSquareIncrement,
+                                                            double ndf) :
+    MeasuredStateOnPlane(state), chiSquareIncrement_(chiSquareIncrement), ndf_(ndf)
+  {
+    ;
+  }
+
+  inline KalmanFittedStateOnPlane& KalmanFittedStateOnPlane::operator=(KalmanFittedStateOnPlane other)
+  {
+    swap(other);
+    return *this;
+  }
+
+  inline void KalmanFittedStateOnPlane::swap(KalmanFittedStateOnPlane& other)
+  {
+    MeasuredStateOnPlane::swap(other);
+    std::swap(this->chiSquareIncrement_, other.chiSquareIncrement_);
+    std::swap(this->ndf_, other.ndf_);
+  }
 
 } /* End of namespace genfit */
 /** @} */

--- a/fitters/include/KalmanFitter.h
+++ b/fitters/include/KalmanFitter.h
@@ -30,52 +30,52 @@
 
 namespace genfit {
 
-class KalmanFitterInfo;
-class MeasuredStateOnPlane;
-class TrackPoint;
+  class KalmanFitterInfo;
+  class MeasuredStateOnPlane;
+  class TrackPoint;
 
-/**
- * @brief Simple Kalman filter implementation.
- */
-class KalmanFitter : public AbsKalmanFitter {
+  /**
+   * @brief Simple Kalman filter implementation.
+   */
+  class KalmanFitter : public AbsKalmanFitter {
 
- private:
+  private:
 
-  // These private functions are needed, otherwise strange things happen, no idea why!
-  KalmanFitter(const KalmanFitter&);
-  KalmanFitter& operator=(KalmanFitter const&);
+    // These private functions are needed, otherwise strange things happen, no idea why!
+    KalmanFitter(const KalmanFitter&);
+    KalmanFitter& operator=(KalmanFitter const&);
 
- public:
+  public:
 
-  KalmanFitter(unsigned int maxIterations = 4, double deltaPval = 1e-3, double blowUpFactor = 1e3, bool squareRootFormalism = false)
-    : AbsKalmanFitter(maxIterations, deltaPval, blowUpFactor), currentState_(nullptr),
-      squareRootFormalism_(squareRootFormalism)
-  {}
+    KalmanFitter(unsigned int maxIterations = 4, double deltaPval = 1e-3, double blowUpFactor = 1e3, bool squareRootFormalism = false)
+      : AbsKalmanFitter(maxIterations, deltaPval, blowUpFactor), currentState_(nullptr),
+        squareRootFormalism_(squareRootFormalism)
+    {}
 
-  ~KalmanFitter() {}
+    ~KalmanFitter() {}
 
-  //! Hit resorting currently NOT supported.
-  void processTrackWithRep(Track* tr, const AbsTrackRep* rep, bool resortHits = false) override;
+    //! Hit resorting currently NOT supported.
+    void processTrackWithRep(Track* tr, const AbsTrackRep* rep, bool resortHits = false) override;
 
-  //! process only a part of the track. Can also be used to process the track only in backward direction.
-  //! Does not alter the FitStatus and does not do multiple iterations.
-  void processTrackPartially(Track* tr, const AbsTrackRep* rep, int startId = 0, int endId = -1);
+    //! process only a part of the track. Can also be used to process the track only in backward direction.
+    //! Does not alter the FitStatus and does not do multiple iterations.
+    void processTrackPartially(Track* tr, const AbsTrackRep* rep, int startId = 0, int endId = -1);
 
-  void useSquareRootFormalism(bool squareRootFormalism = true) {squareRootFormalism_ = squareRootFormalism;}
+    void useSquareRootFormalism(bool squareRootFormalism = true) {squareRootFormalism_ = squareRootFormalism;}
 
- private:
-  bool fitTrack(Track* tr, const AbsTrackRep* rep, double& chi2, double& ndf, int startId, int endId, int& nFailedHits);
-  void processTrackPoint(TrackPoint* tp,
-      const AbsTrackRep* rep, double& chi2, double& ndf, int direction);
+  private:
+    bool fitTrack(Track* tr, const AbsTrackRep* rep, double& chi2, double& ndf, int startId, int endId, int& nFailedHits);
+    void processTrackPoint(TrackPoint* tp,
+                           const AbsTrackRep* rep, double& chi2, double& ndf, int direction);
 
-  std::unique_ptr<MeasuredStateOnPlane> currentState_;
+    std::unique_ptr<MeasuredStateOnPlane> currentState_;
 
-  bool squareRootFormalism_;
+    bool squareRootFormalism_;
 
- public:
-  ClassDefOverride(KalmanFitter,1)
+  public:
+    ClassDefOverride(KalmanFitter, 1)
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/fitters/include/KalmanFitterInfo.h
+++ b/fitters/include/KalmanFitterInfo.h
@@ -38,110 +38,112 @@
 namespace genfit {
 
 
-/**
- *  @brief Collects information needed and produced by a AbsKalmanFitter implementations and is specific to one AbsTrackRep of the Track.
- */
-class KalmanFitterInfo : public AbsFitterInfo {
+  /**
+   *  @brief Collects information needed and produced by a AbsKalmanFitter implementations and is specific to one AbsTrackRep of the Track.
+   */
+  class KalmanFitterInfo : public AbsFitterInfo {
 
- public:
+  public:
 
-  KalmanFitterInfo();
-  KalmanFitterInfo(const TrackPoint* trackPoint, const AbsTrackRep* rep);
-  virtual ~KalmanFitterInfo();
+    KalmanFitterInfo();
+    KalmanFitterInfo(const TrackPoint* trackPoint, const AbsTrackRep* rep);
+    virtual ~KalmanFitterInfo();
 
-  virtual KalmanFitterInfo* clone() const override;
+    virtual KalmanFitterInfo* clone() const override;
 
-  ReferenceStateOnPlane* getReferenceState() const {return referenceState_.get();}
-  MeasuredStateOnPlane* getForwardPrediction() const {return forwardPrediction_.get();}
-  MeasuredStateOnPlane* getBackwardPrediction() const {return backwardPrediction_.get();}
-  MeasuredStateOnPlane* getPrediction(int direction) const {if (direction >=0) return forwardPrediction_.get(); return backwardPrediction_.get();}
-  KalmanFittedStateOnPlane* getForwardUpdate() const {return forwardUpdate_.get();}
-  KalmanFittedStateOnPlane* getBackwardUpdate() const {return backwardUpdate_.get();}
-  KalmanFittedStateOnPlane* getUpdate(int direction) const {if (direction >=0) return forwardUpdate_.get(); return backwardUpdate_.get();}
-  const std::vector< genfit::MeasurementOnPlane* >& getMeasurementsOnPlane() const {return measurementsOnPlane_;}
-  MeasurementOnPlane* getMeasurementOnPlane(int i = 0) const {if (i<0) i += measurementsOnPlane_.size(); return measurementsOnPlane_.at(i);}
-  //! Get weighted mean of all measurements.
-  //! @param ignoreWeights If set, the weights of the individual measurements will be ignored (they will be treated as if they all had weight 1)
-  MeasurementOnPlane getAvgWeightedMeasurementOnPlane(bool ignoreWeights = false) const;
-  //! Get measurements which is closest to state.
-  MeasurementOnPlane* getClosestMeasurementOnPlane(const StateOnPlane*) const;
-  unsigned int getNumMeasurements() const {return measurementsOnPlane_.size();}
-  //! Get weights of measurements.
-  std::vector<double> getWeights() const;
-  //! Are the weights fixed?
-  bool areWeightsFixed() const {return fixWeights_;}
-  //! Get unbiased or biased (default) smoothed state.
-  const MeasuredStateOnPlane& getFittedState(bool biased = true) const override;
-  //! Get unbiased (default) or biased residual from ith measurement.
-  MeasurementOnPlane getResidual(unsigned int iMeasurement = 0, bool biased = false, bool onlyMeasurementErrors = true) const override; // calculate residual, track and measurement errors are added if onlyMeasurementErrors is false
-  double getSmoothedChi2(unsigned int iMeasurement = 0) const;
+    ReferenceStateOnPlane* getReferenceState() const {return referenceState_.get();}
+    MeasuredStateOnPlane* getForwardPrediction() const {return forwardPrediction_.get();}
+    MeasuredStateOnPlane* getBackwardPrediction() const {return backwardPrediction_.get();}
+    MeasuredStateOnPlane* getPrediction(int direction) const {if (direction >= 0) return forwardPrediction_.get(); return backwardPrediction_.get();}
+    KalmanFittedStateOnPlane* getForwardUpdate() const {return forwardUpdate_.get();}
+    KalmanFittedStateOnPlane* getBackwardUpdate() const {return backwardUpdate_.get();}
+    KalmanFittedStateOnPlane* getUpdate(int direction) const {if (direction >= 0) return forwardUpdate_.get(); return backwardUpdate_.get();}
+    const std::vector< genfit::MeasurementOnPlane* >& getMeasurementsOnPlane() const {return measurementsOnPlane_;}
+    MeasurementOnPlane* getMeasurementOnPlane(int i = 0) const {if (i < 0) i += measurementsOnPlane_.size(); return measurementsOnPlane_.at(i);}
+    //! Get weighted mean of all measurements.
+    //! @param ignoreWeights If set, the weights of the individual measurements will be ignored (they will be treated as if they all had weight 1)
+    MeasurementOnPlane getAvgWeightedMeasurementOnPlane(bool ignoreWeights = false) const;
+    //! Get measurements which is closest to state.
+    MeasurementOnPlane* getClosestMeasurementOnPlane(const StateOnPlane*) const;
+    unsigned int getNumMeasurements() const {return measurementsOnPlane_.size();}
+    //! Get weights of measurements.
+    std::vector<double> getWeights() const;
+    //! Are the weights fixed?
+    bool areWeightsFixed() const {return fixWeights_;}
+    //! Get unbiased or biased (default) smoothed state.
+    const MeasuredStateOnPlane& getFittedState(bool biased = true) const override;
+    //! Get unbiased (default) or biased residual from ith measurement.
+    MeasurementOnPlane getResidual(unsigned int iMeasurement = 0, bool biased = false,
+                                   bool onlyMeasurementErrors = true) const
+    override; // calculate residual, track and measurement errors are added if onlyMeasurementErrors is false
+    double getSmoothedChi2(unsigned int iMeasurement = 0) const;
 
-  bool hasMeasurements() const override {return getNumMeasurements() > 0;}
-  bool hasReferenceState() const override {return (referenceState_.get() != nullptr);}
-  bool hasForwardPrediction() const override {return (forwardPrediction_.get()  != nullptr);}
-  bool hasBackwardPrediction() const override {return (backwardPrediction_.get() != nullptr);}
-  bool hasForwardUpdate() const override {return (forwardUpdate_.get() != nullptr);}
-  bool hasBackwardUpdate() const override {return (backwardUpdate_.get() != nullptr);}
-  bool hasUpdate(int direction) const override {if (direction < 0) return hasBackwardUpdate(); return hasForwardUpdate();}
-  bool hasPredictionsAndUpdates() const {return (hasForwardPrediction() && hasBackwardPrediction() && hasForwardUpdate() && hasBackwardUpdate());}
+    bool hasMeasurements() const override {return getNumMeasurements() > 0;}
+    bool hasReferenceState() const override {return (referenceState_.get() != nullptr);}
+    bool hasForwardPrediction() const override {return (forwardPrediction_.get()  != nullptr);}
+    bool hasBackwardPrediction() const override {return (backwardPrediction_.get() != nullptr);}
+    bool hasForwardUpdate() const override {return (forwardUpdate_.get() != nullptr);}
+    bool hasBackwardUpdate() const override {return (backwardUpdate_.get() != nullptr);}
+    bool hasUpdate(int direction) const override {if (direction < 0) return hasBackwardUpdate(); return hasForwardUpdate();}
+    bool hasPredictionsAndUpdates() const {return (hasForwardPrediction() && hasBackwardPrediction() && hasForwardUpdate() && hasBackwardUpdate());}
 
-  void setReferenceState(ReferenceStateOnPlane* referenceState);
-  void setForwardPrediction(MeasuredStateOnPlane* forwardPrediction);
-  void setBackwardPrediction(MeasuredStateOnPlane* backwardPrediction);
-  void setPrediction(MeasuredStateOnPlane* prediction, int direction)  {if (direction >=0) setForwardPrediction(prediction); else setBackwardPrediction(prediction);}
-  void setForwardUpdate(KalmanFittedStateOnPlane* forwardUpdate);
-  void setBackwardUpdate(KalmanFittedStateOnPlane* backwardUpdate);
-  void setUpdate(KalmanFittedStateOnPlane* update, int direction)  {if (direction >=0) setForwardUpdate(update); else setBackwardUpdate(update);}
-  void setMeasurementsOnPlane(const std::vector< genfit::MeasurementOnPlane* >& measurementsOnPlane);
-  void addMeasurementOnPlane(MeasurementOnPlane* measurementOnPlane);
-  void addMeasurementsOnPlane(const std::vector< genfit::MeasurementOnPlane* >& measurementsOnPlane);
-  //! Set weights of measurements.
-  void setWeights(const std::vector<double>&);
-  void fixWeights(bool arg = true) {fixWeights_ = arg;}
-  void setRep(const AbsTrackRep* rep) override;
+    void setReferenceState(ReferenceStateOnPlane* referenceState);
+    void setForwardPrediction(MeasuredStateOnPlane* forwardPrediction);
+    void setBackwardPrediction(MeasuredStateOnPlane* backwardPrediction);
+    void setPrediction(MeasuredStateOnPlane* prediction, int direction)  {if (direction >= 0) setForwardPrediction(prediction); else setBackwardPrediction(prediction);}
+    void setForwardUpdate(KalmanFittedStateOnPlane* forwardUpdate);
+    void setBackwardUpdate(KalmanFittedStateOnPlane* backwardUpdate);
+    void setUpdate(KalmanFittedStateOnPlane* update, int direction)  {if (direction >= 0) setForwardUpdate(update); else setBackwardUpdate(update);}
+    void setMeasurementsOnPlane(const std::vector< genfit::MeasurementOnPlane* >& measurementsOnPlane);
+    void addMeasurementOnPlane(MeasurementOnPlane* measurementOnPlane);
+    void addMeasurementsOnPlane(const std::vector< genfit::MeasurementOnPlane* >& measurementsOnPlane);
+    //! Set weights of measurements.
+    void setWeights(const std::vector<double>&);
+    void fixWeights(bool arg = true) {fixWeights_ = arg;}
+    void setRep(const AbsTrackRep* rep) override;
 
-  void deleteForwardInfo() override;
-  void deleteBackwardInfo() override;
-  void deletePredictions();
-  void deleteReferenceInfo() override {setReferenceState(nullptr);}
-  void deleteMeasurementInfo() override;
+    void deleteForwardInfo() override;
+    void deleteBackwardInfo() override;
+    void deletePredictions();
+    void deleteReferenceInfo() override {setReferenceState(nullptr);}
+    void deleteMeasurementInfo() override;
 
-  virtual void Print(const Option_t* = "") const override;
+    virtual void Print(const Option_t* = "") const override;
 
-  virtual bool checkConsistency(const genfit::PruneFlags* = nullptr) const override;
+    virtual bool checkConsistency(const genfit::PruneFlags* = nullptr) const override;
 
- private:
+  private:
 
-  //! Reference state. Used by KalmanFitterRefTrack.
-  std::unique_ptr<ReferenceStateOnPlane> referenceState_; // Ownership
-  std::unique_ptr<MeasuredStateOnPlane> forwardPrediction_; // Ownership
-  std::unique_ptr<KalmanFittedStateOnPlane> forwardUpdate_; // Ownership
-  std::unique_ptr<MeasuredStateOnPlane> backwardPrediction_; // Ownership
-  std::unique_ptr<KalmanFittedStateOnPlane> backwardUpdate_; // Ownership
-  mutable std::unique_ptr<MeasuredStateOnPlane> fittedStateUnbiased_; //!  cache
-  mutable std::unique_ptr<MeasuredStateOnPlane> fittedStateBiased_; //!  cache
+    //! Reference state. Used by KalmanFitterRefTrack.
+    std::unique_ptr<ReferenceStateOnPlane> referenceState_; // Ownership
+    std::unique_ptr<MeasuredStateOnPlane> forwardPrediction_; // Ownership
+    std::unique_ptr<KalmanFittedStateOnPlane> forwardUpdate_; // Ownership
+    std::unique_ptr<MeasuredStateOnPlane> backwardPrediction_; // Ownership
+    std::unique_ptr<KalmanFittedStateOnPlane> backwardUpdate_; // Ownership
+    mutable std::unique_ptr<MeasuredStateOnPlane> fittedStateUnbiased_; //!  cache
+    mutable std::unique_ptr<MeasuredStateOnPlane> fittedStateBiased_; //!  cache
 
- //> TODO ! ptr implement: to the special ownership version
-  /* class owned_pointer_vector : private std::vector<MeasuredStateOnPlane*> {
-   public: 
-    ~owned_pointer_vector() { for (size_t i = 0; i < this->size(); ++i)
-                         delete this[i]; }
-    size_t size() const { return this->size(); };
-    void push_back(MeasuredStateOnPlane* measuredState) { this->push_back(measuredState); };
-    const  MeasuredStateOnPlane* at(size_t i)  const { return this->at(i); }; 
-	//owned_pointer_vector::iterator erase(owned_pointer_vector::iterator position) ;
-	//owned_pointer_vector::iterator erase(owned_pointer_vector::iterator first, owned_pointer_vector::iterator last);
-};
-	*/
+//> TODO ! ptr implement: to the special ownership version
+    /* class owned_pointer_vector : private std::vector<MeasuredStateOnPlane*> {
+     public:
+      ~owned_pointer_vector() { for (size_t i = 0; i < this->size(); ++i)
+                           delete this[i]; }
+      size_t size() const { return this->size(); };
+      void push_back(MeasuredStateOnPlane* measuredState) { this->push_back(measuredState); };
+      const  MeasuredStateOnPlane* at(size_t i)  const { return this->at(i); };
+    //owned_pointer_vector::iterator erase(owned_pointer_vector::iterator position) ;
+    //owned_pointer_vector::iterator erase(owned_pointer_vector::iterator first, owned_pointer_vector::iterator last);
+    };
+    */
 
-  std::vector<MeasurementOnPlane*> measurementsOnPlane_; // Ownership
-  bool fixWeights_; // weights should not be altered by fitters anymore
+    std::vector<MeasurementOnPlane*> measurementsOnPlane_; // Ownership
+    bool fixWeights_; // weights should not be altered by fitters anymore
 
- public:
+  public:
 
-  ClassDefOverride(KalmanFitterInfo,1)
+    ClassDefOverride(KalmanFitterInfo, 1)
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/fitters/include/KalmanFitterRefTrack.h
+++ b/fitters/include/KalmanFitterRefTrack.h
@@ -28,90 +28,92 @@
 
 namespace genfit {
 
-class KalmanFitterInfo;
-class TrackPoint;
-
-/**
- * @brief Kalman filter implementation with linearization around a reference track
- */
-class KalmanFitterRefTrack : public AbsKalmanFitter {
- public:
-  KalmanFitterRefTrack(unsigned int maxIterations = 4, double deltaPval = 1e-3, double blowUpFactor = 1e3,
-		       bool squareRootFormalism = false)
-    : AbsKalmanFitter(maxIterations, deltaPval, blowUpFactor), refitAll_(false), deltaChi2Ref_(1),
-      squareRootFormalism_(squareRootFormalism)
-  {}
-
-  virtual ~KalmanFitterRefTrack() {}
-
-  /** @brief Fit the track.
-   *
-   * Needs a prepared track! Return last TrackPoint that has been processed.
-   */
-  TrackPoint* fitTrack(Track* tr, const AbsTrackRep* rep, double& chi2, double& ndf, int direction);
-
-  void processTrackWithRep(Track* tr, const AbsTrackRep* rep, bool resortHits = false) override;
-
-  /** @brief Prepare the track
-   *
-   * Calc all reference states.
-   * If setSortingParams is true, the extrapolation lengths will be set as sorting parameters
-   * of the TrackPoints.
-   * Returns if the track has been changed.
-   */
-  bool prepareTrack(Track* tr, const AbsTrackRep* rep, bool setSortingParams, int& nFailedHits);
-
-  //! If true always refit all points, otherwise fit points only if reference states have changed
-  void setRefitAll(bool refit = true) {refitAll_ = refit;}
+  class KalmanFitterInfo;
+  class TrackPoint;
 
   /**
-   * When will the reference track be updated?
-   * If (smoothedState - referenceState) * smoothedCov^(-1) * (smoothedState - referenceState)^T >= deltaChi2Ref_.
+   * @brief Kalman filter implementation with linearization around a reference track
    */
-  void setDeltaChi2Ref(double dChi2) {deltaChi2Ref_ = dChi2;}
+  class KalmanFitterRefTrack : public AbsKalmanFitter {
+  public:
+    KalmanFitterRefTrack(unsigned int maxIterations = 4, double deltaPval = 1e-3, double blowUpFactor = 1e3,
+                         bool squareRootFormalism = false)
+      : AbsKalmanFitter(maxIterations, deltaPval, blowUpFactor), refitAll_(false), deltaChi2Ref_(1),
+        squareRootFormalism_(squareRootFormalism)
+    {}
 
- private:
-  void processTrackPoint(KalmanFitterInfo* fi, const KalmanFitterInfo* prevFi, const TrackPoint* tp, double& chi2, double& ndf, int direction);
-  void processTrackPointSqrt(KalmanFitterInfo* fi, const KalmanFitterInfo* prevFi, const TrackPoint* tp, double& chi2, double& ndf, int direction);
+    virtual ~KalmanFitterRefTrack() {}
 
-  /**
-   * @brief Remove referenceStates if they are too far from smoothed states.
-   *
-   * Does NOT remove forward and backward info, but returns from/to where they have to be removed later
-   * Return if anything has changed.
-   */
-  bool removeOutdated(Track* tr, const AbsTrackRep* rep, int& notChangedUntil, int& notChangedFrom);
+    /** @brief Fit the track.
+     *
+     * Needs a prepared track! Return last TrackPoint that has been processed.
+     */
+    TrackPoint* fitTrack(Track* tr, const AbsTrackRep* rep, double& chi2, double& ndf, int direction);
 
-  //! If refitAll_, remove all information.
-  void removeForwardBackwardInfo(Track* tr, const AbsTrackRep* rep, int notChangedUntil, int notChangedFrom) const;
+    void processTrackWithRep(Track* tr, const AbsTrackRep* rep, bool resortHits = false) override;
 
-  bool refitAll_; // always refit all points or only if reference states have changed
-  double deltaChi2Ref_; // reference track update cut
+    /** @brief Prepare the track
+     *
+     * Calc all reference states.
+     * If setSortingParams is true, the extrapolation lengths will be set as sorting parameters
+     * of the TrackPoints.
+     * Returns if the track has been changed.
+     */
+    bool prepareTrack(Track* tr, const AbsTrackRep* rep, bool setSortingParams, int& nFailedHits);
 
-  // aux variables for prepareTrack
-  TMatrixD FTransportMatrix_; //!
-  TMatrixD BTransportMatrix_; //!
-  TMatrixDSym FNoiseMatrix_; //!
-  TMatrixDSym BNoiseMatrix_; //!
-  TVectorD forwardDeltaState_; //!
-  TVectorD backwardDeltaState_; //!
+    //! If true always refit all points, otherwise fit points only if reference states have changed
+    void setRefitAll(bool refit = true) {refitAll_ = refit;}
 
-  // aux variables for processTrackPoint
-  TVectorD p_; //!
-  TMatrixDSym C_; //!
-  TMatrixDSym covSumInv_; //!
-  TMatrixDSym Rinv_; //!
-  TVectorD res_; //!
+    /**
+     * When will the reference track be updated?
+     * If (smoothedState - referenceState) * smoothedCov^(-1) * (smoothedState - referenceState)^T >= deltaChi2Ref_.
+     */
+    void setDeltaChi2Ref(double dChi2) {deltaChi2Ref_ = dChi2;}
 
-  // aux variables for removeOutdated
-  TVectorD resM_; //!
+  private:
+    void processTrackPoint(KalmanFitterInfo* fi, const KalmanFitterInfo* prevFi, const TrackPoint* tp, double& chi2, double& ndf,
+                           int direction);
+    void processTrackPointSqrt(KalmanFitterInfo* fi, const KalmanFitterInfo* prevFi, const TrackPoint* tp, double& chi2, double& ndf,
+                               int direction);
 
-  bool squareRootFormalism_;
+    /**
+     * @brief Remove referenceStates if they are too far from smoothed states.
+     *
+     * Does NOT remove forward and backward info, but returns from/to where they have to be removed later
+     * Return if anything has changed.
+     */
+    bool removeOutdated(Track* tr, const AbsTrackRep* rep, int& notChangedUntil, int& notChangedFrom);
 
- public:
-  ClassDefOverride(KalmanFitterRefTrack, 1)
+    //! If refitAll_, remove all information.
+    void removeForwardBackwardInfo(Track* tr, const AbsTrackRep* rep, int notChangedUntil, int notChangedFrom) const;
 
-};
+    bool refitAll_; // always refit all points or only if reference states have changed
+    double deltaChi2Ref_; // reference track update cut
+
+    // aux variables for prepareTrack
+    TMatrixD FTransportMatrix_; //!
+    TMatrixD BTransportMatrix_; //!
+    TMatrixDSym FNoiseMatrix_; //!
+    TMatrixDSym BNoiseMatrix_; //!
+    TVectorD forwardDeltaState_; //!
+    TVectorD backwardDeltaState_; //!
+
+    // aux variables for processTrackPoint
+    TVectorD p_; //!
+    TMatrixDSym C_; //!
+    TMatrixDSym covSumInv_; //!
+    TMatrixDSym Rinv_; //!
+    TVectorD res_; //!
+
+    // aux variables for removeOutdated
+    TVectorD resM_; //!
+
+    bool squareRootFormalism_;
+
+  public:
+    ClassDefOverride(KalmanFitterRefTrack, 1)
+
+  };
 
 }  /* End of namespace genfit */
 /** @} */

--- a/fitters/include/ReferenceStateOnPlane.h
+++ b/fitters/include/ReferenceStateOnPlane.h
@@ -29,84 +29,84 @@
 
 namespace genfit {
 
-/**
- * @brief #StateOnPlane with linearized transport to that #ReferenceStateOnPlane from previous and next #ReferenceStateOnPlane
- *
- * Transport matrices describe transport TO that plane.
- * We have transport matrix F, noise matrix N and delta state c.
- * Now, state p and covariance C follow this mathematics:
- *
- * p = F * p_old + c
- * C = F * C_old * F^T + N
- *
- */
-class ReferenceStateOnPlane : public StateOnPlane {
+  /**
+   * @brief #StateOnPlane with linearized transport to that #ReferenceStateOnPlane from previous and next #ReferenceStateOnPlane
+   *
+   * Transport matrices describe transport TO that plane.
+   * We have transport matrix F, noise matrix N and delta state c.
+   * Now, state p and covariance C follow this mathematics:
+   *
+   * p = F * p_old + c
+   * C = F * C_old * F^T + N
+   *
+   */
+  class ReferenceStateOnPlane : public StateOnPlane {
 
- public:
+  public:
 
-  ReferenceStateOnPlane();
-  ReferenceStateOnPlane(const TVectorD& state,
-      const SharedPlanePtr& plane,
-      const AbsTrackRep* rep);
-  ReferenceStateOnPlane(const TVectorD& state,
-      const SharedPlanePtr& plane,
-      const AbsTrackRep* rep,
-      const TVectorD& auxInfo);
-  ReferenceStateOnPlane(const StateOnPlane& state);
-  ReferenceStateOnPlane(const ReferenceStateOnPlane&) = default;
+    ReferenceStateOnPlane();
+    ReferenceStateOnPlane(const TVectorD& state,
+                          const SharedPlanePtr& plane,
+                          const AbsTrackRep* rep);
+    ReferenceStateOnPlane(const TVectorD& state,
+                          const SharedPlanePtr& plane,
+                          const AbsTrackRep* rep,
+                          const TVectorD& auxInfo);
+    ReferenceStateOnPlane(const StateOnPlane& state);
+    ReferenceStateOnPlane(const ReferenceStateOnPlane&) = default;
 
-  StateOnPlane& operator=(ReferenceStateOnPlane other);
-  void swap(ReferenceStateOnPlane& other); // nothrow
+    StateOnPlane& operator=(ReferenceStateOnPlane other);
+    void swap(ReferenceStateOnPlane& other); // nothrow
 
-  virtual ~ReferenceStateOnPlane() {}
+    virtual ~ReferenceStateOnPlane() {}
 
-  void setForwardSegmentLength(double len) {forwardSegmentLength_ = len;}
-  void setBackwardSegmentLength(double len) {backwardSegmentLength_ = len;}
-  void setForwardTransportMatrix(const TMatrixD& mat) {forwardTransportMatrix_.ResizeTo(mat); forwardTransportMatrix_=mat;}
-  void setBackwardTransportMatrix(const TMatrixD& mat) {backwardTransportMatrix_.ResizeTo(mat); backwardTransportMatrix_=mat;}
-  void setTransportMatrix(const TMatrixD& mat, int direction) {if (direction >= 0) setForwardTransportMatrix(mat); else setBackwardTransportMatrix(mat);}
-  void setForwardNoiseMatrix(const TMatrixDSym& mat) {forwardNoiseMatrix_.ResizeTo(mat); forwardNoiseMatrix_=mat;}
-  void setBackwardNoiseMatrix(const TMatrixDSym& mat) {backwardNoiseMatrix_.ResizeTo(mat); backwardNoiseMatrix_=mat;}
-  void setNoiseMatrix(const TMatrixDSym& mat, int direction) {if (direction >= 0) setForwardNoiseMatrix(mat); else setBackwardNoiseMatrix(mat);}
-  void setForwardDeltaState(const TVectorD& mat) {forwardDeltaState_.ResizeTo(mat); forwardDeltaState_=mat;}
-  void setBackwardDeltaState(const TVectorD& mat) {backwardDeltaState_.ResizeTo(mat); backwardDeltaState_=mat;}
-  void setDeltaState(const TVectorD& mat, int direction) {if (direction >= 0) setForwardDeltaState(mat); else setBackwardDeltaState(mat);}
-
-
-  double getForwardSegmentLength() const {return forwardSegmentLength_;}
-  double getBackwardSegmentLength() const {return backwardSegmentLength_;}
-  const TMatrixD& getForwardTransportMatrix() const {return forwardTransportMatrix_;}
-  const TMatrixD& getBackwardTransportMatrix() const {return backwardTransportMatrix_;}
-  const TMatrixD& getTransportMatrix(int direction) const {if (direction >= 0) return forwardTransportMatrix_; return backwardTransportMatrix_;}
-  const TMatrixDSym& getForwardNoiseMatrix() const {return forwardNoiseMatrix_;}
-  const TMatrixDSym& getBackwardNoiseMatrix() const {return backwardNoiseMatrix_;}
-  const TMatrixDSym& getNoiseMatrix(int direction) const {if (direction >= 0) return forwardNoiseMatrix_; return backwardNoiseMatrix_;}
-  const TVectorD& getForwardDeltaState() const {return forwardDeltaState_;}
-  const TVectorD& getBackwardDeltaState() const {return backwardDeltaState_;}
-  const TVectorD& getDeltaState(int direction) const {if (direction >= 0) return forwardDeltaState_; return backwardDeltaState_;}
-
-  void resetForward();
-  void resetBackward();
-
-  virtual void Print(Option_t* option = "") const override;
-
- protected:
-
-  double forwardSegmentLength_; /**< Segment length from previous referenceState */
-  double backwardSegmentLength_; /**< Segment length from next referenceState */
-  TMatrixD forwardTransportMatrix_; /**< transport matrix F from previous referenceState */
-  TMatrixD backwardTransportMatrix_; /**< transport matrix F from next referenceState */
-  TMatrixDSym forwardNoiseMatrix_; /**< noise matrix N for transport from previous referenceState */
-  TMatrixDSym backwardNoiseMatrix_; /**< noise matrix N for transport from next referenceState */
-  TVectorD forwardDeltaState_; /**< c */
-  TVectorD backwardDeltaState_; /**< c */
+    void setForwardSegmentLength(double len) {forwardSegmentLength_ = len;}
+    void setBackwardSegmentLength(double len) {backwardSegmentLength_ = len;}
+    void setForwardTransportMatrix(const TMatrixD& mat) {forwardTransportMatrix_.ResizeTo(mat); forwardTransportMatrix_ = mat;}
+    void setBackwardTransportMatrix(const TMatrixD& mat) {backwardTransportMatrix_.ResizeTo(mat); backwardTransportMatrix_ = mat;}
+    void setTransportMatrix(const TMatrixD& mat, int direction) {if (direction >= 0) setForwardTransportMatrix(mat); else setBackwardTransportMatrix(mat);}
+    void setForwardNoiseMatrix(const TMatrixDSym& mat) {forwardNoiseMatrix_.ResizeTo(mat); forwardNoiseMatrix_ = mat;}
+    void setBackwardNoiseMatrix(const TMatrixDSym& mat) {backwardNoiseMatrix_.ResizeTo(mat); backwardNoiseMatrix_ = mat;}
+    void setNoiseMatrix(const TMatrixDSym& mat, int direction) {if (direction >= 0) setForwardNoiseMatrix(mat); else setBackwardNoiseMatrix(mat);}
+    void setForwardDeltaState(const TVectorD& mat) {forwardDeltaState_.ResizeTo(mat); forwardDeltaState_ = mat;}
+    void setBackwardDeltaState(const TVectorD& mat) {backwardDeltaState_.ResizeTo(mat); backwardDeltaState_ = mat;}
+    void setDeltaState(const TVectorD& mat, int direction) {if (direction >= 0) setForwardDeltaState(mat); else setBackwardDeltaState(mat);}
 
 
- public:
+    double getForwardSegmentLength() const {return forwardSegmentLength_;}
+    double getBackwardSegmentLength() const {return backwardSegmentLength_;}
+    const TMatrixD& getForwardTransportMatrix() const {return forwardTransportMatrix_;}
+    const TMatrixD& getBackwardTransportMatrix() const {return backwardTransportMatrix_;}
+    const TMatrixD& getTransportMatrix(int direction) const {if (direction >= 0) return forwardTransportMatrix_; return backwardTransportMatrix_;}
+    const TMatrixDSym& getForwardNoiseMatrix() const {return forwardNoiseMatrix_;}
+    const TMatrixDSym& getBackwardNoiseMatrix() const {return backwardNoiseMatrix_;}
+    const TMatrixDSym& getNoiseMatrix(int direction) const {if (direction >= 0) return forwardNoiseMatrix_; return backwardNoiseMatrix_;}
+    const TVectorD& getForwardDeltaState() const {return forwardDeltaState_;}
+    const TVectorD& getBackwardDeltaState() const {return backwardDeltaState_;}
+    const TVectorD& getDeltaState(int direction) const {if (direction >= 0) return forwardDeltaState_; return backwardDeltaState_;}
 
-  ClassDefOverride(ReferenceStateOnPlane,1)
+    void resetForward();
+    void resetBackward();
 
-};
+    virtual void Print(Option_t* option = "") const override;
+
+  protected:
+
+    double forwardSegmentLength_; /**< Segment length from previous referenceState */
+    double backwardSegmentLength_; /**< Segment length from next referenceState */
+    TMatrixD forwardTransportMatrix_; /**< transport matrix F from previous referenceState */
+    TMatrixD backwardTransportMatrix_; /**< transport matrix F from next referenceState */
+    TMatrixDSym forwardNoiseMatrix_; /**< noise matrix N for transport from previous referenceState */
+    TMatrixDSym backwardNoiseMatrix_; /**< noise matrix N for transport from next referenceState */
+    TVectorD forwardDeltaState_; /**< c */
+    TVectorD backwardDeltaState_; /**< c */
+
+
+  public:
+
+    ClassDefOverride(ReferenceStateOnPlane, 1)
+
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/fitters/src/AbsKalmanFitter.cc
+++ b/fitters/src/AbsKalmanFitter.cc
@@ -38,8 +38,9 @@ using namespace genfit;
 
 
 void AbsKalmanFitter::getChiSquNdf(const Track* tr, const AbsTrackRep* rep,
-    double& bChi2, double& fChi2,
-    double& bNdf,  double& fNdf) const {
+                                   double& bChi2, double& fChi2,
+                                   double& bNdf,  double& fNdf) const
+{
 
   bChi2 = 0;
   fChi2 = 0;
@@ -48,13 +49,13 @@ void AbsKalmanFitter::getChiSquNdf(const Track* tr, const AbsTrackRep* rep,
 
   const std::vector<TrackPoint*>& pointsWM = tr->getPointsWithMeasurement();
   for (std::vector<TrackPoint*>::const_iterator tpIter = pointsWM.begin(), endIter = pointsWM.end(); tpIter != endIter; ++tpIter) {
-    if (! (*tpIter)->hasFitterInfo(rep))
+    if (!(*tpIter)->hasFitterInfo(rep))
       continue;
 
     AbsFitterInfo* afi = (*tpIter)->getFitterInfo(rep);
     KalmanFitterInfo* fi = dynamic_cast<KalmanFitterInfo*>(afi);
     if (!fi) {
-      Exception exc("AbsKalmanFitter::getChiSqu(): fitterInfo is not a KalmanFitterInfo", __LINE__,__FILE__);
+      Exception exc("AbsKalmanFitter::getChiSqu(): fitterInfo is not a KalmanFitterInfo", __LINE__, __FILE__);
       throw exc;
     }
 
@@ -62,7 +63,7 @@ void AbsKalmanFitter::getChiSquNdf(const Track* tr, const AbsTrackRep* rep,
     KalmanFittedStateOnPlane* bup = fi->getBackwardUpdate();
 
     if (fup == nullptr || bup == nullptr) {
-      Exception exc("AbsKalmanFitter::getChiSqu(): fup == nullptr || bup == nullptr", __LINE__,__FILE__);
+      Exception exc("AbsKalmanFitter::getChiSqu(): fup == nullptr || bup == nullptr", __LINE__, __FILE__);
       throw exc;
     }
 
@@ -81,7 +82,8 @@ void AbsKalmanFitter::getChiSquNdf(const Track* tr, const AbsTrackRep* rep,
 }
 
 
-double AbsKalmanFitter::getChiSqu(const Track* tr, const AbsTrackRep* rep, int direction) const {
+double AbsKalmanFitter::getChiSqu(const Track* tr, const AbsTrackRep* rep, int direction) const
+{
   double bChi2(0), fChi2(0), bNdf(0), fNdf(0);
 
   getChiSquNdf(tr, rep, bChi2, fChi2, bNdf, fNdf);
@@ -91,7 +93,8 @@ double AbsKalmanFitter::getChiSqu(const Track* tr, const AbsTrackRep* rep, int d
   return fChi2;
 }
 
-double AbsKalmanFitter::getNdf(const Track* tr, const AbsTrackRep* rep, int direction) const {
+double AbsKalmanFitter::getNdf(const Track* tr, const AbsTrackRep* rep, int direction) const
+{
   double bChi2(0), fChi2(0), bNdf(0), fNdf(0);
 
   getChiSquNdf(tr, rep, bChi2, fChi2, bNdf, fNdf);
@@ -101,28 +104,31 @@ double AbsKalmanFitter::getNdf(const Track* tr, const AbsTrackRep* rep, int dire
   return fNdf;
 }
 
-double AbsKalmanFitter::getRedChiSqu(const Track* tr, const AbsTrackRep* rep, int direction) const {
+double AbsKalmanFitter::getRedChiSqu(const Track* tr, const AbsTrackRep* rep, int direction) const
+{
   double bChi2(0), fChi2(0), bNdf(0), fNdf(0);
 
   getChiSquNdf(tr, rep, bChi2, fChi2, bNdf, fNdf);
 
   if (direction < 0)
-    return bChi2/bNdf;
-  return fChi2/fNdf;
+    return bChi2 / bNdf;
+  return fChi2 / fNdf;
 }
 
-double AbsKalmanFitter::getPVal(const Track* tr, const AbsTrackRep* rep, int direction) const {
+double AbsKalmanFitter::getPVal(const Track* tr, const AbsTrackRep* rep, int direction) const
+{
   double bChi2(0), fChi2(0), bNdf(0), fNdf(0);
 
   getChiSquNdf(tr, rep, bChi2, fChi2, bNdf, fNdf);
 
   if (direction < 0)
-    return std::max(0.,ROOT::Math::chisquared_cdf_c(bChi2, bNdf));
-  return std::max(0.,ROOT::Math::chisquared_cdf_c(fChi2, fNdf));
+    return std::max(0., ROOT::Math::chisquared_cdf_c(bChi2, bNdf));
+  return std::max(0., ROOT::Math::chisquared_cdf_c(fChi2, fNdf));
 }
 
 
-bool AbsKalmanFitter::isTrackPrepared(const Track* tr, const AbsTrackRep* rep) const {
+bool AbsKalmanFitter::isTrackPrepared(const Track* tr, const AbsTrackRep* rep) const
+{
   const std::vector<TrackPoint*>& points = tr->getPointsWithMeasurement();
 
   if (points.size() == 0)
@@ -144,7 +150,8 @@ bool AbsKalmanFitter::isTrackPrepared(const Track* tr, const AbsTrackRep* rep) c
   return true;
 }
 
-bool AbsKalmanFitter::isTrackFitted(const Track* tr, const AbsTrackRep* rep) const {
+bool AbsKalmanFitter::isTrackFitted(const Track* tr, const AbsTrackRep* rep) const
+{
   if (! tr->getFitStatus(rep)->isFitted())
     return false;
 
@@ -174,7 +181,9 @@ bool AbsKalmanFitter::isTrackFitted(const Track* tr, const AbsTrackRep* rep) con
 }
 
 
-const std::vector<MeasurementOnPlane *> AbsKalmanFitter::getMeasurements(const KalmanFitterInfo* fi, const TrackPoint* tp, int direction) const {
+const std::vector<MeasurementOnPlane*> AbsKalmanFitter::getMeasurements(const KalmanFitterInfo* fi, const TrackPoint* tp,
+    int direction) const
+{
 
   switch (multipleMeasurementHandling_) {
     case weightedAverage :
@@ -182,70 +191,63 @@ const std::vector<MeasurementOnPlane *> AbsKalmanFitter::getMeasurements(const K
       return fi->getMeasurementsOnPlane();
 
     case weightedClosestToReference :
-    case unweightedClosestToReference :
-    {
+    case unweightedClosestToReference : {
       if (!fi->hasReferenceState()) {
-        Exception e("AbsKalmanFitter::getMeasurement: no ReferenceState.", __LINE__,__FILE__);
+        Exception e("AbsKalmanFitter::getMeasurement: no ReferenceState.", __LINE__, __FILE__);
         e.setFatal();
         throw e;
       }
-      std::vector<MeasurementOnPlane *> retVal;
+      std::vector<MeasurementOnPlane*> retVal;
       retVal.push_back(fi->getClosestMeasurementOnPlane(fi->getReferenceState()));
       return retVal;
     }
 
     case weightedClosestToPrediction :
-    case unweightedClosestToPrediction :
-    {
+    case unweightedClosestToPrediction : {
       if (!fi->hasPrediction(direction)) {
-        Exception e("AbsKalmanFitter::getMeasurement: no prediction.", __LINE__,__FILE__);
+        Exception e("AbsKalmanFitter::getMeasurement: no prediction.", __LINE__, __FILE__);
         e.setFatal();
         throw e;
       }
-      std::vector<MeasurementOnPlane *> retVal;
+      std::vector<MeasurementOnPlane*> retVal;
       retVal.push_back(fi->getClosestMeasurementOnPlane(fi->getPrediction(direction)));
       return retVal;
     }
 
 
     case weightedClosestToReferenceWire :
-    case unweightedClosestToReferenceWire :
-    {
+    case unweightedClosestToReferenceWire : {
       if (tp->getNumRawMeasurements() == 1 && tp->getRawMeasurement()->isLeftRightMeasurement()) {
         if (!fi->hasReferenceState()) {
-          Exception e("AbsKalmanFitter::getMeasurement: no ReferenceState.", __LINE__,__FILE__);
+          Exception e("AbsKalmanFitter::getMeasurement: no ReferenceState.", __LINE__, __FILE__);
           e.setFatal();
           throw e;
         }
-        std::vector<MeasurementOnPlane *> retVal;
+        std::vector<MeasurementOnPlane*> retVal;
         retVal.push_back(fi->getClosestMeasurementOnPlane(fi->getReferenceState()));
         return retVal;
-      }
-      else
+      } else
         return fi->getMeasurementsOnPlane();
     }
 
     case weightedClosestToPredictionWire :
-    case unweightedClosestToPredictionWire :
-    {
+    case unweightedClosestToPredictionWire : {
       if (tp->getNumRawMeasurements() == 1 && tp->getRawMeasurement()->isLeftRightMeasurement()) {
         if (!fi->hasPrediction(direction)) {
-          Exception e("AbsKalmanFitter::getMeasurement: no prediction.", __LINE__,__FILE__);
+          Exception e("AbsKalmanFitter::getMeasurement: no prediction.", __LINE__, __FILE__);
           e.setFatal();
           throw e;
         }
-        std::vector<MeasurementOnPlane *> retVal;
+        std::vector<MeasurementOnPlane*> retVal;
         retVal.push_back(fi->getClosestMeasurementOnPlane(fi->getPrediction(direction)));
         return retVal;
-      }
-      else
+      } else
         return fi->getMeasurementsOnPlane();
     }
 
 
-    default:
-    {
-      Exception e("AbsKalmanFitter::getMeasurement: choice not valid.", __LINE__,__FILE__);
+    default: {
+      Exception e("AbsKalmanFitter::getMeasurement: choice not valid.", __LINE__, __FILE__);
       e.setFatal();
       throw e;
     }
@@ -253,7 +255,8 @@ const std::vector<MeasurementOnPlane *> AbsKalmanFitter::getMeasurements(const K
 }
 
 
-bool AbsKalmanFitter::canIgnoreWeights() const {
+bool AbsKalmanFitter::canIgnoreWeights() const
+{
   switch (multipleMeasurementHandling_) {
     case unweightedAverage :
     case unweightedClosestToReference :
@@ -269,9 +272,8 @@ bool AbsKalmanFitter::canIgnoreWeights() const {
     case weightedClosestToPredictionWire :
       return false;
 
-    default:
-    {
-      Exception e("AbsKalmanFitter::canIgnoreWeights: choice not valid.", __LINE__,__FILE__);
+    default: {
+      Exception e("AbsKalmanFitter::canIgnoreWeights: choice not valid.", __LINE__, __FILE__);
       e.setFatal();
       throw e;
     }

--- a/fitters/src/DAF.cc
+++ b/fitters/src/DAF.cc
@@ -40,362 +40,367 @@
 
 namespace genfit {
 
-DAF::DAF(bool useRefKalman, double deltaPval, double deltaWeight)
-  : AbsKalmanFitter(10, deltaPval), deltaWeight_(deltaWeight)
-{
-  if (useRefKalman) {
-    kalman_.reset(new KalmanFitterRefTrack());
-    static_cast<KalmanFitterRefTrack*>(kalman_.get())->setRefitAll();
-  }
-  else
-    kalman_.reset(new KalmanFitter());
+  DAF::DAF(bool useRefKalman, double deltaPval, double deltaWeight)
+    : AbsKalmanFitter(10, deltaPval), deltaWeight_(deltaWeight)
+  {
+    if (useRefKalman) {
+      kalman_.reset(new KalmanFitterRefTrack());
+      static_cast<KalmanFitterRefTrack*>(kalman_.get())->setRefitAll();
+    } else
+      kalman_.reset(new KalmanFitter());
 
-  kalman_->setMultipleMeasurementHandling(weightedAverage);
-  kalman_->setMaxIterations(1);
+    kalman_->setMultipleMeasurementHandling(weightedAverage);
+    kalman_->setMaxIterations(1);
 
-  setAnnealingScheme(100, 0.1, 5); // also sets maxIterations_
-  setProbCut(0.001);
-}
-
-DAF::DAF(AbsKalmanFitter* kalman, double deltaPval, double deltaWeight)
-  : AbsKalmanFitter(10, deltaPval), deltaWeight_(deltaWeight)
-{
-  kalman_.reset(kalman);
-  kalman_->setMultipleMeasurementHandling(weightedAverage); // DAF makes no sense otherwise
-  kalman_->setMaxIterations(1);
-
-  if (dynamic_cast<KalmanFitterRefTrack*>(kalman_.get()) != nullptr) {
-    static_cast<KalmanFitterRefTrack*>(kalman_.get())->setRefitAll();
+    setAnnealingScheme(100, 0.1, 5); // also sets maxIterations_
+    setProbCut(0.001);
   }
 
-  setAnnealingScheme(100, 0.1, 5); // also sets maxIterations_
-  setProbCut(0.01);
-}
+  DAF::DAF(AbsKalmanFitter* kalman, double deltaPval, double deltaWeight)
+    : AbsKalmanFitter(10, deltaPval), deltaWeight_(deltaWeight)
+  {
+    kalman_.reset(kalman);
+    kalman_->setMultipleMeasurementHandling(weightedAverage); // DAF makes no sense otherwise
+    kalman_->setMaxIterations(1);
 
+    if (dynamic_cast<KalmanFitterRefTrack*>(kalman_.get()) != nullptr) {
+      static_cast<KalmanFitterRefTrack*>(kalman_.get())->setRefitAll();
+    }
 
-void DAF::processTrackWithRep(Track* tr, const AbsTrackRep* rep, bool resortHits) {
-
-  if (debugLvl_ > 0) {
-    debugOut<<"DAF::processTrack //////////////////////////////////////////////////////////////// \n";
+    setAnnealingScheme(100, 0.1, 5); // also sets maxIterations_
+    setProbCut(0.01);
   }
 
-  KalmanFitStatus* status = 0;
-  bool oneLastIter = false;
 
-  double lastPval = -1;
-
-  for(unsigned int iBeta = 0;; ++iBeta) {
+  void DAF::processTrackWithRep(Track* tr, const AbsTrackRep* rep, bool resortHits)
+  {
 
     if (debugLvl_ > 0) {
-      debugOut<<"DAF::processTrack, trackRep  " << rep << ", iteration " << iBeta+1 << ", beta = " << betas_.at(iBeta) << "\n";
+      debugOut << "DAF::processTrack //////////////////////////////////////////////////////////////// \n";
     }
 
-    kalman_->processTrackWithRep(tr, rep, resortHits);
+    KalmanFitStatus* status = 0;
+    bool oneLastIter = false;
 
-    status = static_cast<KalmanFitStatus*>(tr->getFitStatus(rep));
-    status->setIsFittedWithDaf();
-    status->setNumIterations(iBeta+1);
+    double lastPval = -1;
 
+    for (unsigned int iBeta = 0;; ++iBeta) {
 
-    // check break conditions
-
-    if (! status->isFitted()){
       if (debugLvl_ > 0) {
-        debugOut << "DAF::Kalman could not fit!\n";
+        debugOut << "DAF::processTrack, trackRep  " << rep << ", iteration " << iBeta + 1 << ", beta = " << betas_.at(iBeta) << "\n";
       }
-      status->setIsFitted(false);
-      break;
-    }
 
-    if( oneLastIter == true){
-      if (debugLvl_ > 0) {
-        debugOut << "DAF::break after one last iteration\n";
-      }
-      status->setIsFitConvergedFully(status->getNFailedPoints() == 0);
-      status->setIsFitConvergedPartially();
-      break;
-    }
+      kalman_->processTrackWithRep(tr, rep, resortHits);
 
-    if(iBeta >= maxIterations_-1){
-      status->setIsFitConvergedFully(false);
-      status->setIsFitConvergedPartially(false);
-      if (debugLvl_ > 0) {
-        debugOut << "DAF::number of max iterations reached!\n";
-      }
-      break;
-    }
+      status = static_cast<KalmanFitStatus*>(tr->getFitStatus(rep));
+      status->setIsFittedWithDaf();
+      status->setNumIterations(iBeta + 1);
 
 
-    // get and update weights
-    bool converged(false);
-    try{
-      converged = calcWeights(tr, rep, betas_.at(iBeta));
-      if (!converged && iBeta >= minIterations_-1 &&
-          status->getBackwardPVal() != 0 && fabs(lastPval - status->getBackwardPVal()) < this->deltaPval_) {
+      // check break conditions
+
+      if (! status->isFitted()) {
         if (debugLvl_ > 0) {
-          debugOut << "converged by Pval = " << status->getBackwardPVal() << " even though weights changed at iBeta = " << iBeta << std::endl;
+          debugOut << "DAF::Kalman could not fit!\n";
         }
-        converged = true;
+        status->setIsFitted(false);
+        break;
       }
-      lastPval = status->getBackwardPVal();
-    } catch(Exception& e) {
-      errorOut<<e.what();
-      e.info();
-      //errorOut << "calc weights failed" << std::endl;
-      //mini_trk->getTrackRep(0)->setStatusFlag(1);
-      status->setIsFitted(false);
-      status->setIsFitConvergedFully(false);
-      status->setIsFitConvergedPartially(false);
-      break;
-    }
 
-    // check if converged
-    if (iBeta >= minIterations_-1 && converged) {
-      if (debugLvl_ > 0) {
-        debugOut << "DAF::convergence reached in iteration " << iBeta+1 << " -> Do one last iteration with updated weights.\n";
-      }
-      oneLastIter = true;
-      status->setIsFitConvergedFully(status->getNFailedPoints() == 0);
-      status->setIsFitConvergedPartially();
-    }
-
-  } // end loop over betas
-
-
-  if (status->getForwardPVal() == 0. &&
-      status->getBackwardPVal() == 0.) {
-    status->setIsFitConvergedFully(false);
-    status->setIsFitConvergedPartially(false);
-  }
-
-}
-
-
-void DAF::setProbCut(const double prob_cut){
-  for ( int i = 1; i < 7; ++i){
-    addProbCut(prob_cut, i);
-  }
-}
-
-void DAF::addProbCut(const double prob_cut, const int measDim){
-  if ( prob_cut > 1.0 || prob_cut < 0.0){
-    Exception exc("DAF::addProbCut prob_cut is not between 0 and 1",__LINE__,__FILE__);
-    exc.setFatal();
-    throw exc;
-  }
-  if ( measDim < 1 || measDim > 6 ){
-    Exception exc("DAF::addProbCut measDim must be in the range [1,6]",__LINE__,__FILE__);
-    exc.setFatal();
-    throw exc;
-  }
-  chi2Cuts_[measDim] = ROOT::Math::chisquared_quantile_c( prob_cut, measDim);
-}
-
-void DAF::setAnnealingScheme(double bStart, double bFinal, unsigned int nSteps) {
-  // The betas are calculated as a geometric series that takes nSteps
-  // steps to go from bStart to bFinal.
-  assert(bStart > bFinal);
-  assert(bFinal > 1.E-10);
-  assert(nSteps > 1);
-
-  minIterations_ = nSteps;
-  maxIterations_ = nSteps + 4;
-
-  betas_.clear();
-
-  for (unsigned int i=0; i<nSteps; ++i) {
-    betas_.push_back(bStart * pow(bFinal / bStart, i / (nSteps - 1.)));
-  }
-
-  betas_.resize(maxIterations_,betas_.back()); //make sure main loop has a maximum of 10 iterations and also make sure the last beta value is used for if more iterations are needed then the ones set by the user.
-
-  /*for (unsigned int i=0; i<betas_.size(); ++i) {
-    debugOut<< betas_.at(i) << ", ";
-  }*/
-}
-
-
-bool DAF::calcWeights(Track* tr, const AbsTrackRep* rep, double beta) {
-
-  if (debugLvl_ > 0) {
-    debugOut<<"DAF::calcWeights \n";
-  }
-
-  bool converged(true);
-  double maxAbsChange(0);
-
-  const std::vector< TrackPoint* >& trackPoints = tr->getPointsWithMeasurement();
-  for (std::vector< TrackPoint* >::const_iterator tp = trackPoints.begin(); tp != trackPoints.end(); ++tp) {
-    if (! (*tp)->hasFitterInfo(rep)) {
-      continue;
-    }
-    AbsFitterInfo* fi = (*tp)->getFitterInfo(rep);
-    if (dynamic_cast<KalmanFitterInfo*>(fi) == nullptr){
-      Exception exc("DAF::getWeights ==> can only use KalmanFitterInfos",__LINE__,__FILE__);
-      throw exc;
-    }
-    KalmanFitterInfo* kfi = static_cast<KalmanFitterInfo*>(fi);
-
-    if (kfi->areWeightsFixed()) {
-      if (debugLvl_ > 0) {
-        debugOut<<"weights are fixed, continue \n";
-      }
-      continue;
-    }
-
-    unsigned int nMeas = kfi->getNumMeasurements();
-
-    std::vector<double> phi(nMeas, 0.);
-    double phi_sum = 0;
-    double phi_cut = 0;
-    for(unsigned int j=0; j<nMeas; j++) {
-
-      try{
-        const MeasurementOnPlane& residual = kfi->getResidual(j, true, true);
-        const TVectorD& resid(residual.getState());
-        TMatrixDSym Vinv(residual.getCov());
-        double detV;
-        tools::invertMatrix(Vinv, &detV); // can throw an Exception
-        int hitDim = resid.GetNrows();
-        // Needed for normalization, special cases for the two common cases,
-        // shouldn't matter, but the original code made some efforts to make
-        // this calculation faster, and it's not complex ...
-        double twoPiN = 2.*M_PI;
-        if (hitDim == 2)
-          twoPiN *= twoPiN;
-        else if (hitDim > 2)
-          twoPiN = pow(twoPiN, hitDim);
-
-        double chi2 = Vinv.Similarity(resid);
-        if (debugLvl_ > 1) {
-          debugOut<<"chi2 = " << chi2 << "\n";
+      if (oneLastIter == true) {
+        if (debugLvl_ > 0) {
+          debugOut << "DAF::break after one last iteration\n";
         }
-
-	// The common factor beta is eliminated.
-        double norm = 1./sqrt(twoPiN * detV);
-
-        phi[j] = norm*exp(-0.5*chi2/beta);
-	phi_sum += phi[j];
-        //errorOut << "hitDim " << hitDim << " fchi2Cuts[hitDim] " << fchi2Cuts[hitDim] << std::endl;
-        double cutVal = chi2Cuts_[hitDim];
-        assert(cutVal>1.E-6);
-        //the following assumes that in the competing hits could have different V otherwise calculation could be simplified
-        phi_cut += norm*exp(-0.5*cutVal/beta);
+        status->setIsFitConvergedFully(status->getNFailedPoints() == 0);
+        status->setIsFitConvergedPartially();
+        break;
       }
-      catch(Exception& e) {
+
+      if (iBeta >= maxIterations_ - 1) {
+        status->setIsFitConvergedFully(false);
+        status->setIsFitConvergedPartially(false);
+        if (debugLvl_ > 0) {
+          debugOut << "DAF::number of max iterations reached!\n";
+        }
+        break;
+      }
+
+
+      // get and update weights
+      bool converged(false);
+      try {
+        converged = calcWeights(tr, rep, betas_.at(iBeta));
+        if (!converged && iBeta >= minIterations_ - 1 &&
+            status->getBackwardPVal() != 0 && fabs(lastPval - status->getBackwardPVal()) < this->deltaPval_) {
+          if (debugLvl_ > 0) {
+            debugOut << "converged by Pval = " << status->getBackwardPVal() << " even though weights changed at iBeta = " << iBeta << std::endl;
+          }
+          converged = true;
+        }
+        lastPval = status->getBackwardPVal();
+      } catch (Exception& e) {
         errorOut << e.what();
         e.info();
+        //errorOut << "calc weights failed" << std::endl;
+        //mini_trk->getTrackRep(0)->setStatusFlag(1);
+        status->setIsFitted(false);
+        status->setIsFitConvergedFully(false);
+        status->setIsFitConvergedPartially(false);
+        break;
       }
+
+      // check if converged
+      if (iBeta >= minIterations_ - 1 && converged) {
+        if (debugLvl_ > 0) {
+          debugOut << "DAF::convergence reached in iteration " << iBeta + 1 << " -> Do one last iteration with updated weights.\n";
+        }
+        oneLastIter = true;
+        status->setIsFitConvergedFully(status->getNFailedPoints() == 0);
+        status->setIsFitConvergedPartially();
+      }
+
+    } // end loop over betas
+
+
+    if (status->getForwardPVal() == 0. &&
+        status->getBackwardPVal() == 0.) {
+      status->setIsFitConvergedFully(false);
+      status->setIsFitConvergedPartially(false);
     }
 
-    for(unsigned int j=0; j<nMeas; j++) {
-      double weight = phi[j]/(phi_sum+phi_cut);
-      //debugOut << phi_sum << " " << phi_cut << " " << weight << std::endl;
+  }
 
-      // check convergence
-      double absChange(fabs(weight - kfi->getMeasurementOnPlane(j)->getWeight()));
-      if (converged && absChange > deltaWeight_) {
-        converged = false;
-        if (absChange > maxAbsChange)
-          maxAbsChange = absChange;
+
+  void DAF::setProbCut(const double prob_cut)
+  {
+    for (int i = 1; i < 7; ++i) {
+      addProbCut(prob_cut, i);
+    }
+  }
+
+  void DAF::addProbCut(const double prob_cut, const int measDim)
+  {
+    if (prob_cut > 1.0 || prob_cut < 0.0) {
+      Exception exc("DAF::addProbCut prob_cut is not between 0 and 1", __LINE__, __FILE__);
+      exc.setFatal();
+      throw exc;
+    }
+    if (measDim < 1 || measDim > 6) {
+      Exception exc("DAF::addProbCut measDim must be in the range [1,6]", __LINE__, __FILE__);
+      exc.setFatal();
+      throw exc;
+    }
+    chi2Cuts_[measDim] = ROOT::Math::chisquared_quantile_c(prob_cut, measDim);
+  }
+
+  void DAF::setAnnealingScheme(double bStart, double bFinal, unsigned int nSteps)
+  {
+    // The betas are calculated as a geometric series that takes nSteps
+    // steps to go from bStart to bFinal.
+    assert(bStart > bFinal);
+    assert(bFinal > 1.E-10);
+    assert(nSteps > 1);
+
+    minIterations_ = nSteps;
+    maxIterations_ = nSteps + 4;
+
+    betas_.clear();
+
+    for (unsigned int i = 0; i < nSteps; ++i) {
+      betas_.push_back(bStart * pow(bFinal / bStart, i / (nSteps - 1.)));
+    }
+
+    betas_.resize(maxIterations_,
+                  betas_.back()); //make sure main loop has a maximum of 10 iterations and also make sure the last beta value is used for if more iterations are needed then the ones set by the user.
+
+    /*for (unsigned int i=0; i<betas_.size(); ++i) {
+      debugOut<< betas_.at(i) << ", ";
+    }*/
+  }
+
+
+  bool DAF::calcWeights(Track* tr, const AbsTrackRep* rep, double beta)
+  {
+
+    if (debugLvl_ > 0) {
+      debugOut << "DAF::calcWeights \n";
+    }
+
+    bool converged(true);
+    double maxAbsChange(0);
+
+    const std::vector< TrackPoint* >& trackPoints = tr->getPointsWithMeasurement();
+    for (std::vector< TrackPoint* >::const_iterator tp = trackPoints.begin(); tp != trackPoints.end(); ++tp) {
+      if (!(*tp)->hasFitterInfo(rep)) {
+        continue;
+      }
+      AbsFitterInfo* fi = (*tp)->getFitterInfo(rep);
+      if (dynamic_cast<KalmanFitterInfo*>(fi) == nullptr) {
+        Exception exc("DAF::getWeights ==> can only use KalmanFitterInfos", __LINE__, __FILE__);
+        throw exc;
+      }
+      KalmanFitterInfo* kfi = static_cast<KalmanFitterInfo*>(fi);
+
+      if (kfi->areWeightsFixed()) {
+        if (debugLvl_ > 0) {
+          debugOut << "weights are fixed, continue \n";
+        }
+        continue;
       }
 
-      if (debugLvl_ > 0) {
-        if (debugLvl_ > 1 || absChange > deltaWeight_) {
-          debugOut<<"\t old weight: " << kfi->getMeasurementOnPlane(j)->getWeight();
-          debugOut<<"\t new weight: " << weight;
+      unsigned int nMeas = kfi->getNumMeasurements();
+
+      std::vector<double> phi(nMeas, 0.);
+      double phi_sum = 0;
+      double phi_cut = 0;
+      for (unsigned int j = 0; j < nMeas; j++) {
+
+        try {
+          const MeasurementOnPlane& residual = kfi->getResidual(j, true, true);
+          const TVectorD& resid(residual.getState());
+          TMatrixDSym Vinv(residual.getCov());
+          double detV;
+          tools::invertMatrix(Vinv, &detV); // can throw an Exception
+          int hitDim = resid.GetNrows();
+          // Needed for normalization, special cases for the two common cases,
+          // shouldn't matter, but the original code made some efforts to make
+          // this calculation faster, and it's not complex ...
+          double twoPiN = 2.*M_PI;
+          if (hitDim == 2)
+            twoPiN *= twoPiN;
+          else if (hitDim > 2)
+            twoPiN = pow(twoPiN, hitDim);
+
+          double chi2 = Vinv.Similarity(resid);
+          if (debugLvl_ > 1) {
+            debugOut << "chi2 = " << chi2 << "\n";
+          }
+
+          // The common factor beta is eliminated.
+          double norm = 1. / sqrt(twoPiN * detV);
+
+          phi[j] = norm * exp(-0.5 * chi2 / beta);
+          phi_sum += phi[j];
+          //errorOut << "hitDim " << hitDim << " fchi2Cuts[hitDim] " << fchi2Cuts[hitDim] << std::endl;
+          double cutVal = chi2Cuts_[hitDim];
+          assert(cutVal > 1.E-6);
+          //the following assumes that in the competing hits could have different V otherwise calculation could be simplified
+          phi_cut += norm * exp(-0.5 * cutVal / beta);
+        } catch (Exception& e) {
+          errorOut << e.what();
+          e.info();
         }
       }
 
-      kfi->getMeasurementOnPlane(j)->setWeight(weight);
+      for (unsigned int j = 0; j < nMeas; j++) {
+        double weight = phi[j] / (phi_sum + phi_cut);
+        //debugOut << phi_sum << " " << phi_cut << " " << weight << std::endl;
+
+        // check convergence
+        double absChange(fabs(weight - kfi->getMeasurementOnPlane(j)->getWeight()));
+        if (converged && absChange > deltaWeight_) {
+          converged = false;
+          if (absChange > maxAbsChange)
+            maxAbsChange = absChange;
+        }
+
+        if (debugLvl_ > 0) {
+          if (debugLvl_ > 1 || absChange > deltaWeight_) {
+            debugOut << "\t old weight: " << kfi->getMeasurementOnPlane(j)->getWeight();
+            debugOut << "\t new weight: " << weight;
+          }
+        }
+
+        kfi->getMeasurementOnPlane(j)->setWeight(weight);
+      }
     }
-  }
 
-  if (debugLvl_ > 0) {
-    debugOut << "\t  ";
-    debugOut << "max abs weight change = " << maxAbsChange << "\n";
-  }
+    if (debugLvl_ > 0) {
+      debugOut << "\t  ";
+      debugOut << "max abs weight change = " << maxAbsChange << "\n";
+    }
 
-  return converged;
-}
+    return converged;
+  }
 
 
 // Customized from generated Streamer.
-void DAF::Streamer(TBuffer &R__b)
-{
-   // Stream an object of class genfit::DAF.
+  void DAF::Streamer(TBuffer& R__b)
+  {
+    // Stream an object of class genfit::DAF.
 
-   //This works around a msvc bug and should be harmless on other platforms
-   typedef ::genfit::DAF thisClass;
-   UInt_t R__s, R__c;
-   if (R__b.IsReading()) {
-      Version_t R__v = R__b.ReadVersion(&R__s, &R__c); if (R__v) { }
+    //This works around a msvc bug and should be harmless on other platforms
+    typedef ::genfit::DAF thisClass;
+    UInt_t R__s, R__c;
+    if (R__b.IsReading()) {
+      Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+      if (R__v) { }
       //This works around a msvc bug and should be harmless on other platforms
       typedef genfit::AbsKalmanFitter baseClass0;
       baseClass0::Streamer(R__b);
       R__b >> deltaWeight_;
       // weights_ are only of intermediate use -> not saved
       {
-         std::vector<double> &R__stl =  betas_;
-         R__stl.clear();
-         int R__i, R__n;
-         R__b >> R__n;
-         R__stl.reserve(R__n);
-         for (R__i = 0; R__i < R__n; R__i++) {
-            double R__t;
-            R__b >> R__t;
-            R__stl.push_back(R__t);
-         }
+        std::vector<double>& R__stl =  betas_;
+        R__stl.clear();
+        int R__i, R__n;
+        R__b >> R__n;
+        R__stl.reserve(R__n);
+        for (R__i = 0; R__i < R__n; R__i++) {
+          double R__t;
+          R__b >> R__t;
+          R__stl.push_back(R__t);
+        }
       }
       if (R__v == 1) {
- 	 // Old versions kept the chi2Cuts_ in a map.
-         // We ignore non-sensical dimensionalities when reading it again.
-         int R__i, R__n;
-         R__b >> R__n;
-         for (R__i = 0; R__i < R__n; R__i++) {
-	    memset(chi2Cuts_, 0, sizeof(chi2Cuts_));
-            int R__t;
-            R__b >> R__t;
-            double R__t2;
-            R__b >> R__t2;
-	    if (R__t >= 1 && R__t <= 6)
-	      chi2Cuts_[R__t] = R__t2;
-	 }
+        // Old versions kept the chi2Cuts_ in a map.
+        // We ignore non-sensical dimensionalities when reading it again.
+        int R__i, R__n;
+        R__b >> R__n;
+        for (R__i = 0; R__i < R__n; R__i++) {
+          memset(chi2Cuts_, 0, sizeof(chi2Cuts_));
+          int R__t;
+          R__b >> R__t;
+          double R__t2;
+          R__b >> R__t2;
+          if (R__t >= 1 && R__t <= 6)
+            chi2Cuts_[R__t] = R__t2;
+        }
       } else {
-	char n_chi2Cuts;  // should be six
-	R__b >> n_chi2Cuts;
-	assert(n_chi2Cuts == 6);  // Cannot be different as long as sanity prevails.
-	chi2Cuts_[0] = 0; // nonsensical.
-	R__b.ReadFastArray(&chi2Cuts_[1], n_chi2Cuts);
+        char n_chi2Cuts;  // should be six
+        R__b >> n_chi2Cuts;
+        assert(n_chi2Cuts == 6);  // Cannot be different as long as sanity prevails.
+        chi2Cuts_[0] = 0; // nonsensical.
+        R__b.ReadFastArray(&chi2Cuts_[1], n_chi2Cuts);
       }
-      AbsKalmanFitter *p;
+      AbsKalmanFitter* p;
       R__b >> p;
       kalman_.reset(p);
       R__b.CheckByteCount(R__s, R__c, thisClass::IsA());
-   } else {
+    } else {
       R__c = R__b.WriteVersion(thisClass::IsA(), kTRUE);
       //This works around a msvc bug and should be harmless on other platforms
       typedef genfit::AbsKalmanFitter baseClass0;
       baseClass0::Streamer(R__b);
       R__b << deltaWeight_;
       {
-         std::vector<double> &R__stl =  betas_;
-         int R__n=int(R__stl.size());
-         R__b << R__n;
-         if(R__n) {
-            std::vector<double>::iterator R__k;
-            for (R__k = R__stl.begin(); R__k != R__stl.end(); ++R__k) {
+        std::vector<double>& R__stl =  betas_;
+        int R__n = int(R__stl.size());
+        R__b << R__n;
+        if (R__n) {
+          std::vector<double>::iterator R__k;
+          for (R__k = R__stl.begin(); R__k != R__stl.end(); ++R__k) {
             R__b << (*R__k);
-            }
-         }
+          }
+        }
       }
       {
-	R__b << (char)6;  // Number of chi2Cuts_
-	R__b.WriteFastArray(&chi2Cuts_[1], 6);
+        R__b << (char)6;  // Number of chi2Cuts_
+        R__b.WriteFastArray(&chi2Cuts_[1], 6);
       }
       R__b << kalman_.get();
       R__b.SetByteCount(R__c, kTRUE);
-   }
-}
+    }
+  }
 
 } /* End of namespace genfit */

--- a/fitters/src/KalmanFitStatus.cc
+++ b/fitters/src/KalmanFitStatus.cc
@@ -24,22 +24,22 @@
 
 namespace genfit {
 
-void KalmanFitStatus::Print(const Option_t*) const
-{
-  FitStatus::Print();
-  if (fittedWithDaf_) printOut << " track has been fitted with DAF,";
-  if (fittedWithReferenceTrack_) printOut << " track has been fitted with reference track,";
-  if (isFitted_) {
-    printOut << " numIterations = " << numIterations_ << ", ";
-    printOut << "track length = " << trackLen_ << ", ";
-    printOut << "fChi2 = " << fChi2_ << ", ";
-    printOut << "bChi2 = " << FitStatus::getChi2() << ", ";
-    printOut << "fNdf = " << fNdf_ << ", ";
-    printOut << "bNdf = " << FitStatus::getNdf() << ", ";
-    printOut << "fPVal = " << getForwardPVal() << ", ";
-    printOut << "bPVal = " << getBackwardPVal() << "\n";
+  void KalmanFitStatus::Print(const Option_t*) const
+  {
+    FitStatus::Print();
+    if (fittedWithDaf_) printOut << " track has been fitted with DAF,";
+    if (fittedWithReferenceTrack_) printOut << " track has been fitted with reference track,";
+    if (isFitted_) {
+      printOut << " numIterations = " << numIterations_ << ", ";
+      printOut << "track length = " << trackLen_ << ", ";
+      printOut << "fChi2 = " << fChi2_ << ", ";
+      printOut << "bChi2 = " << FitStatus::getChi2() << ", ";
+      printOut << "fNdf = " << fNdf_ << ", ";
+      printOut << "bNdf = " << FitStatus::getNdf() << ", ";
+      printOut << "fPVal = " << getForwardPVal() << ", ";
+      printOut << "bPVal = " << getBackwardPVal() << "\n";
+    }
+    printOut << "\n";
   }
-  printOut << "\n";
-}
 
 } /* End of namespace genfit */

--- a/fitters/src/KalmanFitterInfo.cc
+++ b/fitters/src/KalmanFitterInfo.cc
@@ -34,685 +34,715 @@
 
 namespace genfit {
 
-KalmanFitterInfo::KalmanFitterInfo() :
-  AbsFitterInfo(), fixWeights_(false)
-{
-  ;
-}
-
-KalmanFitterInfo::KalmanFitterInfo(const TrackPoint* trackPoint, const AbsTrackRep* rep)  :
-  AbsFitterInfo(trackPoint, rep), fixWeights_(false)
-{
-  ;
-}
-
-KalmanFitterInfo::~KalmanFitterInfo() {
-  deleteMeasurementInfo();
-}
-
-
-KalmanFitterInfo* KalmanFitterInfo::clone() const {
-  KalmanFitterInfo* retVal = new KalmanFitterInfo(this->getTrackPoint(), this->getRep());
-  if (hasReferenceState())
-    retVal->setReferenceState(new ReferenceStateOnPlane(*getReferenceState()));
-  if (hasForwardPrediction())
-    retVal->setForwardPrediction(new MeasuredStateOnPlane(*getForwardPrediction()));
-  if (hasForwardUpdate())
-    retVal->setForwardUpdate(new KalmanFittedStateOnPlane(*getForwardUpdate()));
-  if (hasBackwardPrediction())
-    retVal->setBackwardPrediction(new MeasuredStateOnPlane(*getBackwardPrediction()));
-  if (hasBackwardUpdate())
-    retVal->setBackwardUpdate(new KalmanFittedStateOnPlane(*getBackwardUpdate()));
-
-  retVal->measurementsOnPlane_.reserve(getNumMeasurements());
-  for (std::vector<MeasurementOnPlane*>::const_iterator it = this->measurementsOnPlane_.begin(); it != this->measurementsOnPlane_.end(); ++it) {
-    retVal->addMeasurementOnPlane(new MeasurementOnPlane(**it));
+  KalmanFitterInfo::KalmanFitterInfo() :
+    AbsFitterInfo(), fixWeights_(false)
+  {
+    ;
   }
 
-  retVal->fixWeights_ = this->fixWeights_;
+  KalmanFitterInfo::KalmanFitterInfo(const TrackPoint* trackPoint, const AbsTrackRep* rep)  :
+    AbsFitterInfo(trackPoint, rep), fixWeights_(false)
+  {
+    ;
+  }
 
-  return retVal;
-}
+  KalmanFitterInfo::~KalmanFitterInfo()
+  {
+    deleteMeasurementInfo();
+  }
 
 
-MeasurementOnPlane KalmanFitterInfo::getAvgWeightedMeasurementOnPlane(bool ignoreWeights) const {
+  KalmanFitterInfo* KalmanFitterInfo::clone() const
+  {
+    KalmanFitterInfo* retVal = new KalmanFitterInfo(this->getTrackPoint(), this->getRep());
+    if (hasReferenceState())
+      retVal->setReferenceState(new ReferenceStateOnPlane(*getReferenceState()));
+    if (hasForwardPrediction())
+      retVal->setForwardPrediction(new MeasuredStateOnPlane(*getForwardPrediction()));
+    if (hasForwardUpdate())
+      retVal->setForwardUpdate(new KalmanFittedStateOnPlane(*getForwardUpdate()));
+    if (hasBackwardPrediction())
+      retVal->setBackwardPrediction(new MeasuredStateOnPlane(*getBackwardPrediction()));
+    if (hasBackwardUpdate())
+      retVal->setBackwardUpdate(new KalmanFittedStateOnPlane(*getBackwardUpdate()));
 
-  MeasurementOnPlane retVal(*(measurementsOnPlane_[0]));
-
-  if(measurementsOnPlane_.size() == 1) {
-    if (ignoreWeights) {
-      retVal.setWeight(1.);
+    retVal->measurementsOnPlane_.reserve(getNumMeasurements());
+    for (std::vector<MeasurementOnPlane*>::const_iterator it = this->measurementsOnPlane_.begin();
+         it != this->measurementsOnPlane_.end(); ++it) {
+      retVal->addMeasurementOnPlane(new MeasurementOnPlane(**it));
     }
-    else {
-      double weight = (measurementsOnPlane_[0])->getWeight();
-      if (weight != 1.) {
-        retVal.getCov() *= 1. / weight;
-      }
-      retVal.setWeight(weight);
-    }
+
+    retVal->fixWeights_ = this->fixWeights_;
+
     return retVal;
   }
 
-  // more than one hit
 
-  // cppcheck-suppress unreadVariable
-  double sumOfWeights(0), weight(0);
+  MeasurementOnPlane KalmanFitterInfo::getAvgWeightedMeasurementOnPlane(bool ignoreWeights) const
+  {
 
-  retVal.getState().Zero();
-  retVal.getCov().Zero();
+    MeasurementOnPlane retVal(*(measurementsOnPlane_[0]));
 
-  TMatrixDSym covInv;
-
-  for(unsigned int i=0; i<measurementsOnPlane_.size(); ++i) {
-
-    if (i>0) {
-      // make sure we have compatible measurement types
-      // TODO: replace with Exceptions!
-      assert(measurementsOnPlane_[i]->getPlane() == measurementsOnPlane_[0]->getPlane());
-      assert(*(measurementsOnPlane_[i]->getHMatrix()) == *(measurementsOnPlane_[0]->getHMatrix()));
+    if (measurementsOnPlane_.size() == 1) {
+      if (ignoreWeights) {
+        retVal.setWeight(1.);
+      } else {
+        double weight = (measurementsOnPlane_[0])->getWeight();
+        if (weight != 1.) {
+          retVal.getCov() *= 1. / weight;
+        }
+        retVal.setWeight(weight);
+      }
+      return retVal;
     }
 
-    tools::invertMatrix(measurementsOnPlane_[i]->getCov(), covInv); // invert cov
-    if (ignoreWeights) {
-      sumOfWeights += 1.;
-    }
-    else {
-      weight = measurementsOnPlane_[i]->getWeight();
-      sumOfWeights += weight;
-      covInv *= weight; // weigh cov
-    }
-    retVal.getCov() += covInv; // covInv is already inverted and weighted
+    // more than one hit
 
-    retVal.getState() += covInv * measurementsOnPlane_[i]->getState();
+    // cppcheck-suppress unreadVariable
+    double sumOfWeights(0), weight(0);
+
+    retVal.getState().Zero();
+    retVal.getCov().Zero();
+
+    TMatrixDSym covInv;
+
+    for (unsigned int i = 0; i < measurementsOnPlane_.size(); ++i) {
+
+      if (i > 0) {
+        // make sure we have compatible measurement types
+        // TODO: replace with Exceptions!
+        assert(measurementsOnPlane_[i]->getPlane() == measurementsOnPlane_[0]->getPlane());
+        assert(*(measurementsOnPlane_[i]->getHMatrix()) == *(measurementsOnPlane_[0]->getHMatrix()));
+      }
+
+      tools::invertMatrix(measurementsOnPlane_[i]->getCov(), covInv); // invert cov
+      if (ignoreWeights) {
+        sumOfWeights += 1.;
+      } else {
+        weight = measurementsOnPlane_[i]->getWeight();
+        sumOfWeights += weight;
+        covInv *= weight; // weigh cov
+      }
+      retVal.getCov() += covInv; // covInv is already inverted and weighted
+
+      retVal.getState() += covInv * measurementsOnPlane_[i]->getState();
+    }
+
+    // invert Cov
+    tools::invertMatrix(retVal.getCov());
+
+    retVal.getState() *= retVal.getCov();
+
+    retVal.setWeight(sumOfWeights);
+
+    return retVal;
   }
 
-  // invert Cov
-  tools::invertMatrix(retVal.getCov());
 
-  retVal.getState() *= retVal.getCov();
+  MeasurementOnPlane* KalmanFitterInfo::getClosestMeasurementOnPlane(const StateOnPlane* sop) const
+  {
+    if (measurementsOnPlane_.size() == 0)
+      return nullptr;
 
-  retVal.setWeight(sumOfWeights);
+    if (measurementsOnPlane_.size() == 1)
+      return getMeasurementOnPlane(0);
 
-  return retVal;
-}
+    double normMin(9.99E99);
+    unsigned int iMin(0);
+    const AbsHMatrix* H = measurementsOnPlane_[0]->getHMatrix();
+    for (unsigned int i = 0; i < getNumMeasurements(); ++i) {
+      if (*(measurementsOnPlane_[i]->getHMatrix()) != *H) {
+        Exception e("KalmanFitterInfo::getClosestMeasurementOnPlane: Cannot compare measurements with different H-Matrices. Maybe you have to select a different multipleMeasurementHandling.",
+                    __LINE__, __FILE__);
+        e.setFatal();
+        throw e;
+      }
 
-
-MeasurementOnPlane* KalmanFitterInfo::getClosestMeasurementOnPlane(const StateOnPlane* sop) const {
-  if(measurementsOnPlane_.size() == 0)
-    return nullptr;
-
-  if(measurementsOnPlane_.size() == 1)
-    return getMeasurementOnPlane(0);
-
-  double normMin(9.99E99);
-  unsigned int iMin(0);
-  const AbsHMatrix* H = measurementsOnPlane_[0]->getHMatrix();
-  for (unsigned int i=0; i<getNumMeasurements(); ++i) {
-    if (*(measurementsOnPlane_[i]->getHMatrix()) != *H){
-      Exception e("KalmanFitterInfo::getClosestMeasurementOnPlane: Cannot compare measurements with different H-Matrices. Maybe you have to select a different multipleMeasurementHandling.", __LINE__,__FILE__);
-      e.setFatal();
-      throw e;
+      TVectorD res = measurementsOnPlane_[i]->getState() - H->Hv(sop->getState());
+      double norm = sqrt(res.Norm2Sqr());
+      if (norm < normMin) {
+        normMin = norm;
+        iMin = i;
+      }
     }
 
-    TVectorD res = measurementsOnPlane_[i]->getState() - H->Hv(sop->getState());
-    double norm = sqrt(res.Norm2Sqr());
-    if (norm < normMin) {
-      normMin = norm;
-      iMin = i;
+    return getMeasurementOnPlane(iMin);
+  }
+
+
+  std::vector<double> KalmanFitterInfo::getWeights() const
+  {
+    std::vector<double> retVal(getNumMeasurements());
+
+    for (unsigned int i = 0; i < getNumMeasurements(); ++i) {
+      retVal[i] = getMeasurementOnPlane(i)->getWeight();
     }
+
+    return retVal;
   }
 
-  return getMeasurementOnPlane(iMin);
-}
+
+  const MeasuredStateOnPlane& KalmanFitterInfo::getFittedState(bool biased) const
+  {
+
+    // check if we can use cached states
+    if (biased && fittedStateBiased_)
+      return *fittedStateBiased_;
+    if (!biased && fittedStateUnbiased_)
+      return *fittedStateUnbiased_;
 
 
-std::vector<double> KalmanFitterInfo::getWeights() const {
-  std::vector<double> retVal(getNumMeasurements());
+    const TrackPoint* tp = this->getTrackPoint();
+    const Track* tr = tp->getTrack();
+    const AbsTrackRep* rep =  this->getRep();
 
-  for (unsigned int i=0; i<getNumMeasurements(); ++i) {
-    retVal[i] = getMeasurementOnPlane(i)->getWeight();
-  }
-
-  return retVal;
-}
-
-
-const MeasuredStateOnPlane& KalmanFitterInfo::getFittedState(bool biased) const {
-
-  // check if we can use cached states
-  if (biased && fittedStateBiased_)
-    return *fittedStateBiased_;
-  if (!biased && fittedStateUnbiased_)
-    return *fittedStateUnbiased_;
-
-
-  const TrackPoint* tp = this->getTrackPoint();
-  const Track* tr = tp->getTrack();
-  const AbsTrackRep* rep =  this->getRep();
-
-  bool first(false), last(false);
-  PruneFlags& flag = tr->getFitStatus(rep)->getPruneFlags();
-  // if Track is pruned so that only one TrackPoint remains, see if it was the first or last one
-  #ifdef DEBUG
-  if (flag.isPruned()) {
-    debugOut << "KalmanFitterInfo::getFittedState - Track is pruned and has " << tr->getNumPoints() << " TrackPoints \n";
-    flag.Print();
-  }
-  #endif
-  if (flag.isPruned() && tr->getNumPoints() == 1) {
-    if (flag.hasFlags("F")) {
-      first = true;
-      #ifdef DEBUG
-      debugOut << "KalmanFitterInfo::getFittedState - has flag F \n";
-      #endif
+    bool first(false), last(false);
+    PruneFlags& flag = tr->getFitStatus(rep)->getPruneFlags();
+    // if Track is pruned so that only one TrackPoint remains, see if it was the first or last one
+#ifdef DEBUG
+    if (flag.isPruned()) {
+      debugOut << "KalmanFitterInfo::getFittedState - Track is pruned and has " << tr->getNumPoints() << " TrackPoints \n";
+      flag.Print();
     }
-    else if (flag.hasFlags("L")) {
-      last = true;
-      #ifdef DEBUG
-      debugOut << "KalmanFitterInfo::getFittedState - has flag L \n";
-      #endif
+#endif
+    if (flag.isPruned() && tr->getNumPoints() == 1) {
+      if (flag.hasFlags("F")) {
+        first = true;
+#ifdef DEBUG
+        debugOut << "KalmanFitterInfo::getFittedState - has flag F \n";
+#endif
+      } else if (flag.hasFlags("L")) {
+        last = true;
+#ifdef DEBUG
+        debugOut << "KalmanFitterInfo::getFittedState - has flag L \n";
+#endif
+      }
+    } else { // otherwise check against TrackPoint order
+      first = tr->getPointWithFitterInfo(0, rep) == tp;
+      last = tr->getPointWithFitterInfo(-1, rep) == tp;
     }
-  }
-  else { // otherwise check against TrackPoint order
-    first = tr->getPointWithFitterInfo(0, rep) == tp;
-    last = tr->getPointWithFitterInfo(-1, rep) == tp;
-  }
 
-  #ifdef DEBUG
-  debugOut << "KalmanFitterInfo::getFittedState first " << first << ", last " << last << "\n";
-  debugOut << "KalmanFitterInfo::getFittedState forwardPrediction_ " << forwardPrediction_.get() << ", forwardUpdate_ " << forwardUpdate_.get() << "\n";
-  debugOut << "KalmanFitterInfo::getFittedState backwardPrediction_ " << backwardPrediction_.get() << ", backwardUpdate_ " << backwardUpdate_.get() << "\n";
-  #endif
+#ifdef DEBUG
+    debugOut << "KalmanFitterInfo::getFittedState first " << first << ", last " << last << "\n";
+    debugOut << "KalmanFitterInfo::getFittedState forwardPrediction_ " << forwardPrediction_.get() << ", forwardUpdate_ " <<
+             forwardUpdate_.get() << "\n";
+    debugOut << "KalmanFitterInfo::getFittedState backwardPrediction_ " << backwardPrediction_.get() << ", backwardUpdate_ " <<
+             backwardUpdate_.get() << "\n";
+#endif
 
-  /*
-  if both needed forward prediction/update and backward prediction are available,
-  use them to calculate smoothed state.
-  Otherwise, if one is missing (i.e. has been pruned) and we are at first or last hit,
-  use only backward or forward prediction (unbiased) of update (biased).
-  */
+    /*
+    if both needed forward prediction/update and backward prediction are available,
+    use them to calculate smoothed state.
+    Otherwise, if one is missing (i.e. has been pruned) and we are at first or last hit,
+    use only backward or forward prediction (unbiased) of update (biased).
+    */
 
-  if (biased) {
-    // last measurement and no backward prediction -> use forward update
+    if (biased) {
+      // last measurement and no backward prediction -> use forward update
+      if (last && !backwardPrediction_) {
+        if (!forwardUpdate_) {
+          Exception e("KalmanFitterInfo::getFittedState: Needed updates/predictions not available in this FitterInfo.", __LINE__, __FILE__);
+          e.setFatal();
+          throw e;
+        }
+#ifdef DEBUG
+        debugOut << "KalmanFitterInfo::getFittedState - biased at last measurement = forwardUpdate_ \n";
+#endif
+        return *forwardUpdate_;
+      }
+
+      // first measurement and no forward update -> use backward update
+      if (first && (!forwardUpdate_ || (backwardUpdate_ && !forwardPrediction_))) {
+        if (!backwardUpdate_.get()) {
+          Exception e("KalmanFitterInfo::getFittedState: Needed updates/predictions not available in this FitterInfo.", __LINE__, __FILE__);
+          e.setFatal();
+          throw e;
+        }
+#ifdef DEBUG
+        debugOut << "KalmanFitterInfo::getFittedState - biased at first measurement = backwardUpdate_ \n";
+        //backwardUpdate_->Print();
+#endif
+        return *backwardUpdate_;
+      }
+
+      if (!forwardUpdate_ || !backwardPrediction_) {
+        Exception e("KalmanFitterInfo::getFittedState: Needed updates/predictions not available in this FitterInfo.", __LINE__, __FILE__);
+        e.setFatal();
+        throw e;
+      }
+#ifdef DEBUG
+      debugOut << "KalmanFitterInfo::getFittedState - biased = mean(forwardUpdate_, backwardPrediction_) \n";
+#endif
+      fittedStateBiased_.reset(new MeasuredStateOnPlane(calcAverageState(*forwardUpdate_, *backwardPrediction_)));
+      return *fittedStateBiased_;
+    }
+
+    // unbiased
+
+    // last measurement and no backward prediction -> use forward prediction
     if (last && !backwardPrediction_) {
-      if(!forwardUpdate_) {
-        Exception e("KalmanFitterInfo::getFittedState: Needed updates/predictions not available in this FitterInfo.", __LINE__,__FILE__);
+      if (!forwardPrediction_) {
+        Exception e("KalmanFitterInfo::getFittedState: Needed updates/predictions not available in this FitterInfo.", __LINE__, __FILE__);
         e.setFatal();
         throw e;
       }
-      #ifdef DEBUG
-      debugOut << "KalmanFitterInfo::getFittedState - biased at last measurement = forwardUpdate_ \n";
-      #endif
-      return *forwardUpdate_;
+#ifdef DEBUG
+      debugOut << "KalmanFitterInfo::getFittedState - unbiased at last measurement = forwardPrediction_ \n";
+#endif
+      return *forwardPrediction_;
     }
 
-    // first measurement and no forward update -> use backward update
-    if (first && (!forwardUpdate_ || (backwardUpdate_ && !forwardPrediction_) ) ) {
-      if(!backwardUpdate_.get()) {
-        Exception e("KalmanFitterInfo::getFittedState: Needed updates/predictions not available in this FitterInfo.", __LINE__,__FILE__);
+    // first measurement and no forward prediction -> use backward prediction
+    if (first && !forwardPrediction_) {
+      if (!backwardPrediction_) {
+        Exception e("KalmanFitterInfo::getFittedState: Needed updates/predictions not available in this FitterInfo.", __LINE__, __FILE__);
         e.setFatal();
         throw e;
       }
-      #ifdef DEBUG
-      debugOut << "KalmanFitterInfo::getFittedState - biased at first measurement = backwardUpdate_ \n";
-      //backwardUpdate_->Print();
-      #endif
-      return *backwardUpdate_;
+#ifdef DEBUG
+      debugOut << "KalmanFitterInfo::getFittedState - unbiased at first measurement = backwardPrediction_ \n";
+#endif
+      return *backwardPrediction_;
     }
 
-    if(!forwardUpdate_ || !backwardPrediction_) {
-      Exception e("KalmanFitterInfo::getFittedState: Needed updates/predictions not available in this FitterInfo.", __LINE__,__FILE__);
+    if (!forwardPrediction_ || !backwardPrediction_) {
+      Exception e("KalmanFitterInfo::getFittedState: Needed updates/predictions not available in this FitterInfo.", __LINE__, __FILE__);
       e.setFatal();
       throw e;
     }
-    #ifdef DEBUG
-    debugOut << "KalmanFitterInfo::getFittedState - biased = mean(forwardUpdate_, backwardPrediction_) \n";
-    #endif
-    fittedStateBiased_.reset(new MeasuredStateOnPlane(calcAverageState(*forwardUpdate_, *backwardPrediction_)));
-    return *fittedStateBiased_;
+#ifdef DEBUG
+    debugOut << "KalmanFitterInfo::getFittedState - unbiased = mean(forwardPrediction_, backwardPrediction_) \n";
+#endif
+    fittedStateUnbiased_.reset(new MeasuredStateOnPlane(calcAverageState(*forwardPrediction_, *backwardPrediction_)));
+    return *fittedStateUnbiased_;
   }
 
-  // unbiased
 
-  // last measurement and no backward prediction -> use forward prediction
-  if (last && !backwardPrediction_) {
-    if(!forwardPrediction_) {
-      Exception e("KalmanFitterInfo::getFittedState: Needed updates/predictions not available in this FitterInfo.", __LINE__,__FILE__);
-      e.setFatal();
+  MeasurementOnPlane KalmanFitterInfo::getResidual(unsigned int iMeasurement, bool biased, bool onlyMeasurementErrors) const
+  {
+
+    const MeasuredStateOnPlane& smoothedState = getFittedState(biased);
+    const MeasurementOnPlane* measurement = measurementsOnPlane_.at(iMeasurement);
+    const SharedPlanePtr& plane = measurement->getPlane();
+
+    // check equality of planes and reps
+    if (*(smoothedState.getPlane()) != *plane) {
+      Exception e("KalmanFitterInfo::getResidual: smoothedState and measurement are not defined in the same plane.", __LINE__, __FILE__);
       throw e;
     }
-    #ifdef DEBUG
-    debugOut << "KalmanFitterInfo::getFittedState - unbiased at last measurement = forwardPrediction_ \n";
-    #endif
-    return *forwardPrediction_;
-  }
-
-  // first measurement and no forward prediction -> use backward prediction
-  if (first && !forwardPrediction_) {
-    if(!backwardPrediction_) {
-      Exception e("KalmanFitterInfo::getFittedState: Needed updates/predictions not available in this FitterInfo.", __LINE__,__FILE__);
-      e.setFatal();
+    if (smoothedState.getRep() != measurement->getRep()) {
+      Exception e("KalmanFitterInfo::getResidual: smoothedState and measurement are not defined wrt the same TrackRep.", __LINE__,
+                  __FILE__);
       throw e;
     }
-    #ifdef DEBUG
-    debugOut << "KalmanFitterInfo::getFittedState - unbiased at first measurement = backwardPrediction_ \n";
-    #endif
-    return *backwardPrediction_;
+
+    const AbsHMatrix* H = measurement->getHMatrix();
+
+    //TODO: shouldn't the definition be (smoothed - measured) ?
+    // res = -(H*smoothedState - measuredState)
+    TVectorD res(H->Hv(smoothedState.getState()));
+    res -= measurement->getState();
+    res *= -1;
+
+    if (onlyMeasurementErrors) {
+      return MeasurementOnPlane(res, measurement->getCov(), plane, smoothedState.getRep(), H->clone(), measurement->getWeight());
+    }
+
+    TMatrixDSym cov(smoothedState.getCov());
+    H->HMHt(cov);
+    cov += measurement->getCov();
+
+    return MeasurementOnPlane(res, cov, plane, smoothedState.getRep(), H->clone(), measurement->getWeight());
   }
 
-  if(!forwardPrediction_ || !backwardPrediction_) {
-    Exception e("KalmanFitterInfo::getFittedState: Needed updates/predictions not available in this FitterInfo.", __LINE__,__FILE__);
-    e.setFatal();
-    throw e;
-  }
-  #ifdef DEBUG
-  debugOut << "KalmanFitterInfo::getFittedState - unbiased = mean(forwardPrediction_, backwardPrediction_) \n";
-  #endif
-  fittedStateUnbiased_.reset(new MeasuredStateOnPlane(calcAverageState(*forwardPrediction_, *backwardPrediction_)));
-  return *fittedStateUnbiased_;
-}
 
+  double KalmanFitterInfo::getSmoothedChi2(unsigned int iMeasurement) const
+  {
+    const MeasurementOnPlane& res = getResidual(iMeasurement, true, false);
 
-MeasurementOnPlane KalmanFitterInfo::getResidual(unsigned int iMeasurement, bool biased, bool onlyMeasurementErrors) const {
-
-  const MeasuredStateOnPlane& smoothedState = getFittedState(biased);
-  const MeasurementOnPlane* measurement = measurementsOnPlane_.at(iMeasurement);
-  const SharedPlanePtr& plane = measurement->getPlane();
-
-  // check equality of planes and reps
-  if(*(smoothedState.getPlane()) != *plane) {
-    Exception e("KalmanFitterInfo::getResidual: smoothedState and measurement are not defined in the same plane.", __LINE__,__FILE__);
-    throw e;
-  }
-  if(smoothedState.getRep() != measurement->getRep()) {
-    Exception e("KalmanFitterInfo::getResidual: smoothedState and measurement are not defined wrt the same TrackRep.", __LINE__,__FILE__);
-    throw e;
+    TMatrixDSym Rinv;
+    tools::invertMatrix(res.getCov(), Rinv);
+    return Rinv.Similarity(res.getState());
   }
 
-  const AbsHMatrix* H = measurement->getHMatrix();
 
-  //TODO: shouldn't the definition be (smoothed - measured) ?
-  // res = -(H*smoothedState - measuredState)
-  TVectorD res(H->Hv(smoothedState.getState()));
-  res -= measurement->getState();
-  res *= -1;
+  void KalmanFitterInfo::setReferenceState(ReferenceStateOnPlane* referenceState)
+  {
+    referenceState_.reset(referenceState);
+    if (referenceState_)
+      setPlane(referenceState_->getPlane());
 
-  if (onlyMeasurementErrors) {
-    return MeasurementOnPlane(res, measurement->getCov(), plane, smoothedState.getRep(), H->clone(), measurement->getWeight());
+    // if plane has changed, delete outdated info
+    /*if (forwardPrediction_ && forwardPrediction_->getPlane() != getPlane())
+      setForwardPrediction(0);
+
+    if (forwardUpdate_ && forwardUpdate_->getPlane() != getPlane())
+      setForwardUpdate(0);
+
+    if (backwardPrediction_ && backwardPrediction_->getPlane() != getPlane())
+      setBackwardPrediction(0);
+
+    if (backwardUpdate_ && backwardUpdate_->getPlane() != getPlane())
+      setBackwardUpdate(0);
+
+    if (measurementsOnPlane_.size() > 0 && measurementsOnPlane_[0]->getPlane() != getPlane())
+      deleteMeasurementInfo();
+    */
   }
-    
-  TMatrixDSym cov(smoothedState.getCov());
-  H->HMHt(cov);
-  cov += measurement->getCov();
-
-  return MeasurementOnPlane(res, cov, plane, smoothedState.getRep(), H->clone(), measurement->getWeight());
-}
 
 
-double KalmanFitterInfo::getSmoothedChi2(unsigned int iMeasurement) const {
-  const MeasurementOnPlane& res = getResidual(iMeasurement, true, false);
+  void KalmanFitterInfo::setForwardPrediction(MeasuredStateOnPlane* forwardPrediction)
+  {
+    forwardPrediction_.reset(forwardPrediction);
+    fittedStateUnbiased_.reset();
+    fittedStateBiased_.reset();
+    if (forwardPrediction_)
+      setPlane(forwardPrediction_->getPlane());
+  }
 
-  TMatrixDSym Rinv;
-  tools::invertMatrix(res.getCov(), Rinv);
-  return Rinv.Similarity(res.getState());
-}
+  void KalmanFitterInfo::setBackwardPrediction(MeasuredStateOnPlane* backwardPrediction)
+  {
+    backwardPrediction_.reset(backwardPrediction);
+    fittedStateUnbiased_.reset();
+    fittedStateBiased_.reset();
+    if (backwardPrediction_)
+      setPlane(backwardPrediction_->getPlane());
+  }
+
+  void KalmanFitterInfo::setForwardUpdate(KalmanFittedStateOnPlane* forwardUpdate)
+  {
+    forwardUpdate_.reset(forwardUpdate);
+    fittedStateUnbiased_.reset();
+    fittedStateBiased_.reset();
+    if (forwardUpdate_)
+      setPlane(forwardUpdate_->getPlane());
+  }
+
+  void KalmanFitterInfo::setBackwardUpdate(KalmanFittedStateOnPlane* backwardUpdate)
+  {
+    backwardUpdate_.reset(backwardUpdate);
+    fittedStateUnbiased_.reset();
+    fittedStateBiased_.reset();
+    if (backwardUpdate_)
+      setPlane(backwardUpdate_->getPlane());
+  }
 
 
-void KalmanFitterInfo::setReferenceState(ReferenceStateOnPlane* referenceState) {
-  referenceState_.reset(referenceState);
-  if (referenceState_)
-    setPlane(referenceState_->getPlane());
-
-  // if plane has changed, delete outdated info
-  /*if (forwardPrediction_ && forwardPrediction_->getPlane() != getPlane())
-    setForwardPrediction(0);
-
-  if (forwardUpdate_ && forwardUpdate_->getPlane() != getPlane())
-    setForwardUpdate(0);
-
-  if (backwardPrediction_ && backwardPrediction_->getPlane() != getPlane())
-    setBackwardPrediction(0);
-
-  if (backwardUpdate_ && backwardUpdate_->getPlane() != getPlane())
-    setBackwardUpdate(0);
-
-  if (measurementsOnPlane_.size() > 0 && measurementsOnPlane_[0]->getPlane() != getPlane())
+  void KalmanFitterInfo::setMeasurementsOnPlane(const std::vector< genfit::MeasurementOnPlane* >& measurementsOnPlane)
+  {
     deleteMeasurementInfo();
-  */
-}
 
-
-void KalmanFitterInfo::setForwardPrediction(MeasuredStateOnPlane* forwardPrediction) {
-  forwardPrediction_.reset(forwardPrediction);
-  fittedStateUnbiased_.reset();
-  fittedStateBiased_.reset();
-  if (forwardPrediction_)
-    setPlane(forwardPrediction_->getPlane());
-}
-
-void KalmanFitterInfo::setBackwardPrediction(MeasuredStateOnPlane* backwardPrediction) {
-  backwardPrediction_.reset(backwardPrediction);
-  fittedStateUnbiased_.reset();
-  fittedStateBiased_.reset();
-  if (backwardPrediction_)
-    setPlane(backwardPrediction_->getPlane());
-}
-
-void KalmanFitterInfo::setForwardUpdate(KalmanFittedStateOnPlane* forwardUpdate) {
-  forwardUpdate_.reset(forwardUpdate);
-  fittedStateUnbiased_.reset();
-  fittedStateBiased_.reset();
-  if (forwardUpdate_)
-    setPlane(forwardUpdate_->getPlane());
-}
-
-void KalmanFitterInfo::setBackwardUpdate(KalmanFittedStateOnPlane* backwardUpdate) {
-  backwardUpdate_.reset(backwardUpdate);
-  fittedStateUnbiased_.reset();
-  fittedStateBiased_.reset();
-  if (backwardUpdate_)
-    setPlane(backwardUpdate_->getPlane());
-}
-
-
-void KalmanFitterInfo::setMeasurementsOnPlane(const std::vector< genfit::MeasurementOnPlane* >& measurementsOnPlane) {
-  deleteMeasurementInfo();
-
-  for (std::vector<MeasurementOnPlane*>::const_iterator m = measurementsOnPlane.begin(), mend = measurementsOnPlane.end(); m < mend; ++m) {
-    addMeasurementOnPlane(*m);
-  }
-}
-
-
-void KalmanFitterInfo::addMeasurementOnPlane(MeasurementOnPlane* measurementOnPlane) {
-  if (measurementsOnPlane_.size() == 0)
-    setPlane(measurementOnPlane->getPlane());
-
-  measurementsOnPlane_.push_back(measurementOnPlane);
-}
-
-void KalmanFitterInfo::addMeasurementsOnPlane(const std::vector< genfit::MeasurementOnPlane* >& measurementsOnPlane) {
-  for (std::vector<MeasurementOnPlane*>::const_iterator m = measurementsOnPlane.begin(), mend = measurementsOnPlane.end(); m < mend; ++m) {
-    addMeasurementOnPlane(*m);
-  }
-}
-
-
-void KalmanFitterInfo::setRep(const AbsTrackRep* rep) {
-  rep_ = rep;
-
-  if (referenceState_)
-    referenceState_->setRep(rep);
-
-  if (forwardPrediction_)
-    forwardPrediction_->setRep(rep);
-
-  if (forwardUpdate_)
-    forwardUpdate_->setRep(rep);
-
-  if (backwardPrediction_)
-    backwardPrediction_->setRep(rep);
-
-  if (backwardUpdate_)
-    backwardUpdate_->setRep(rep);
-
-  for (std::vector<MeasurementOnPlane*>::iterator it = measurementsOnPlane_.begin(); it != measurementsOnPlane_.end(); ++it) {
-    (*it)->setRep(rep);
-  }
-}
-
-
-void KalmanFitterInfo::setWeights(const std::vector<double>& weights) {
-
-  if (weights.size() != getNumMeasurements()) {
-    Exception e("KalmanFitterInfo::setWeights: weights do not have the same size as measurementsOnPlane", __LINE__,__FILE__);
-    throw e;
+    for (std::vector<MeasurementOnPlane*>::const_iterator m = measurementsOnPlane.begin(), mend = measurementsOnPlane.end(); m < mend;
+         ++m) {
+      addMeasurementOnPlane(*m);
+    }
   }
 
-  if (fixWeights_) {
-    errorOut << "KalmanFitterInfo::setWeights - WARNING: setting weights even though weights are fixed!" << std::endl;
+
+  void KalmanFitterInfo::addMeasurementOnPlane(MeasurementOnPlane* measurementOnPlane)
+  {
+    if (measurementsOnPlane_.size() == 0)
+      setPlane(measurementOnPlane->getPlane());
+
+    measurementsOnPlane_.push_back(measurementOnPlane);
   }
 
-  for (unsigned int i=0; i<getNumMeasurements(); ++i) {
-    getMeasurementOnPlane(i)->setWeight(weights[i]);
-  }
-}
-
-
-void KalmanFitterInfo::deleteForwardInfo() {
-  setForwardPrediction(nullptr);
-  setForwardUpdate(nullptr);
-  fittedStateUnbiased_.reset();
-  fittedStateBiased_.reset();
-}
-
-void KalmanFitterInfo::deleteBackwardInfo() {
-  setBackwardPrediction(nullptr);
-  setBackwardUpdate(nullptr);
-  fittedStateUnbiased_.reset();
-  fittedStateBiased_.reset();
-}
-
-void KalmanFitterInfo::deletePredictions() {
-  setForwardPrediction(nullptr);
-  setBackwardPrediction(nullptr);
-  fittedStateUnbiased_.reset();
-  fittedStateBiased_.reset();
-}
-
-void KalmanFitterInfo::deleteMeasurementInfo() {
-  // FIXME: need smart pointers / smart containers here
-  for (size_t i = 0; i < measurementsOnPlane_.size(); ++i)
-    delete measurementsOnPlane_[i];
-
-  measurementsOnPlane_.clear();
-}
-
-
-void KalmanFitterInfo::Print(const Option_t*) const {
-  printOut << "genfit::KalmanFitterInfo. Belongs to TrackPoint " << trackPoint_ << "; TrackRep " <<  rep_  << "\n";
-
-  if (fixWeights_)
-    printOut << "Weights are fixed.\n";
-
-  for (unsigned int i=0; i<measurementsOnPlane_.size(); ++i) {
-    printOut << "MeasurementOnPlane Nr " << i <<": "; measurementsOnPlane_[i]->Print();
+  void KalmanFitterInfo::addMeasurementsOnPlane(const std::vector< genfit::MeasurementOnPlane* >& measurementsOnPlane)
+  {
+    for (std::vector<MeasurementOnPlane*>::const_iterator m = measurementsOnPlane.begin(), mend = measurementsOnPlane.end(); m < mend;
+         ++m) {
+      addMeasurementOnPlane(*m);
+    }
   }
 
-  if (referenceState_) {
-    printOut << "Reference state: "; referenceState_->Print();
-  }
-  if (forwardPrediction_) {
-    printOut << "Forward prediction_: "; forwardPrediction_->Print();
-  }
-  if (forwardUpdate_) {
-    printOut << "Forward update: "; forwardUpdate_->Print();
-  }
-  if (backwardPrediction_) {
-    printOut << "Backward prediction_: "; backwardPrediction_->Print();
-  }
-  if (backwardUpdate_) {
-    printOut << "Backward update: "; backwardUpdate_->Print();
-  }
 
-}
+  void KalmanFitterInfo::setRep(const AbsTrackRep* rep)
+  {
+    rep_ = rep;
 
+    if (referenceState_)
+      referenceState_->setRep(rep);
 
-bool KalmanFitterInfo::checkConsistency(const genfit::PruneFlags* flags) const {
+    if (forwardPrediction_)
+      forwardPrediction_->setRep(rep);
 
-  bool retVal(true);
+    if (forwardUpdate_)
+      forwardUpdate_->setRep(rep);
 
-  // check if in a TrackPoint
-  if (!trackPoint_) {
-    errorOut << "KalmanFitterInfo::checkConsistency(): trackPoint_ is nullptr" << std::endl;
-    retVal = false;
+    if (backwardPrediction_)
+      backwardPrediction_->setRep(rep);
+
+    if (backwardUpdate_)
+      backwardUpdate_->setRep(rep);
+
+    for (std::vector<MeasurementOnPlane*>::iterator it = measurementsOnPlane_.begin(); it != measurementsOnPlane_.end(); ++it) {
+      (*it)->setRep(rep);
+    }
   }
 
-  // check if there is a reference state
-  /*if (!referenceState_) {
-    errorOut << "KalmanFitterInfo::checkConsistency(): referenceState_ is nullptr" << std::endl;
-    retVal = false;
-  }*/
 
-  SharedPlanePtr plane = getPlane();
+  void KalmanFitterInfo::setWeights(const std::vector<double>& weights)
+  {
 
-  if (plane.get() == nullptr) {
-    if (!(referenceState_ || forwardPrediction_ || forwardUpdate_ || backwardPrediction_ || backwardUpdate_ || measurementsOnPlane_.size() > 0))
-      return true;
-    errorOut << "KalmanFitterInfo::checkConsistency(): plane is nullptr" << std::endl;
-    retVal = false;
+    if (weights.size() != getNumMeasurements()) {
+      Exception e("KalmanFitterInfo::setWeights: weights do not have the same size as measurementsOnPlane", __LINE__, __FILE__);
+      throw e;
+    }
+
+    if (fixWeights_) {
+      errorOut << "KalmanFitterInfo::setWeights - WARNING: setting weights even though weights are fixed!" << std::endl;
+    }
+
+    for (unsigned int i = 0; i < getNumMeasurements(); ++i) {
+      getMeasurementOnPlane(i)->setWeight(weights[i]);
+    }
   }
 
-  // cppcheck-suppress unreadVariable
-  TVector3 oTest = plane->getO(); // see if the plane object is there
-  // cppcheck-suppress unreadVariable
-  oTest *= 47.11;
 
-  // if more than one measurement, check if they have the same dimensionality
-  if (measurementsOnPlane_.size() > 1) {
-    int dim = measurementsOnPlane_[0]->getState().GetNrows();
-    for (unsigned int i = 1; i<measurementsOnPlane_.size(); ++i) {
-      if(measurementsOnPlane_[i]->getState().GetNrows() != dim) {
-        errorOut << "KalmanFitterInfo::checkConsistency(): measurementsOnPlane_ do not all have the same dimensionality" << std::endl;
+  void KalmanFitterInfo::deleteForwardInfo()
+  {
+    setForwardPrediction(nullptr);
+    setForwardUpdate(nullptr);
+    fittedStateUnbiased_.reset();
+    fittedStateBiased_.reset();
+  }
+
+  void KalmanFitterInfo::deleteBackwardInfo()
+  {
+    setBackwardPrediction(nullptr);
+    setBackwardUpdate(nullptr);
+    fittedStateUnbiased_.reset();
+    fittedStateBiased_.reset();
+  }
+
+  void KalmanFitterInfo::deletePredictions()
+  {
+    setForwardPrediction(nullptr);
+    setBackwardPrediction(nullptr);
+    fittedStateUnbiased_.reset();
+    fittedStateBiased_.reset();
+  }
+
+  void KalmanFitterInfo::deleteMeasurementInfo()
+  {
+    // FIXME: need smart pointers / smart containers here
+    for (size_t i = 0; i < measurementsOnPlane_.size(); ++i)
+      delete measurementsOnPlane_[i];
+
+    measurementsOnPlane_.clear();
+  }
+
+
+  void KalmanFitterInfo::Print(const Option_t*) const
+  {
+    printOut << "genfit::KalmanFitterInfo. Belongs to TrackPoint " << trackPoint_ << "; TrackRep " <<  rep_  << "\n";
+
+    if (fixWeights_)
+      printOut << "Weights are fixed.\n";
+
+    for (unsigned int i = 0; i < measurementsOnPlane_.size(); ++i) {
+      printOut << "MeasurementOnPlane Nr " << i << ": "; measurementsOnPlane_[i]->Print();
+    }
+
+    if (referenceState_) {
+      printOut << "Reference state: "; referenceState_->Print();
+    }
+    if (forwardPrediction_) {
+      printOut << "Forward prediction_: "; forwardPrediction_->Print();
+    }
+    if (forwardUpdate_) {
+      printOut << "Forward update: "; forwardUpdate_->Print();
+    }
+    if (backwardPrediction_) {
+      printOut << "Backward prediction_: "; backwardPrediction_->Print();
+    }
+    if (backwardUpdate_) {
+      printOut << "Backward update: "; backwardUpdate_->Print();
+    }
+
+  }
+
+
+  bool KalmanFitterInfo::checkConsistency(const genfit::PruneFlags* flags) const
+  {
+
+    bool retVal(true);
+
+    // check if in a TrackPoint
+    if (!trackPoint_) {
+      errorOut << "KalmanFitterInfo::checkConsistency(): trackPoint_ is nullptr" << std::endl;
+      retVal = false;
+    }
+
+    // check if there is a reference state
+    /*if (!referenceState_) {
+      errorOut << "KalmanFitterInfo::checkConsistency(): referenceState_ is nullptr" << std::endl;
+      retVal = false;
+    }*/
+
+    SharedPlanePtr plane = getPlane();
+
+    if (plane.get() == nullptr) {
+      if (!(referenceState_ || forwardPrediction_ || forwardUpdate_ || backwardPrediction_ || backwardUpdate_
+            || measurementsOnPlane_.size() > 0))
+        return true;
+      errorOut << "KalmanFitterInfo::checkConsistency(): plane is nullptr" << std::endl;
+      retVal = false;
+    }
+
+    // cppcheck-suppress unreadVariable
+    TVector3 oTest = plane->getO(); // see if the plane object is there
+    // cppcheck-suppress unreadVariable
+    oTest *= 47.11;
+
+    // if more than one measurement, check if they have the same dimensionality
+    if (measurementsOnPlane_.size() > 1) {
+      int dim = measurementsOnPlane_[0]->getState().GetNrows();
+      for (unsigned int i = 1; i < measurementsOnPlane_.size(); ++i) {
+        if (measurementsOnPlane_[i]->getState().GetNrows() != dim) {
+          errorOut << "KalmanFitterInfo::checkConsistency(): measurementsOnPlane_ do not all have the same dimensionality" << std::endl;
+          retVal = false;
+        }
+      }
+      if (dim == 0) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): measurementsOnPlane_ have dimension 0" << std::endl;
         retVal = false;
       }
     }
-    if (dim == 0) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): measurementsOnPlane_ have dimension 0" << std::endl;
-      retVal = false;
-    }
-  }
 
-  // see if everything else is defined wrt this plane and rep_
-  int dim = rep_->getDim(); // check dim
-  if (referenceState_) {
-    if(referenceState_->getPlane() != plane) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): referenceState_ is not defined with the correct plane " << referenceState_->getPlane().get() << " vs. " << plane.get() << std::endl;
-      retVal = false;
-    }
-    if (referenceState_->getRep() != rep_) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): referenceState_ is not defined with the correct TrackRep" << std::endl;
-      retVal = false;
-    }
-    if (referenceState_->getState().GetNrows() != dim) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): referenceState_ does not have the right dimension!" << std::endl;
-      retVal = false;
-    }
-  }
-
-  if (forwardPrediction_) {
-    if(forwardPrediction_->getPlane() != plane) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): forwardPrediction_ is not defined with the correct plane" << std::endl;
-      retVal = false;
-    }
-    if(forwardPrediction_->getRep() != rep_) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): forwardPrediction_ is not defined with the correct TrackRep" << std::endl;
-      retVal = false;
-    }
-    if (forwardPrediction_->getState().GetNrows() != dim || forwardPrediction_->getCov().GetNrows() != dim) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): forwardPrediction_ does not have the right dimension!" << std::endl;
-      retVal = false;
-    }
-  }
-  if (forwardUpdate_) {
-    if(forwardUpdate_->getPlane() != plane) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): forwardUpdate_ is not defined with the correct plane" << std::endl;
-      retVal = false;
-    }
-    if(forwardUpdate_->getRep() != rep_) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): forwardUpdate_ is not defined with the correct TrackRep" << std::endl;
-      retVal = false;
-    }
-    if (forwardUpdate_->getState().GetNrows() != dim || forwardUpdate_->getCov().GetNrows() != dim) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): forwardUpdate_ does not have the right dimension!" << std::endl;
-      retVal = false;
-    }
-  }
-
-  if (backwardPrediction_) {
-    if(backwardPrediction_->getPlane() != plane) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): backwardPrediction_ is not defined with the correct plane" << std::endl;
-      retVal = false;
-    }
-    if(backwardPrediction_->getRep() != rep_) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): backwardPrediction_ is not defined with the correct TrackRep" << std::endl;
-      retVal = false;
-    }
-    if (backwardPrediction_->getState().GetNrows() != dim || backwardPrediction_->getCov().GetNrows() != dim) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): backwardPrediction_ does not have the right dimension!" << std::endl;
-      retVal = false;
-    }
-  }
-  if (backwardUpdate_) {
-    if(backwardUpdate_->getPlane() != plane) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): backwardUpdate_ is not defined with the correct plane" << std::endl;
-      retVal = false;
-    }
-    if(backwardUpdate_->getRep() != rep_) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): backwardUpdate_ is not defined with the correct TrackRep" << std::endl;
-      retVal = false;
-    }
-    if (backwardUpdate_->getState().GetNrows() != dim || backwardUpdate_->getCov().GetNrows() != dim) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): backwardUpdate_ does not have the right dimension!" << std::endl;
-      retVal = false;
-    }
-  }
-
-  for (std::vector<MeasurementOnPlane*>::const_iterator it = measurementsOnPlane_.begin(); it != measurementsOnPlane_.end(); ++it) {
-    if((*it)->getPlane() != plane) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): measurement is not defined with the correct plane" << std::endl;
-      retVal = false;
-    }
-    if((*it)->getRep() != rep_) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): measurement is not defined with the correct TrackRep" << std::endl;
-      retVal = false;
-    }
-    if ((*it)->getState().GetNrows() == 0) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): measurement has dimension 0!" << std::endl;
-      retVal = false;
-    }
-  }
-
-  if (flags == nullptr or !flags->hasFlags("U")) { // if predictions have not been pruned
-    // see if there is an update w/o prediction or measurement
-    if (forwardUpdate_ && !forwardPrediction_) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): forwardUpdate_ w/o forwardPrediction_" << std::endl;
-      retVal = false;
-    }
-
-
-    if (backwardUpdate_ && !backwardPrediction_) {
-      errorOut << "KalmanFitterInfo::checkConsistency(): backwardUpdate_ w/o backwardPrediction_" << std::endl;
-      retVal = false;
-    }
-
-    if (flags == nullptr or !flags->hasFlags("M")) {
-      if (forwardUpdate_ && measurementsOnPlane_.size() == 0) {
-        errorOut << "KalmanFitterInfo::checkConsistency(): forwardUpdate_ w/o measurement" << std::endl;
+    // see if everything else is defined wrt this plane and rep_
+    int dim = rep_->getDim(); // check dim
+    if (referenceState_) {
+      if (referenceState_->getPlane() != plane) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): referenceState_ is not defined with the correct plane " <<
+                 referenceState_->getPlane().get() << " vs. " << plane.get() << std::endl;
         retVal = false;
       }
-
-      if (backwardUpdate_ && measurementsOnPlane_.size() == 0) {
-        errorOut << "KalmanFitterInfo::checkConsistency(): backwardUpdate_ w/o measurement" << std::endl;
+      if (referenceState_->getRep() != rep_) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): referenceState_ is not defined with the correct TrackRep" << std::endl;
+        retVal = false;
+      }
+      if (referenceState_->getState().GetNrows() != dim) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): referenceState_ does not have the right dimension!" << std::endl;
         retVal = false;
       }
     }
+
+    if (forwardPrediction_) {
+      if (forwardPrediction_->getPlane() != plane) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): forwardPrediction_ is not defined with the correct plane" << std::endl;
+        retVal = false;
+      }
+      if (forwardPrediction_->getRep() != rep_) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): forwardPrediction_ is not defined with the correct TrackRep" << std::endl;
+        retVal = false;
+      }
+      if (forwardPrediction_->getState().GetNrows() != dim || forwardPrediction_->getCov().GetNrows() != dim) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): forwardPrediction_ does not have the right dimension!" << std::endl;
+        retVal = false;
+      }
+    }
+    if (forwardUpdate_) {
+      if (forwardUpdate_->getPlane() != plane) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): forwardUpdate_ is not defined with the correct plane" << std::endl;
+        retVal = false;
+      }
+      if (forwardUpdate_->getRep() != rep_) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): forwardUpdate_ is not defined with the correct TrackRep" << std::endl;
+        retVal = false;
+      }
+      if (forwardUpdate_->getState().GetNrows() != dim || forwardUpdate_->getCov().GetNrows() != dim) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): forwardUpdate_ does not have the right dimension!" << std::endl;
+        retVal = false;
+      }
+    }
+
+    if (backwardPrediction_) {
+      if (backwardPrediction_->getPlane() != plane) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): backwardPrediction_ is not defined with the correct plane" << std::endl;
+        retVal = false;
+      }
+      if (backwardPrediction_->getRep() != rep_) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): backwardPrediction_ is not defined with the correct TrackRep" << std::endl;
+        retVal = false;
+      }
+      if (backwardPrediction_->getState().GetNrows() != dim || backwardPrediction_->getCov().GetNrows() != dim) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): backwardPrediction_ does not have the right dimension!" << std::endl;
+        retVal = false;
+      }
+    }
+    if (backwardUpdate_) {
+      if (backwardUpdate_->getPlane() != plane) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): backwardUpdate_ is not defined with the correct plane" << std::endl;
+        retVal = false;
+      }
+      if (backwardUpdate_->getRep() != rep_) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): backwardUpdate_ is not defined with the correct TrackRep" << std::endl;
+        retVal = false;
+      }
+      if (backwardUpdate_->getState().GetNrows() != dim || backwardUpdate_->getCov().GetNrows() != dim) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): backwardUpdate_ does not have the right dimension!" << std::endl;
+        retVal = false;
+      }
+    }
+
+    for (std::vector<MeasurementOnPlane*>::const_iterator it = measurementsOnPlane_.begin(); it != measurementsOnPlane_.end(); ++it) {
+      if ((*it)->getPlane() != plane) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): measurement is not defined with the correct plane" << std::endl;
+        retVal = false;
+      }
+      if ((*it)->getRep() != rep_) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): measurement is not defined with the correct TrackRep" << std::endl;
+        retVal = false;
+      }
+      if ((*it)->getState().GetNrows() == 0) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): measurement has dimension 0!" << std::endl;
+        retVal = false;
+      }
+    }
+
+    if (flags == nullptr or !flags->hasFlags("U")) { // if predictions have not been pruned
+      // see if there is an update w/o prediction or measurement
+      if (forwardUpdate_ && !forwardPrediction_) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): forwardUpdate_ w/o forwardPrediction_" << std::endl;
+        retVal = false;
+      }
+
+
+      if (backwardUpdate_ && !backwardPrediction_) {
+        errorOut << "KalmanFitterInfo::checkConsistency(): backwardUpdate_ w/o backwardPrediction_" << std::endl;
+        retVal = false;
+      }
+
+      if (flags == nullptr or !flags->hasFlags("M")) {
+        if (forwardUpdate_ && measurementsOnPlane_.size() == 0) {
+          errorOut << "KalmanFitterInfo::checkConsistency(): forwardUpdate_ w/o measurement" << std::endl;
+          retVal = false;
+        }
+
+        if (backwardUpdate_ && measurementsOnPlane_.size() == 0) {
+          errorOut << "KalmanFitterInfo::checkConsistency(): backwardUpdate_ w/o measurement" << std::endl;
+          retVal = false;
+        }
+      }
+    }
+
+
+    return retVal;
   }
-
-
-  return retVal;
-}
 
 
 // Modified from auto-generated Streamer to correctly deal with smart pointers.
-void KalmanFitterInfo::Streamer(TBuffer &R__b)
-{
-   // Stream an object of class genfit::KalmanFitterInfo.
+  void KalmanFitterInfo::Streamer(TBuffer& R__b)
+  {
+    // Stream an object of class genfit::KalmanFitterInfo.
 
-   //This works around a msvc bug and should be harmless on other platforms
-   typedef ::genfit::KalmanFitterInfo thisClass;
-   UInt_t R__s, R__c;
-   if (R__b.IsReading()) {
-      Version_t R__v = R__b.ReadVersion(&R__s, &R__c); if (R__v) { }
+    //This works around a msvc bug and should be harmless on other platforms
+    typedef ::genfit::KalmanFitterInfo thisClass;
+    UInt_t R__s, R__c;
+    if (R__b.IsReading()) {
+      Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+      if (R__v) { }
       //This works around a msvc bug and should be harmless on other platforms
       typedef genfit::AbsFitterInfo baseClass0;
       baseClass0::Streamer(R__b);
@@ -740,23 +770,23 @@ void KalmanFitterInfo::Streamer(TBuffer &R__b)
         forwardUpdate_->setPlane(getPlane());
         // rep needs to be fixed up
       }
-      if (flag & (1 << 3)) {	
+      if (flag & (1 << 3)) {
         backwardPrediction_.reset(new MeasuredStateOnPlane());
         backwardPrediction_->Streamer(R__b);
         backwardPrediction_->setPlane(getPlane());
         // rep needs to be fixed up
       }
-      if (flag & (1 << 4)) {	
+      if (flag & (1 << 4)) {
         backwardUpdate_.reset(new KalmanFittedStateOnPlane());
         backwardUpdate_->Streamer(R__b);
         backwardUpdate_->setPlane(getPlane());
         // rep needs to be fixed up
       }
       {
-        std::vector<genfit::MeasurementOnPlane*,std::allocator<genfit::MeasurementOnPlane*> > &R__stl =  measurementsOnPlane_;
-        TClass *R__tcl1 = TBuffer::GetClass(typeid(genfit::MeasurementOnPlane));
-        if (R__tcl1==0) {
-          Error("measurementsOnPlane_ streamer","Missing the TClass object for genfit::MeasurementOnPlane!");
+        std::vector<genfit::MeasurementOnPlane*, std::allocator<genfit::MeasurementOnPlane*> >& R__stl =  measurementsOnPlane_;
+        TClass* R__tcl1 = TBuffer::GetClass(typeid(genfit::MeasurementOnPlane));
+        if (R__tcl1 == 0) {
+          Error("measurementsOnPlane_ streamer", "Missing the TClass object for genfit::MeasurementOnPlane!");
           return;
         }
         int R__i, R__n;
@@ -770,43 +800,43 @@ void KalmanFitterInfo::Streamer(TBuffer &R__b)
         }
       }
       R__b.CheckByteCount(R__s, R__c, thisClass::IsA());
-   } else {
-     R__c = R__b.WriteVersion(thisClass::IsA(), kTRUE);
-     //This works around a msvc bug and should be harmless on other platforms
-     typedef genfit::AbsFitterInfo baseClass0;
-     baseClass0::Streamer(R__b);
-     // "!!" forces the value to 1 or 0 (pointer != 0 or pointer == 0),
-     // this value is then written as a bitfield.
-     int flag = ((!!referenceState_)
-		 | (!!forwardPrediction_ << 1)
-		 | (!!forwardUpdate_ << 2)
-		 | (!!backwardPrediction_ << 3)
-		 | (!!backwardUpdate_ << 4));
-     R__b << flag;
-     if (flag & 1)
-       referenceState_->Streamer(R__b);
-     if (flag & (1 << 1))
-       forwardPrediction_->Streamer(R__b);
-     if (flag & (1 << 2))
-       forwardUpdate_->Streamer(R__b);
-     if (flag & (1 << 3))
-       backwardPrediction_->Streamer(R__b);
-     if (flag & (1 << 4))
-       backwardUpdate_->Streamer(R__b);
-     {
-       std::vector<genfit::MeasurementOnPlane*,std::allocator<genfit::MeasurementOnPlane*> > &R__stl =  measurementsOnPlane_;
-       int R__n=int(R__stl.size());
-       R__b << R__n;
-       if(R__n) {
-         std::vector<genfit::MeasurementOnPlane*,std::allocator<genfit::MeasurementOnPlane*> >::iterator R__k;
-         for (R__k = R__stl.begin(); R__k != R__stl.end(); ++R__k) {
-           (*R__k)->Streamer(R__b);
-         }
-       }
-     }
-     R__b.SetByteCount(R__c, kTRUE);
+    } else {
+      R__c = R__b.WriteVersion(thisClass::IsA(), kTRUE);
+      //This works around a msvc bug and should be harmless on other platforms
+      typedef genfit::AbsFitterInfo baseClass0;
+      baseClass0::Streamer(R__b);
+      // "!!" forces the value to 1 or 0 (pointer != 0 or pointer == 0),
+      // this value is then written as a bitfield.
+      int flag = ((!!referenceState_)
+                  | (!!forwardPrediction_ << 1)
+                  | (!!forwardUpdate_ << 2)
+                  | (!!backwardPrediction_ << 3)
+                  | (!!backwardUpdate_ << 4));
+      R__b << flag;
+      if (flag & 1)
+        referenceState_->Streamer(R__b);
+      if (flag & (1 << 1))
+        forwardPrediction_->Streamer(R__b);
+      if (flag & (1 << 2))
+        forwardUpdate_->Streamer(R__b);
+      if (flag & (1 << 3))
+        backwardPrediction_->Streamer(R__b);
+      if (flag & (1 << 4))
+        backwardUpdate_->Streamer(R__b);
+      {
+        std::vector<genfit::MeasurementOnPlane*, std::allocator<genfit::MeasurementOnPlane*> >& R__stl =  measurementsOnPlane_;
+        int R__n = int(R__stl.size());
+        R__b << R__n;
+        if (R__n) {
+          std::vector<genfit::MeasurementOnPlane*, std::allocator<genfit::MeasurementOnPlane*> >::iterator R__k;
+          for (R__k = R__stl.begin(); R__k != R__stl.end(); ++R__k) {
+            (*R__k)->Streamer(R__b);
+          }
+        }
+      }
+      R__b.SetByteCount(R__c, kTRUE);
+    }
   }
-}
 
 
 } /* End of namespace genfit */

--- a/fitters/src/KalmanFitterRefTrack.cc
+++ b/fitters/src/KalmanFitterRefTrack.cc
@@ -62,41 +62,41 @@ TrackPoint* KalmanFitterRefTrack::fitTrack(Track* tr, const AbsTrackRep* rep, do
   C_.ResizeTo(dim, dim);
 
   for (size_t i = 0; i < tr->getNumPointsWithMeasurement(); ++i) {
-      TrackPoint *tp = 0;
-      assert(direction == +1 || direction == -1);
-      if (direction == +1)
-        tp = tr->getPointWithMeasurement(i);
-      else if (direction == -1)
-        tp = tr->getPointWithMeasurement(-i-1);
+    TrackPoint* tp = 0;
+    assert(direction == +1 || direction == -1);
+    if (direction == +1)
+      tp = tr->getPointWithMeasurement(i);
+    else if (direction == -1)
+      tp = tr->getPointWithMeasurement(-i - 1);
 
-      if (! tp->hasFitterInfo(rep)) {
-        if (debugLvl_ > 0) {
-          debugOut << "TrackPoint " << i << " has no fitterInfo -> continue. \n";
-        }
-        continue;
-      }
-
-      KalmanFitterInfo* fi = static_cast<KalmanFitterInfo*>(tp->getFitterInfo(rep));
-
-      if (alreadyFitted && fi->hasUpdate(direction)) {
-        if (debugLvl_ > 0) {
-          debugOut << "TrackPoint " << i << " is already fitted -> continue. \n";
-        }
-        prevFi = fi;
-        chi2 += fi->getUpdate(direction)->getChiSquareIncrement();
-        ndf += fi->getUpdate(direction)->getNdf();
-        continue;
-      }
-
-      alreadyFitted = false;
-
+    if (! tp->hasFitterInfo(rep)) {
       if (debugLvl_ > 0) {
-        debugOut << " process TrackPoint nr. " << i << "\n";
+        debugOut << "TrackPoint " << i << " has no fitterInfo -> continue. \n";
       }
-      processTrackPoint(fi, prevFi, tp, chi2, ndf, direction);
-      retVal = tp;
+      continue;
+    }
 
+    KalmanFitterInfo* fi = static_cast<KalmanFitterInfo*>(tp->getFitterInfo(rep));
+
+    if (alreadyFitted && fi->hasUpdate(direction)) {
+      if (debugLvl_ > 0) {
+        debugOut << "TrackPoint " << i << " is already fitted -> continue. \n";
+      }
       prevFi = fi;
+      chi2 += fi->getUpdate(direction)->getChiSquareIncrement();
+      ndf += fi->getUpdate(direction)->getNdf();
+      continue;
+    }
+
+    alreadyFitted = false;
+
+    if (debugLvl_ > 0) {
+      debugOut << " process TrackPoint nr. " << i << "\n";
+    }
+    processTrackPoint(fi, prevFi, tp, chi2, ndf, direction);
+    retVal = tp;
+
+    prevFi = fi;
   }
 
   return retVal;
@@ -106,7 +106,7 @@ TrackPoint* KalmanFitterRefTrack::fitTrack(Track* tr, const AbsTrackRep* rep, do
 void KalmanFitterRefTrack::processTrackWithRep(Track* tr, const AbsTrackRep* rep, bool resortHits)
 {
   if (tr->hasFitStatus(rep) && tr->getFitStatus(rep)->isTrackPruned()) {
-    Exception exc("KalmanFitterRefTrack::processTrack: Cannot process pruned track!", __LINE__,__FILE__);
+    Exception exc("KalmanFitterRefTrack::processTrack: Cannot process pruned track!", __LINE__, __FILE__);
     throw exc;
   }
 
@@ -123,13 +123,13 @@ void KalmanFitterRefTrack::processTrackWithRep(Track* tr, const AbsTrackRep* rep
 
   status->setIsFittedWithReferenceTrack(true);
 
-  unsigned int nIt=0;
+  unsigned int nIt = 0;
   for (;;) {
 
     try {
       if (debugLvl_ > 0) {
         debugOut << " KalmanFitterRefTrack::processTrack with rep " << rep
-        << " (id == " << tr->getIdForRep(rep) << ")"<< ", iteration nr. " << nIt << "\n";
+                 << " (id == " << tr->getIdForRep(rep) << ")" << ", iteration nr. " << nIt << "\n";
       }
 
       // prepare
@@ -149,7 +149,8 @@ void KalmanFitterRefTrack::processTrackWithRep(Track* tr, const AbsTrackRep* rep
         status->setNFailedPoints(nFailedHits);
 
         status->setHasTrackChanged(false);
-        status->setCharge(rep->getCharge(*static_cast<KalmanFitterInfo*>(tr->getPointWithMeasurement(0)->getFitterInfo(rep))->getBackwardUpdate()));
+        status->setCharge(rep->getCharge(*static_cast<KalmanFitterInfo*>(tr->getPointWithMeasurement(0)->getFitterInfo(
+                                           rep))->getBackwardUpdate()));
         status->setNumIterations(nIt);
         status->setForwardChi2(chi2FW);
         status->setBackwardChi2(chi2BW);
@@ -211,16 +212,17 @@ void KalmanFitterRefTrack::processTrackWithRep(Track* tr, const AbsTrackRep* rep
       ++nIt;
 
 
-      double PvalBW = std::max(0.,ROOT::Math::chisquared_cdf_c(chi2BW, ndfBW));
-      double PvalFW = (debugLvl_ > 0) ? std::max(0.,ROOT::Math::chisquared_cdf_c(chi2FW, ndfFW)) : 0; // Don't calculate if not debugging as this function potentially takes a lot of time.
+      double PvalBW = std::max(0., ROOT::Math::chisquared_cdf_c(chi2BW, ndfBW));
+      double PvalFW = (debugLvl_ > 0) ? std::max(0., ROOT::Math::chisquared_cdf_c(chi2FW,
+                                                 ndfFW)) : 0; // Don't calculate if not debugging as this function potentially takes a lot of time.
 
       if (debugLvl_ > 0) {
         debugOut << "KalmanFitterRefTrack::Track after fit:"; tr->Print("C");
 
         debugOut << "old chi2s: " << oldChi2BW << ", " << oldChi2FW
-            << " new chi2s: " << chi2BW << ", " << chi2FW << std::endl;
+                 << " new chi2s: " << chi2BW << ", " << chi2FW << std::endl;
         debugOut << "old pVals: " << oldPvalBW << ", " << oldPvalFW
-            << " new pVals: " << PvalBW << ", " << PvalFW << std::endl;
+                 << " new pVals: " << PvalBW << ", " << PvalFW << std::endl;
       }
 
       // See if p-value only changed little.  If the initial
@@ -234,8 +236,7 @@ void KalmanFitterRefTrack::processTrackWithRep(Track* tr, const AbsTrackRep* rep
         // if pVal ~ 0, check if chi2 has changed significantly
         if (fabs(1 - fabs(oldChi2BW / chi2BW)) > relChi2Change_) {
           finished = false;
-        }
-        else {
+        } else {
           finished = true;
           converged = true;
         }
@@ -247,7 +248,7 @@ void KalmanFitterRefTrack::processTrackWithRep(Track* tr, const AbsTrackRep* rep
       if (finished) {
         if (debugLvl_ > 0) {
           debugOut << "Fit is finished! ";
-          if(converged)
+          if (converged)
             debugOut << "Fit is converged! ";
           debugOut << "\n";
         }
@@ -261,8 +262,7 @@ void KalmanFitterRefTrack::processTrackWithRep(Track* tr, const AbsTrackRep* rep
         status->setNFailedPoints(nFailedHits);
 
         break;
-      }
-      else {
+      } else {
         oldPvalBW = PvalBW;
         oldChi2BW = chi2BW;
         if (debugLvl_ > 0) {
@@ -277,8 +277,7 @@ void KalmanFitterRefTrack::processTrackWithRep(Track* tr, const AbsTrackRep* rep
         }
         break;
       }
-    }
-    catch(Exception& e) {
+    } catch (Exception& e) {
       errorOut << e.what();
       status->setIsFitted(false);
       status->setIsFitConvergedFully(false);
@@ -304,8 +303,7 @@ void KalmanFitterRefTrack::processTrackWithRep(Track* tr, const AbsTrackRep* rep
 
   if (tp != nullptr) {
     status->setIsFitted();
-  }
-  else { // none of the trackPoints has a fitterInfo
+  } else { // none of the trackPoints has a fitterInfo
     status->setIsFitted(false);
     status->setIsFitConvergedFully(false);
     status->setIsFitConvergedPartially(false);
@@ -325,7 +323,8 @@ void KalmanFitterRefTrack::processTrackWithRep(Track* tr, const AbsTrackRep* rep
 }
 
 
-bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool setSortingParams, int& nFailedHits) {
+bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool setSortingParams, int& nFailedHits)
+{
 
   if (debugLvl_ > 0) {
     debugOut << "KalmanFitterRefTrack::prepareTrack \n";
@@ -366,12 +365,12 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
   unsigned int nPoints = tr->getNumPoints();
 
 
-  unsigned int i=0;
+  unsigned int i = 0;
   nFailedHits = 0;
 
 
   // loop over TrackPoints
-  for (; i<nPoints; ++i) {
+  for (; i < nPoints; ++i) {
 
     try {
 
@@ -405,8 +404,7 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
         changedSmthg = true;
         fitterInfo = new KalmanFitterInfo(trackPoint, rep);
         trackPoint->setFitterInfo(fitterInfo);
-      }
-      else {
+      } else {
         if (debugLvl_ > 0) {
           debugOut << "TrackPoint " << i << " (" << trackPoint << ") already has KalmanFitterInfo \n";
         }
@@ -424,8 +422,7 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
           debugOut << "got smoothed state \n";
           //smoothedState->Print();
         }
-      }
-      else {
+      } else {
         smoothedState = nullptr;
       }
 
@@ -454,7 +451,8 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
 
         if (prevReferenceState == nullptr) {
           if (debugLvl_ > 0) {
-            debugOut << "TrackPoint already has referenceState but previous referenceState is nullptr -> reset forward info of current reference state and continue \n";
+            debugOut <<
+                     "TrackPoint already has referenceState but previous referenceState is nullptr -> reset forward info of current reference state and continue \n";
           }
 
           referenceState->resetForward();
@@ -472,7 +470,8 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
 
         // previous refState has been altered ->need to update transport matrices
         if (debugLvl_ > 0) {
-          debugOut << "TrackPoint already has referenceState but previous referenceState has been altered -> update transport matrices and continue \n";
+          debugOut <<
+                   "TrackPoint already has referenceState but previous referenceState has been altered -> update transport matrices and continue \n";
         }
         StateOnPlane stateToExtrapolate(*prevReferenceState);
 
@@ -493,8 +492,7 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
           BTransportMatrix_.UnitMatrix();
           BNoiseMatrix_.Zero();
           backwardDeltaState_.Zero();
-        }
-        else {
+        } else {
           rep->getForwardJacobianAndNoise(FTransportMatrix_, FNoiseMatrix_, forwardDeltaState_);
           rep->getBackwardJacobianAndNoise(BTransportMatrix_, BNoiseMatrix_, backwardDeltaState_);
         }
@@ -529,36 +527,33 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
         if (debugLvl_ > 0)
           debugOut << "construct plane with smoothedState \n";
         plane = trackPoint->getRawMeasurement(0)->constructPlane(*smoothedState);
-      }
-      else if (prevSmoothedState != nullptr) {
+      } else if (prevSmoothedState != nullptr) {
         if (debugLvl_ > 0) {
           debugOut << "construct plane with prevSmoothedState \n";
           //prevSmoothedState->Print();
         }
         plane = trackPoint->getRawMeasurement(0)->constructPlane(*prevSmoothedState);
-      }
-      else if (prevReferenceState != nullptr) {
+      } else if (prevReferenceState != nullptr) {
         if (debugLvl_ > 0) {
           debugOut << "construct plane with prevReferenceState \n";
         }
         plane = trackPoint->getRawMeasurement(0)->constructPlane(*prevReferenceState);
-      }
-      else if (rep != tr->getCardinalRep() &&
-                trackPoint->hasFitterInfo(tr->getCardinalRep()) &&
-                dynamic_cast<KalmanFitterInfo*>(trackPoint->getFitterInfo(tr->getCardinalRep())) != nullptr &&
-                static_cast<KalmanFitterInfo*>(trackPoint->getFitterInfo(tr->getCardinalRep()))->hasPredictionsAndUpdates() ) {
+      } else if (rep != tr->getCardinalRep() &&
+                 trackPoint->hasFitterInfo(tr->getCardinalRep()) &&
+                 dynamic_cast<KalmanFitterInfo*>(trackPoint->getFitterInfo(tr->getCardinalRep())) != nullptr &&
+                 static_cast<KalmanFitterInfo*>(trackPoint->getFitterInfo(tr->getCardinalRep()))->hasPredictionsAndUpdates()) {
         if (debugLvl_ > 0) {
           debugOut << "construct plane with smoothed state of cardinal rep fit \n";
         }
         TVector3 pos, mom;
-        const MeasuredStateOnPlane& fittedState = static_cast<KalmanFitterInfo*>(trackPoint->getFitterInfo(tr->getCardinalRep()))->getFittedState(true);
+        const MeasuredStateOnPlane& fittedState = static_cast<KalmanFitterInfo*>(trackPoint->getFitterInfo(
+                                                    tr->getCardinalRep()))->getFittedState(true);
         tr->getCardinalRep()->getPosMom(fittedState, pos, mom);
         StateOnPlane cardinalState(rep);
         rep->setPosMom(cardinalState, pos, mom);
         rep->setQop(cardinalState, tr->getCardinalRep()->getQop(fittedState));
         plane = trackPoint->getRawMeasurement(0)->constructPlane(cardinalState);
-      }
-      else {
+      } else {
         if (debugLvl_ > 0) {
           debugOut << "construct plane with state from track \n";
         }
@@ -568,7 +563,7 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
       }
 
       if (plane.get() == nullptr) {
-        Exception exc("KalmanFitterRefTrack::prepareTrack ==> construced plane is nullptr!",__LINE__,__FILE__);
+        Exception exc("KalmanFitterRefTrack::prepareTrack ==> construced plane is nullptr!", __LINE__, __FILE__);
         exc.setFatal();
         throw exc;
       }
@@ -586,32 +581,30 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
             debugOut << "extrapolate smoothedState to plane\n";
           }
           stateToExtrapolate.reset(new StateOnPlane(*smoothedState));
-        }
-        else if (referenceState != nullptr) {
+        } else if (referenceState != nullptr) {
           if (debugLvl_ > 0) {
             debugOut << "extrapolate referenceState to plane\n";
           }
           stateToExtrapolate.reset(new StateOnPlane(*referenceState));
-        }
-        else if (rep != tr->getCardinalRep() &&
-                  trackPoint->hasFitterInfo(tr->getCardinalRep()) &&
-                  dynamic_cast<KalmanFitterInfo*>(trackPoint->getFitterInfo(tr->getCardinalRep())) != nullptr &&
-                  static_cast<KalmanFitterInfo*>(trackPoint->getFitterInfo(tr->getCardinalRep()))->hasPredictionsAndUpdates() ) {
+        } else if (rep != tr->getCardinalRep() &&
+                   trackPoint->hasFitterInfo(tr->getCardinalRep()) &&
+                   dynamic_cast<KalmanFitterInfo*>(trackPoint->getFitterInfo(tr->getCardinalRep())) != nullptr &&
+                   static_cast<KalmanFitterInfo*>(trackPoint->getFitterInfo(tr->getCardinalRep()))->hasPredictionsAndUpdates()) {
           if (debugLvl_ > 0) {
             debugOut << "extrapolate smoothed state of cardinal rep fit to plane\n";
           }
           TVector3 pos, mom;
-          const MeasuredStateOnPlane& fittedState = static_cast<KalmanFitterInfo*>(trackPoint->getFitterInfo(tr->getCardinalRep()))->getFittedState(true);
+          const MeasuredStateOnPlane& fittedState = static_cast<KalmanFitterInfo*>(trackPoint->getFitterInfo(
+                                                      tr->getCardinalRep()))->getFittedState(true);
           stateToExtrapolate.reset(new StateOnPlane(fittedState));
           stateToExtrapolate->setRep(rep);
-        }
-        else {
+        } else {
           if (debugLvl_ > 0) {
             debugOut << "extrapolate seed from track to plane\n";
           }
           stateToExtrapolate.reset(new StateOnPlane(rep));
           rep->setPosMom(*stateToExtrapolate, tr->getStateSeed());
-      	  rep->setTime(*stateToExtrapolate, tr->getTimeSeed());
+          rep->setTime(*stateToExtrapolate, tr->getTimeSeed());
         }
       } // end if (prevFitterInfo == nullptr)
       else {
@@ -620,9 +613,8 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
             debugOut << "extrapolate prevSmoothedState to plane \n";
           }
           stateToExtrapolate.reset(new StateOnPlane(*prevSmoothedState));
-        }
-        else {
-          assert (prevReferenceState != nullptr);
+        } else {
+          assert(prevReferenceState != nullptr);
           if (debugLvl_ > 0) {
             debugOut << "extrapolate prevReferenceState to plane \n";
           }
@@ -657,15 +649,14 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
         BTransportMatrix_.UnitMatrix();
         BNoiseMatrix_.Zero();
         backwardDeltaState_.Zero();
-      }
-      else {
-        if (i>0)
+      } else {
+        if (i > 0)
           rep->getForwardJacobianAndNoise(FTransportMatrix_, FNoiseMatrix_, forwardDeltaState_);
         rep->getBackwardJacobianAndNoise(BTransportMatrix_, BNoiseMatrix_, backwardDeltaState_);
       }
 
 
-      if (i==0) {
+      if (i == 0) {
         // if we are at first measurement and seed state is defined somewhere else
         segmentLen = 0;
         trackLen = 0;
@@ -687,9 +678,9 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
       newRefState = true;
       changedSmthg = true;
       referenceState = new ReferenceStateOnPlane(stateToExtrapolate->getState(),
-             stateToExtrapolate->getPlane(),
-             stateToExtrapolate->getRep(),
-             stateToExtrapolate->getAuxInfo());
+                                                 stateToExtrapolate->getPlane(),
+                                                 stateToExtrapolate->getRep(),
+                                                 stateToExtrapolate->getAuxInfo());
       referenceState->setForwardSegmentLength(segmentLen);
       referenceState->setForwardTransportMatrix(FTransportMatrix_);
       referenceState->setForwardNoiseMatrix(FNoiseMatrix_);
@@ -705,7 +696,8 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
       bool oldWeightsFixed = fitterInfo->areWeightsFixed();
       fitterInfo->deleteMeasurementInfo();
       const std::vector<AbsMeasurement*>& rawMeasurements = trackPoint->getRawMeasurements();
-      for ( std::vector< genfit::AbsMeasurement* >::const_iterator measurement = rawMeasurements.begin(), lastMeasurement = rawMeasurements.end(); measurement != lastMeasurement; ++measurement) {
+      for (std::vector< genfit::AbsMeasurement* >::const_iterator measurement = rawMeasurements.begin(),
+           lastMeasurement = rawMeasurements.end(); measurement != lastMeasurement; ++measurement) {
         assert((*measurement) != nullptr);
         fitterInfo->addMeasurementsOnPlane((*measurement)->constructMeasurementsOnPlane(*referenceState));
       }
@@ -721,8 +713,7 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
       prevFitterInfo = fitterInfo;
       prevSmoothedState = smoothedState;
 
-    }
-    catch (Exception& e) {
+    } catch (Exception& e) {
 
       if (debugLvl_ > 0) {
         errorOut << "exception at hit " << i << "\n";
@@ -731,7 +722,7 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
 
 
       ++nFailedHits;
-      if (maxFailedHits_<0 || nFailedHits <= maxFailedHits_) {
+      if (maxFailedHits_ < 0 || nFailedHits <= maxFailedHits_) {
         prevNewRefState = true;
         referenceState = nullptr;
         smoothedState = nullptr;
@@ -741,7 +732,7 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
           tr->getPoint(i)->setSortingParameter(trackLen);
 
         if (debugLvl_ > 0) {
-          debugOut << "There was an exception, try to continue with next TrackPoint " << i+1 << " \n";
+          debugOut << "There was an exception, try to continue with next TrackPoint " << i + 1 << " \n";
         }
 
         continue;
@@ -752,7 +743,7 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
       removeForwardBackwardInfo(tr, rep, notChangedUntil, notChangedFrom);
 
       // set sorting parameters of rest of TrackPoints and remove FitterInfos
-      for (; i<nPoints; ++i) {
+      for (; i < nPoints; ++i) {
         TrackPoint* trackPoint = tr->getPoint(i);
 
         if (setSortingParams)
@@ -802,7 +793,8 @@ bool KalmanFitterRefTrack::prepareTrack(Track* tr, const AbsTrackRep* rep, bool 
 
 
 bool
-KalmanFitterRefTrack::removeOutdated(Track* tr, const AbsTrackRep* rep, int& notChangedUntil, int& notChangedFrom) {
+KalmanFitterRefTrack::removeOutdated(Track* tr, const AbsTrackRep* rep, int& notChangedUntil, int& notChangedFrom)
+{
 
   if (debugLvl_ > 0) {
     debugOut << "KalmanFitterRefTrack::removeOutdated \n";
@@ -811,11 +803,11 @@ KalmanFitterRefTrack::removeOutdated(Track* tr, const AbsTrackRep* rep, int& not
   bool changedSmthg(false);
 
   unsigned int nPoints = tr->getNumPoints();
-  notChangedUntil = nPoints-1;
+  notChangedUntil = nPoints - 1;
   notChangedFrom = 0;
 
   // loop over TrackPoints
-  for (unsigned int i=0; i<nPoints; ++i) {
+  for (unsigned int i = 0; i < nPoints; ++i) {
 
     TrackPoint* trackPoint = tr->getPoint(i);
 
@@ -855,8 +847,8 @@ KalmanFitterRefTrack::removeOutdated(Track* tr, const AbsTrackRep* rep, int& not
 
       // calculate chi2, ignore off diagonals
       double* resArray = resM_.GetMatrixArray();
-      for (int j=0; j<smoothedState.getCov().GetNcols(); ++j)
-        chi2 += resArray[j]*resArray[j] / smoothedState.getCov()(j,j);
+      for (int j = 0; j < smoothedState.getCov().GetNcols(); ++j)
+        chi2 += resArray[j] * resArray[j] / smoothedState.getCov()(j, j);
 
       if (chi2 < deltaChi2Ref_) {
         // reference state is near smoothed state ->  do not update reference state
@@ -879,10 +871,10 @@ KalmanFitterRefTrack::removeOutdated(Track* tr, const AbsTrackRep* rep, int& not
     changedSmthg = true;
 
     // decided to update reference state -> set notChangedUntil (only once)
-    if (notChangedUntil == (int)nPoints-1)
-      notChangedUntil = i-1;
+    if (notChangedUntil == (int)nPoints - 1)
+      notChangedUntil = i - 1;
 
-    notChangedFrom = i+1;
+    notChangedFrom = i + 1;
 
   } // end loop over TrackPoints
 
@@ -896,7 +888,8 @@ KalmanFitterRefTrack::removeOutdated(Track* tr, const AbsTrackRep* rep, int& not
 
 
 void
-KalmanFitterRefTrack::removeForwardBackwardInfo(Track* tr, const AbsTrackRep* rep, int notChangedUntil, int notChangedFrom) const {
+KalmanFitterRefTrack::removeForwardBackwardInfo(Track* tr, const AbsTrackRep* rep, int notChangedUntil, int notChangedFrom) const
+{
 
   unsigned int nPoints = tr->getNumPoints();
 
@@ -907,19 +900,20 @@ KalmanFitterRefTrack::removeForwardBackwardInfo(Track* tr, const AbsTrackRep* re
   }
 
   // delete forward/backward info from/to points where reference states have changed
-  if (notChangedUntil != (int)nPoints-1) {
-    tr->deleteForwardInfo(notChangedUntil+1, -1, rep);
+  if (notChangedUntil != (int)nPoints - 1) {
+    tr->deleteForwardInfo(notChangedUntil + 1, -1, rep);
   }
   if (notChangedFrom != 0)
-    tr->deleteBackwardInfo(0, notChangedFrom-1, rep);
+    tr->deleteBackwardInfo(0, notChangedFrom - 1, rep);
 
 }
 
 
 void
-KalmanFitterRefTrack::processTrackPoint(KalmanFitterInfo* fi, const KalmanFitterInfo* prevFi, const TrackPoint* tp, double& chi2, double& ndf, int direction)
+KalmanFitterRefTrack::processTrackPoint(KalmanFitterInfo* fi, const KalmanFitterInfo* prevFi, const TrackPoint* tp, double& chi2,
+                                        double& ndf, int direction)
 {
-  if(squareRootFormalism_) {
+  if (squareRootFormalism_) {
     processTrackPointSqrt(fi, prevFi, tp, chi2, ndf, direction);
     return;
   }
@@ -946,28 +940,28 @@ KalmanFitterRefTrack::processTrackPoint(KalmanFitterInfo* fi, const KalmanFitter
     C_ = prevFi->getUpdate(direction)->getCov();
     C_.Similarity(F);
     C_ += N;
-    fi->setPrediction(new MeasuredStateOnPlane(p_, C_, fi->getReferenceState()->getPlane(), fi->getReferenceState()->getRep(), fi->getReferenceState()->getAuxInfo()), direction);
+    fi->setPrediction(new MeasuredStateOnPlane(p_, C_, fi->getReferenceState()->getPlane(), fi->getReferenceState()->getRep(),
+                                               fi->getReferenceState()->getAuxInfo()), direction);
     if (debugLvl_ > 1) {
       debugOut << "\033[31m";
       debugOut << "F (Transport Matrix) "; F.Print();
       debugOut << "p_{k,r} (reference state) "; fi->getReferenceState()->getState().Print();
       debugOut << "c (delta state) "; fi->getReferenceState()->getDeltaState(direction).Print();
-      debugOut << "F*p_{k-1,r} + c "; (F *prevFi->getReferenceState()->getState() + fi->getReferenceState()->getDeltaState(direction)).Print();
+      debugOut << "F*p_{k-1,r} + c ";
+      (F * prevFi->getReferenceState()->getState() + fi->getReferenceState()->getDeltaState(direction)).Print();
     }
-  }
-  else {
+  } else {
     if (fi->hasPrediction(direction)) {
       if (debugLvl_ > 0) {
         debugOut << "  Use prediction as start \n";
       }
       p_ = fi->getPrediction(direction)->getState();
       C_ = fi->getPrediction(direction)->getCov();
-    }
-    else {
+    } else {
       if (debugLvl_ > 0) {
         debugOut << "  Use reference state and seed cov as start \n";
       }
-      const AbsTrackRep *rep = fi->getReferenceState()->getRep();
+      const AbsTrackRep* rep = fi->getReferenceState()->getRep();
       p_ = fi->getReferenceState()->getState();
 
       // Convert from 6D covariance of the seed to whatever the trackRep wants.
@@ -996,8 +990,8 @@ KalmanFitterRefTrack::processTrackPoint(KalmanFitterInfo* fi, const KalmanFitter
   // update(s)
   double chi2inc = 0;
   double ndfInc = 0;
-  const std::vector<MeasurementOnPlane *> measurements = getMeasurements(fi, tp, direction);
-  for (std::vector<MeasurementOnPlane *>::const_iterator it = measurements.begin(); it != measurements.end(); ++it) {
+  const std::vector<MeasurementOnPlane*> measurements = getMeasurements(fi, tp, direction);
+  for (std::vector<MeasurementOnPlane*>::const_iterator it = measurements.begin(); it != measurements.end(); ++it) {
     const MeasurementOnPlane& m = **it;
 
     if (!canIgnoreWeights() && m.getWeight() <= 1.01E-10) {
@@ -1010,8 +1004,8 @@ KalmanFitterRefTrack::processTrackPoint(KalmanFitterInfo* fi, const KalmanFitter
     const AbsHMatrix* H(m.getHMatrix());
     // (weighted) cov
     const TMatrixDSym& V((!canIgnoreWeights() && m.getWeight() < 0.99999) ?
-                          1./m.getWeight() * m.getCov() :
-                          m.getCov());
+                         1. / m.getWeight() * m.getCov() :
+                         m.getCov());
 
     covSumInv_.ResizeTo(C_);
     covSumInv_ = C_; // (V_k + H_k C_{k|k-1} H_k^T)^(-1)
@@ -1028,7 +1022,7 @@ KalmanFitterRefTrack::processTrackPoint(KalmanFitterInfo* fi, const KalmanFitter
     if (debugLvl_ > 1) {
       debugOut << "\033[34m";
       debugOut << "m (measurement) "; m.getState().Print();
-      debugOut << "V ((weighted) measurement covariance) "; (1./m.getWeight() * m.getCov()).Print();
+      debugOut << "V ((weighted) measurement covariance) "; (1. / m.getWeight() * m.getCov()).Print();
       debugOut << "residual        "; res_.Print();
       debugOut << "\033[0m";
     }
@@ -1071,8 +1065,7 @@ KalmanFitterRefTrack::processTrackPoint(KalmanFitterInfo* fi, const KalmanFitter
       bool couldInvert(true);
       try {
         tools::invertMatrix(Rinv_);
-      }
-      catch (Exception& e) {
+      } catch (Exception& e) {
         if (debugLvl_ > 1) {
           debugOut << e.what();
         }
@@ -1091,8 +1084,7 @@ KalmanFitterRefTrack::processTrackPoint(KalmanFitterInfo* fi, const KalmanFitter
 
     if (!canIgnoreWeights()) {
       ndfInc += m.getWeight() * m.getState().GetNrows();
-    }
-    else
+    } else
       ndfInc += m.getState().GetNrows();
 
 
@@ -1102,7 +1094,8 @@ KalmanFitterRefTrack::processTrackPoint(KalmanFitterInfo* fi, const KalmanFitter
   ndf += ndfInc;
 
 
-  KalmanFittedStateOnPlane* upState = new KalmanFittedStateOnPlane(p_, C_, fi->getReferenceState()->getPlane(), fi->getReferenceState()->getRep(), fi->getReferenceState()->getAuxInfo(), chi2inc, ndfInc);
+  KalmanFittedStateOnPlane* upState = new KalmanFittedStateOnPlane(p_, C_, fi->getReferenceState()->getPlane(),
+      fi->getReferenceState()->getRep(), fi->getReferenceState()->getAuxInfo(), chi2inc, ndfInc);
   upState->setAuxInfo(fi->getReferenceState()->getAuxInfo());
   fi->setUpdate(upState, direction);
 
@@ -1125,7 +1118,7 @@ KalmanFitterRefTrack::processTrackPoint(KalmanFitterInfo* fi, const KalmanFitter
 
 void
 KalmanFitterRefTrack::processTrackPointSqrt(KalmanFitterInfo* fi, const KalmanFitterInfo* prevFi,
-					    const TrackPoint* tp, double& chi2, double& ndf, int direction)
+                                            const TrackPoint* tp, double& chi2, double& ndf, int direction)
 {
   if (debugLvl_ > 0) {
     debugOut << " KalmanFitterRefTrack::processTrackPointSqrt " << fi->getTrackPoint() << "\n";
@@ -1157,16 +1150,17 @@ KalmanFitterRefTrack::processTrackPointSqrt(KalmanFitterInfo* fi, const KalmanFi
     tools::noiseMatrixSqrt(N, Q);
     tools::kalmanPredictionCovSqrt(decompS.GetU(), F, Q, S);
 
-    fi->setPrediction(new MeasuredStateOnPlane(p_, TMatrixDSym(TMatrixDSym::kAtA, S), fi->getReferenceState()->getPlane(), fi->getReferenceState()->getRep(), fi->getReferenceState()->getAuxInfo()), direction);
+    fi->setPrediction(new MeasuredStateOnPlane(p_, TMatrixDSym(TMatrixDSym::kAtA, S), fi->getReferenceState()->getPlane(),
+                                               fi->getReferenceState()->getRep(), fi->getReferenceState()->getAuxInfo()), direction);
     if (debugLvl_ > 1) {
       debugOut << "\033[31m";
       debugOut << "F (Transport Matrix) "; F.Print();
       debugOut << "p_{k,r} (reference state) "; fi->getReferenceState()->getState().Print();
       debugOut << "c (delta state) "; fi->getReferenceState()->getDeltaState(direction).Print();
-      debugOut << "F*p_{k-1,r} + c "; (F *prevFi->getReferenceState()->getState() + fi->getReferenceState()->getDeltaState(direction)).Print();
+      debugOut << "F*p_{k-1,r} + c ";
+      (F * prevFi->getReferenceState()->getState() + fi->getReferenceState()->getDeltaState(direction)).Print();
     }
-  }
-  else {
+  } else {
     if (fi->hasPrediction(direction)) {
       if (debugLvl_ > 0) {
         debugOut << "  Use prediction as start \n";
@@ -1175,12 +1169,11 @@ KalmanFitterRefTrack::processTrackPointSqrt(KalmanFitterInfo* fi, const KalmanFi
       TDecompChol decompS(fi->getPrediction(direction)->getCov());
       decompS.Decompose();
       S = decompS.GetU();
-    }
-    else {
+    } else {
       if (debugLvl_ > 0) {
         debugOut << "  Use reference state and seed cov as start \n";
       }
-      const AbsTrackRep *rep = fi->getReferenceState()->getRep();
+      const AbsTrackRep* rep = fi->getReferenceState()->getRep();
       p_ = fi->getReferenceState()->getState();
 
       // Convert from 6D covariance of the seed to whatever the trackRep wants.
@@ -1212,8 +1205,8 @@ KalmanFitterRefTrack::processTrackPointSqrt(KalmanFitterInfo* fi, const KalmanFi
   double chi2inc = 0;
   double ndfInc = 0;
 
-  const std::vector<MeasurementOnPlane *> measurements = getMeasurements(fi, tp, direction);
-  for (std::vector<MeasurementOnPlane *>::const_iterator it = measurements.begin(); it != measurements.end(); ++it) {
+  const std::vector<MeasurementOnPlane*> measurements = getMeasurements(fi, tp, direction);
+  for (std::vector<MeasurementOnPlane*>::const_iterator it = measurements.begin(); it != measurements.end(); ++it) {
     const MeasurementOnPlane& m = **it;
 
     if (!canIgnoreWeights() && m.getWeight() <= 1.01E-10) {
@@ -1226,8 +1219,8 @@ KalmanFitterRefTrack::processTrackPointSqrt(KalmanFitterInfo* fi, const KalmanFi
     const AbsHMatrix* H(m.getHMatrix());
     // (weighted) cov
     const TMatrixDSym& V((!canIgnoreWeights() && m.getWeight() < 0.99999) ?
-                          1./m.getWeight() * m.getCov() :
-                          m.getCov());
+                         1. / m.getWeight() * m.getCov() :
+                         m.getCov());
     TDecompChol decompR(V);
     decompR.Decompose();
     const TMatrixD& R(decompR.GetU());
@@ -1238,12 +1231,12 @@ KalmanFitterRefTrack::processTrackPointSqrt(KalmanFitterInfo* fi, const KalmanFi
 
     TVectorD update;
     tools::kalmanUpdateSqrt(S, res_, R, H,
-			    update, S);
+                            update, S);
 
     if (debugLvl_ > 1) {
       debugOut << "\033[34m";
       debugOut << "m (measurement) "; m.getState().Print();
-      debugOut << "V ((weighted) measurement covariance) "; (1./m.getWeight() * m.getCov()).Print();
+      debugOut << "V ((weighted) measurement covariance) "; (1. / m.getWeight() * m.getCov()).Print();
       debugOut << "residual        "; res_.Print();
       debugOut << "\033[0m";
     }
@@ -1280,8 +1273,7 @@ KalmanFitterRefTrack::processTrackPointSqrt(KalmanFitterInfo* fi, const KalmanFi
       bool couldInvert(true);
       try {
         tools::invertMatrix(Rinv_);
-      }
-      catch (Exception& e) {
+      } catch (Exception& e) {
         if (debugLvl_ > 1) {
           debugOut << e.what();
         }
@@ -1299,8 +1291,7 @@ KalmanFitterRefTrack::processTrackPointSqrt(KalmanFitterInfo* fi, const KalmanFi
 
     if (!canIgnoreWeights()) {
       ndfInc += m.getWeight() * m.getState().GetNrows();
-    }
-    else
+    } else
       ndfInc += m.getState().GetNrows();
 
 
@@ -1312,7 +1303,8 @@ KalmanFitterRefTrack::processTrackPointSqrt(KalmanFitterInfo* fi, const KalmanFi
   ndf += ndfInc;
 
 
-  KalmanFittedStateOnPlane* upState = new KalmanFittedStateOnPlane(p_, C_, fi->getReferenceState()->getPlane(), fi->getReferenceState()->getRep(), fi->getReferenceState()->getAuxInfo(), chi2inc, ndfInc);
+  KalmanFittedStateOnPlane* upState = new KalmanFittedStateOnPlane(p_, C_, fi->getReferenceState()->getPlane(),
+      fi->getReferenceState()->getRep(), fi->getReferenceState()->getAuxInfo(), chi2inc, ndfInc);
   upState->setAuxInfo(fi->getReferenceState()->getAuxInfo());
   fi->setUpdate(upState, direction);
 

--- a/fitters/src/ReferenceStateOnPlane.cc
+++ b/fitters/src/ReferenceStateOnPlane.cc
@@ -23,122 +23,127 @@
 
 namespace genfit {
 
-ReferenceStateOnPlane::ReferenceStateOnPlane() :
-  StateOnPlane(),
-  forwardSegmentLength_(0),
-  backwardSegmentLength_(0),
-  forwardTransportMatrix_(),
-  backwardTransportMatrix_(),
-  forwardNoiseMatrix_(),
-  backwardNoiseMatrix_(),
-  forwardDeltaState_(),
-  backwardDeltaState_()
-{
-  ;
-}
+  ReferenceStateOnPlane::ReferenceStateOnPlane() :
+    StateOnPlane(),
+    forwardSegmentLength_(0),
+    backwardSegmentLength_(0),
+    forwardTransportMatrix_(),
+    backwardTransportMatrix_(),
+    forwardNoiseMatrix_(),
+    backwardNoiseMatrix_(),
+    forwardDeltaState_(),
+    backwardDeltaState_()
+  {
+    ;
+  }
 
-ReferenceStateOnPlane::ReferenceStateOnPlane(const TVectorD& state,
-    const SharedPlanePtr& plane,
-    const AbsTrackRep* rep) :
-  StateOnPlane(state, plane, rep),
-  forwardSegmentLength_(0),
-  backwardSegmentLength_(0),
-  forwardTransportMatrix_(rep->getDim(), rep->getDim()),
-  backwardTransportMatrix_(rep->getDim(), rep->getDim()),
-  forwardNoiseMatrix_(rep->getDim()),
-  backwardNoiseMatrix_(rep->getDim()),
-  forwardDeltaState_(rep->getDim()),
-  backwardDeltaState_(rep->getDim())
-{
-  ;
-}
+  ReferenceStateOnPlane::ReferenceStateOnPlane(const TVectorD& state,
+                                               const SharedPlanePtr& plane,
+                                               const AbsTrackRep* rep) :
+    StateOnPlane(state, plane, rep),
+    forwardSegmentLength_(0),
+    backwardSegmentLength_(0),
+    forwardTransportMatrix_(rep->getDim(), rep->getDim()),
+    backwardTransportMatrix_(rep->getDim(), rep->getDim()),
+    forwardNoiseMatrix_(rep->getDim()),
+    backwardNoiseMatrix_(rep->getDim()),
+    forwardDeltaState_(rep->getDim()),
+    backwardDeltaState_(rep->getDim())
+  {
+    ;
+  }
 
-ReferenceStateOnPlane::ReferenceStateOnPlane(const TVectorD& state,
-    const SharedPlanePtr& plane,
-    const AbsTrackRep* rep,
-    const TVectorD& auxInfo) :
-  StateOnPlane(state, plane, rep, auxInfo),
-  forwardSegmentLength_(0),
-  backwardSegmentLength_(0),
-  forwardTransportMatrix_(rep->getDim(), rep->getDim()),
-  backwardTransportMatrix_(rep->getDim(), rep->getDim()),
-  forwardNoiseMatrix_(rep->getDim()),
-  backwardNoiseMatrix_(rep->getDim()),
-  forwardDeltaState_(rep->getDim()),
-  backwardDeltaState_(rep->getDim())
-{
-  ;
-}
-
-
-ReferenceStateOnPlane::ReferenceStateOnPlane(const StateOnPlane& state) :
-  StateOnPlane(state),
-  forwardSegmentLength_(0),
-  backwardSegmentLength_(0),
-  forwardTransportMatrix_(state.getRep()->getDim(), state.getRep()->getDim()),
-  backwardTransportMatrix_(state.getRep()->getDim(), state.getRep()->getDim()),
-  forwardNoiseMatrix_(state.getRep()->getDim()),
-  backwardNoiseMatrix_(state.getRep()->getDim()),
-  forwardDeltaState_(state.getRep()->getDim()),
-  backwardDeltaState_(state.getRep()->getDim())
-{
-  errorOut << "should never come here" << std::endl;
-  exit(0);
-}
+  ReferenceStateOnPlane::ReferenceStateOnPlane(const TVectorD& state,
+                                               const SharedPlanePtr& plane,
+                                               const AbsTrackRep* rep,
+                                               const TVectorD& auxInfo) :
+    StateOnPlane(state, plane, rep, auxInfo),
+    forwardSegmentLength_(0),
+    backwardSegmentLength_(0),
+    forwardTransportMatrix_(rep->getDim(), rep->getDim()),
+    backwardTransportMatrix_(rep->getDim(), rep->getDim()),
+    forwardNoiseMatrix_(rep->getDim()),
+    backwardNoiseMatrix_(rep->getDim()),
+    forwardDeltaState_(rep->getDim()),
+    backwardDeltaState_(rep->getDim())
+  {
+    ;
+  }
 
 
-StateOnPlane& ReferenceStateOnPlane::operator=(ReferenceStateOnPlane other) {
-  swap(other);
-  return *this;
-}
-
-void ReferenceStateOnPlane::swap(ReferenceStateOnPlane& other) {
-  StateOnPlane::swap(other);
-  std::swap(this->forwardSegmentLength_, other.forwardSegmentLength_);
-  std::swap(this->backwardSegmentLength_, other.backwardSegmentLength_);
-  this->forwardTransportMatrix_.ResizeTo(other.forwardTransportMatrix_);
-  std::swap(this->forwardTransportMatrix_, other.forwardTransportMatrix_);
-  this->backwardTransportMatrix_.ResizeTo(other.backwardTransportMatrix_);
-  std::swap(this->backwardTransportMatrix_, other.backwardTransportMatrix_);
-  this->forwardNoiseMatrix_.ResizeTo(other.forwardNoiseMatrix_);
-  std::swap(this->forwardNoiseMatrix_, other.forwardNoiseMatrix_);
-  this->backwardNoiseMatrix_.ResizeTo(other.backwardNoiseMatrix_);
-  std::swap(this->backwardNoiseMatrix_, other.backwardNoiseMatrix_);
-  this->forwardDeltaState_.ResizeTo(other.forwardDeltaState_);
-  std::swap(this->forwardDeltaState_, other.forwardDeltaState_);
-  this->backwardDeltaState_.ResizeTo(other.backwardDeltaState_);
-  std::swap(this->backwardDeltaState_, other.backwardDeltaState_);
-}
+  ReferenceStateOnPlane::ReferenceStateOnPlane(const StateOnPlane& state) :
+    StateOnPlane(state),
+    forwardSegmentLength_(0),
+    backwardSegmentLength_(0),
+    forwardTransportMatrix_(state.getRep()->getDim(), state.getRep()->getDim()),
+    backwardTransportMatrix_(state.getRep()->getDim(), state.getRep()->getDim()),
+    forwardNoiseMatrix_(state.getRep()->getDim()),
+    backwardNoiseMatrix_(state.getRep()->getDim()),
+    forwardDeltaState_(state.getRep()->getDim()),
+    backwardDeltaState_(state.getRep()->getDim())
+  {
+    errorOut << "should never come here" << std::endl;
+    exit(0);
+  }
 
 
-void ReferenceStateOnPlane::resetForward() {
-  forwardSegmentLength_ = 0;
-  forwardTransportMatrix_.UnitMatrix();
-  forwardNoiseMatrix_.Zero();
-  forwardDeltaState_.Zero();
-}
+  StateOnPlane& ReferenceStateOnPlane::operator=(ReferenceStateOnPlane other)
+  {
+    swap(other);
+    return *this;
+  }
 
-void ReferenceStateOnPlane::resetBackward() {
-  backwardSegmentLength_ = 0;
-  backwardTransportMatrix_.UnitMatrix();
-  backwardNoiseMatrix_.Zero();
-  backwardDeltaState_.Zero();
-}
+  void ReferenceStateOnPlane::swap(ReferenceStateOnPlane& other)
+  {
+    StateOnPlane::swap(other);
+    std::swap(this->forwardSegmentLength_, other.forwardSegmentLength_);
+    std::swap(this->backwardSegmentLength_, other.backwardSegmentLength_);
+    this->forwardTransportMatrix_.ResizeTo(other.forwardTransportMatrix_);
+    std::swap(this->forwardTransportMatrix_, other.forwardTransportMatrix_);
+    this->backwardTransportMatrix_.ResizeTo(other.backwardTransportMatrix_);
+    std::swap(this->backwardTransportMatrix_, other.backwardTransportMatrix_);
+    this->forwardNoiseMatrix_.ResizeTo(other.forwardNoiseMatrix_);
+    std::swap(this->forwardNoiseMatrix_, other.forwardNoiseMatrix_);
+    this->backwardNoiseMatrix_.ResizeTo(other.backwardNoiseMatrix_);
+    std::swap(this->backwardNoiseMatrix_, other.backwardNoiseMatrix_);
+    this->forwardDeltaState_.ResizeTo(other.forwardDeltaState_);
+    std::swap(this->forwardDeltaState_, other.forwardDeltaState_);
+    this->backwardDeltaState_.ResizeTo(other.backwardDeltaState_);
+    std::swap(this->backwardDeltaState_, other.backwardDeltaState_);
+  }
 
 
-void ReferenceStateOnPlane::Print(Option_t*) const {
-  StateOnPlane::Print();
+  void ReferenceStateOnPlane::resetForward()
+  {
+    forwardSegmentLength_ = 0;
+    forwardTransportMatrix_.UnitMatrix();
+    forwardNoiseMatrix_.Zero();
+    forwardDeltaState_.Zero();
+  }
 
-  printOut << " forwardSegmentLength: " << forwardSegmentLength_ << "\n";
-  printOut << " forwardTransportMatrix: "; forwardTransportMatrix_.Print();
-  printOut << " forwardNoiseMatrix: "; forwardNoiseMatrix_.Print();
-  printOut << " forwardDeltaState: "; forwardDeltaState_.Print();
+  void ReferenceStateOnPlane::resetBackward()
+  {
+    backwardSegmentLength_ = 0;
+    backwardTransportMatrix_.UnitMatrix();
+    backwardNoiseMatrix_.Zero();
+    backwardDeltaState_.Zero();
+  }
 
-  printOut << " backwardSegmentLength_: " << backwardSegmentLength_ << "\n";
-  printOut << " backwardTransportMatrix: "; backwardTransportMatrix_.Print();
-  printOut << " backwardNoiseMatrix: "; backwardNoiseMatrix_.Print();
-  printOut << " backwardDeltaState: "; backwardDeltaState_.Print();
-}
+
+  void ReferenceStateOnPlane::Print(Option_t*) const
+  {
+    StateOnPlane::Print();
+
+    printOut << " forwardSegmentLength: " << forwardSegmentLength_ << "\n";
+    printOut << " forwardTransportMatrix: "; forwardTransportMatrix_.Print();
+    printOut << " forwardNoiseMatrix: "; forwardNoiseMatrix_.Print();
+    printOut << " forwardDeltaState: "; forwardDeltaState_.Print();
+
+    printOut << " backwardSegmentLength_: " << backwardSegmentLength_ << "\n";
+    printOut << " backwardTransportMatrix: "; backwardTransportMatrix_.Print();
+    printOut << " backwardNoiseMatrix: "; backwardNoiseMatrix_.Print();
+    printOut << " backwardDeltaState: "; backwardDeltaState_.Print();
+  }
 
 
 } /* End of namespace genfit */

--- a/measurements/include/FullMeasurement.h
+++ b/measurements/include/FullMeasurement.h
@@ -30,39 +30,39 @@
 
 namespace genfit {
 
-class AbsTrackRep;
+  class AbsTrackRep;
 
-/** @brief Measurement class implementing a measurement of all track parameters.
- *
- *  @author Johannes Rauch  (Technische Universit&auml;t M&uuml;nchen, original author)
- *
- * This class can e.g. be used, if the fitted track parameters measured in one subdetector should be
- * put into one "measurement".
- */
-class FullMeasurement : public AbsMeasurement {
+  /** @brief Measurement class implementing a measurement of all track parameters.
+   *
+   *  @author Johannes Rauch  (Technische Universit&auml;t M&uuml;nchen, original author)
+   *
+   * This class can e.g. be used, if the fitted track parameters measured in one subdetector should be
+   * put into one "measurement".
+   */
+  class FullMeasurement : public AbsMeasurement {
 
- public:
-  FullMeasurement(int nDim = 5);
-  FullMeasurement(const MeasuredStateOnPlane&, int detId = -1, int hitId = -1, TrackPoint* trackPoint = nullptr);
+  public:
+    FullMeasurement(int nDim = 5);
+    FullMeasurement(const MeasuredStateOnPlane&, int detId = -1, int hitId = -1, TrackPoint* trackPoint = nullptr);
 
-  virtual ~FullMeasurement() {;}
+    virtual ~FullMeasurement() {;}
 
-  virtual AbsMeasurement* clone() const override {return new FullMeasurement(*this);}
+    virtual AbsMeasurement* clone() const override {return new FullMeasurement(*this);}
 
-  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const override;
+    virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const override;
 
-  virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const override;
+    virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const override;
 
-  virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const override;
+    virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const override;
 
- protected:
-  SharedPlanePtr plane_;   //! This is persistent, but '!' makes ROOT shut up.
+  protected:
+    SharedPlanePtr plane_;   //! This is persistent, but '!' makes ROOT shut up.
 
- public:
+  public:
 
-  ClassDefOverride(FullMeasurement,1)
+    ClassDefOverride(FullMeasurement, 1)
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/measurements/include/HMatrixPhi.h
+++ b/measurements/include/HMatrixPhi.h
@@ -28,42 +28,42 @@
 
 namespace genfit {
 
-/**
- * @brief AbsHMatrix implementation for one-dimensional MeasurementOnPlane and RKTrackRep parameterization.
- *
- * For one dimensional measurements which are rotated by phi against U of the DetPlane
- * H = (0, 0, 0, cos(phi), sin(phi))
- */
-class HMatrixPhi : public AbsHMatrix {
+  /**
+   * @brief AbsHMatrix implementation for one-dimensional MeasurementOnPlane and RKTrackRep parameterization.
+   *
+   * For one dimensional measurements which are rotated by phi against U of the DetPlane
+   * H = (0, 0, 0, cos(phi), sin(phi))
+   */
+  class HMatrixPhi : public AbsHMatrix {
 
- public:
+  public:
 
-  HMatrixPhi(double phi = 0);
+    HMatrixPhi(double phi = 0);
 
-  const TMatrixD& getMatrix() const;
+    const TMatrixD& getMatrix() const;
 
-  TVectorD Hv(const TVectorD& v) const;
+    TVectorD Hv(const TVectorD& v) const;
 
-  TMatrixD MHt(const TMatrixDSym& M) const;
-  TMatrixD MHt(const TMatrixD& M) const;
+    TMatrixD MHt(const TMatrixDSym& M) const;
+    TMatrixD MHt(const TMatrixD& M) const;
 
-  void HMHt(TMatrixDSym& M) const;
+    void HMHt(TMatrixDSym& M) const;
 
-  virtual HMatrixPhi* clone() const {return new HMatrixPhi(*this);}
+    virtual HMatrixPhi* clone() const {return new HMatrixPhi(*this);}
 
-  virtual bool isEqual(const AbsHMatrix& other) const;
+    virtual bool isEqual(const AbsHMatrix& other) const;
 
-  virtual void Print(const Option_t* = "") const;
+    virtual void Print(const Option_t* = "") const;
 
-  ClassDef(HMatrixPhi,1)
+    ClassDef(HMatrixPhi, 1)
 
- private:
+  private:
 
-  double phi_;
-  double cosPhi_; //!
-  double sinPhi_; //!
+    double phi_;
+    double cosPhi_; //!
+    double sinPhi_; //!
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/measurements/include/HMatrixU.h
+++ b/measurements/include/HMatrixU.h
@@ -28,36 +28,36 @@
 
 namespace genfit {
 
-/**
- * @brief AbsHMatrix implementation for one-dimensional MeasurementOnPlane and RKTrackRep parameterization.
- *
- * This projects out u.
- * H = (0, 0, 0, 1, 0)
- */
-class HMatrixU : public AbsHMatrix {
+  /**
+   * @brief AbsHMatrix implementation for one-dimensional MeasurementOnPlane and RKTrackRep parameterization.
+   *
+   * This projects out u.
+   * H = (0, 0, 0, 1, 0)
+   */
+  class HMatrixU : public AbsHMatrix {
 
- public:
+  public:
 
-  HMatrixU() {;}
+    HMatrixU() {;}
 
-  const TMatrixD& getMatrix() const override;
+    const TMatrixD& getMatrix() const override;
 
-  TVectorD Hv(const TVectorD& v) const override;
+    TVectorD Hv(const TVectorD& v) const override;
 
-  TMatrixD MHt(const TMatrixDSym& M) const override;
-  TMatrixD MHt(const TMatrixD& M) const override;
+    TMatrixD MHt(const TMatrixDSym& M) const override;
+    TMatrixD MHt(const TMatrixD& M) const override;
 
-  void HMHt(TMatrixDSym& M) const override;
+    void HMHt(TMatrixDSym& M) const override;
 
-  virtual HMatrixU* clone() const override {return new HMatrixU(*this);}
+    virtual HMatrixU* clone() const override {return new HMatrixU(*this);}
 
-  virtual bool isEqual(const AbsHMatrix& other) const override {return (dynamic_cast<const HMatrixU*>(&other) != nullptr);}
+    virtual bool isEqual(const AbsHMatrix& other) const override {return (dynamic_cast<const HMatrixU*>(&other) != nullptr);}
 
-  virtual void Print(const Option_t* = "") const override;
+    virtual void Print(const Option_t* = "") const override;
 
-  ClassDefOverride(HMatrixU,1)
+    ClassDefOverride(HMatrixU, 1)
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/measurements/include/HMatrixUV.h
+++ b/measurements/include/HMatrixUV.h
@@ -28,39 +28,39 @@
 
 namespace genfit {
 
-/**
- * @brief AbsHMatrix implementation for two-dimensional MeasurementOnPlane and RKTrackRep parameterization.
- *
- * This projects out u and v.
- * H = (0, 0, 0, 1, 0)
- *     (0, 0, 0, 0, 1)
- *
- */
-class HMatrixUV : public AbsHMatrix {
+  /**
+   * @brief AbsHMatrix implementation for two-dimensional MeasurementOnPlane and RKTrackRep parameterization.
+   *
+   * This projects out u and v.
+   * H = (0, 0, 0, 1, 0)
+   *     (0, 0, 0, 0, 1)
+   *
+   */
+  class HMatrixUV : public AbsHMatrix {
 
 
- public:
+  public:
 
-  HMatrixUV() {;}
+    HMatrixUV() {;}
 
-  const TMatrixD& getMatrix() const override;
+    const TMatrixD& getMatrix() const override;
 
-  TVectorD Hv(const TVectorD& v) const override;
+    TVectorD Hv(const TVectorD& v) const override;
 
-  TMatrixD MHt(const TMatrixDSym& M) const override;
-  TMatrixD MHt(const TMatrixD& M) const override;
+    TMatrixD MHt(const TMatrixDSym& M) const override;
+    TMatrixD MHt(const TMatrixD& M) const override;
 
-  void HMHt(TMatrixDSym& M) const override;
+    void HMHt(TMatrixDSym& M) const override;
 
-  virtual HMatrixUV* clone() const override {return new HMatrixUV(*this);}
+    virtual HMatrixUV* clone() const override {return new HMatrixUV(*this);}
 
-  virtual bool isEqual(const AbsHMatrix& other) const override {return (dynamic_cast<const HMatrixUV*>(&other) != nullptr);}
+    virtual bool isEqual(const AbsHMatrix& other) const override {return (dynamic_cast<const HMatrixUV*>(&other) != nullptr);}
 
-  virtual void Print(const Option_t* = "") const override;
+    virtual void Print(const Option_t* = "") const override;
 
-  ClassDefOverride(HMatrixUV,1)
+    ClassDefOverride(HMatrixUV, 1)
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/measurements/include/HMatrixUnit.h
+++ b/measurements/include/HMatrixUnit.h
@@ -28,39 +28,39 @@
 
 namespace genfit {
 
-/**
- * @brief AbsHMatrix implementation for 5-dimensional MeasurementOnPlane and RKTrackRep parameterization.
- *
- * H = (1, 0, 0, 0, 0)
- *     (0, 1, 0, 0, 0)
- *     (0, 0, 1, 0, 0)
- *     (0, 0, 0, 1, 0)
- *     (0, 0, 0, 0, 1)
- */
-class HMatrixUnit : public AbsHMatrix {
+  /**
+   * @brief AbsHMatrix implementation for 5-dimensional MeasurementOnPlane and RKTrackRep parameterization.
+   *
+   * H = (1, 0, 0, 0, 0)
+   *     (0, 1, 0, 0, 0)
+   *     (0, 0, 1, 0, 0)
+   *     (0, 0, 0, 1, 0)
+   *     (0, 0, 0, 0, 1)
+   */
+  class HMatrixUnit : public AbsHMatrix {
 
- public:
+  public:
 
-  HMatrixUnit() {;}
+    HMatrixUnit() {;}
 
-  const TMatrixD& getMatrix() const;
+    const TMatrixD& getMatrix() const;
 
-  TVectorD Hv(const TVectorD& v) const {return v;}
+    TVectorD Hv(const TVectorD& v) const {return v;}
 
-  TMatrixD MHt(const TMatrixDSym& M) const {return TMatrixD(M);}
-  TMatrixD MHt(const TMatrixD& M) const {return M;}
+    TMatrixD MHt(const TMatrixDSym& M) const {return TMatrixD(M);}
+    TMatrixD MHt(const TMatrixD& M) const {return M;}
 
-  void HMHt(TMatrixDSym&) const {return;}
+    void HMHt(TMatrixDSym&) const {return;}
 
-  virtual HMatrixUnit* clone() const {return new HMatrixUnit(*this);}
+    virtual HMatrixUnit* clone() const {return new HMatrixUnit(*this);}
 
-  virtual bool isEqual(const AbsHMatrix& other) const {return (dynamic_cast<const HMatrixUnit*>(&other) != nullptr);}
+    virtual bool isEqual(const AbsHMatrix& other) const {return (dynamic_cast<const HMatrixUnit*>(&other) != nullptr);}
 
-  virtual void Print(const Option_t* = "") const;
+    virtual void Print(const Option_t* = "") const;
 
-  ClassDef(HMatrixUnit,1)
+    ClassDef(HMatrixUnit, 1)
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/measurements/include/HMatrixV.h
+++ b/measurements/include/HMatrixV.h
@@ -28,36 +28,36 @@
 
 namespace genfit {
 
-/**
- * @brief AbsHMatrix implementation for one-dimensional MeasurementOnPlane and RKTrackRep parameterization.
- *
- * This projects out v.
- * H = (0, 0, 0, 0, 1)
- */
-class HMatrixV : public AbsHMatrix {
+  /**
+   * @brief AbsHMatrix implementation for one-dimensional MeasurementOnPlane and RKTrackRep parameterization.
+   *
+   * This projects out v.
+   * H = (0, 0, 0, 0, 1)
+   */
+  class HMatrixV : public AbsHMatrix {
 
- public:
+  public:
 
-  HMatrixV() {;}
+    HMatrixV() {;}
 
-  const TMatrixD& getMatrix() const override;
+    const TMatrixD& getMatrix() const override;
 
-  TVectorD Hv(const TVectorD& v) const override;
+    TVectorD Hv(const TVectorD& v) const override;
 
-  TMatrixD MHt(const TMatrixDSym& M) const override;
-  TMatrixD MHt(const TMatrixD& M) const override;
+    TMatrixD MHt(const TMatrixDSym& M) const override;
+    TMatrixD MHt(const TMatrixD& M) const override;
 
-  void HMHt(TMatrixDSym& M) const override;
+    void HMHt(TMatrixDSym& M) const override;
 
-  virtual HMatrixV* clone() const override {return new HMatrixV(*this);}
+    virtual HMatrixV* clone() const override {return new HMatrixV(*this);}
 
-  virtual bool isEqual(const AbsHMatrix& other) const override {return (dynamic_cast<const HMatrixV*>(&other) != nullptr);}
+    virtual bool isEqual(const AbsHMatrix& other) const override {return (dynamic_cast<const HMatrixV*>(&other) != nullptr);}
 
-  virtual void Print(const Option_t* = "") const override;
+    virtual void Print(const Option_t* = "") const override;
 
-  ClassDefOverride(HMatrixV,1)
+    ClassDefOverride(HMatrixV, 1)
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/measurements/include/PlanarMeasurement.h
+++ b/measurements/include/PlanarMeasurement.h
@@ -30,55 +30,55 @@
 
 namespace genfit {
 
-class AbsTrackRep;
+  class AbsTrackRep;
 
-/** @brief Measurement class implementing a planar hit geometry (1 or 2D).
- *
- *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
- *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
- *  @author Johannes Rauch  (Technische Universit&auml;t M&uuml;nchen, original author)
- *
- * The main feature of this type of hit is, that the detector plane
- * is defined by the detector hardware. 
- */
-class PlanarMeasurement : public AbsMeasurement {
-
- public:
-  PlanarMeasurement(int nDim = 1);
-  PlanarMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId, TrackPoint* trackPoint);
-
-  virtual ~PlanarMeasurement() {;}
-
-  virtual AbsMeasurement* clone() const override {return new PlanarMeasurement(*this);}
-
-  int getPlaneId() const {return planeId_;}
-
-  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const override;
-
-  virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const override;
-
-  virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const override;
-
-  virtual void setPlane(const SharedPlanePtr& physicalPlane, int planeId = -1) {physicalPlane_ = physicalPlane; planeId_ = planeId;}
-
-  /** @brief Use if the coordinate for 1D hits measured in V direction.
+  /** @brief Measurement class implementing a planar hit geometry (1 or 2D).
    *
-   * Per default for 1D planar hits, the coordinate is measured in U direction.
-   * With this function you can set it to be measured in V direction.
-   * This affects the outcoe of constructHMatrix().
+   *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
+   *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
+   *  @author Johannes Rauch  (Technische Universit&auml;t M&uuml;nchen, original author)
+   *
+   * The main feature of this type of hit is, that the detector plane
+   * is defined by the detector hardware.
    */
-  void setStripV(bool v = true) {stripV_ = v;}
+  class PlanarMeasurement : public AbsMeasurement {
 
- protected:
-  SharedPlanePtr physicalPlane_;   //! This is persistent, but '!' makes ROOT shut up.
-  int planeId_; // planeId id is -1 per default
-  bool stripV_;
+  public:
+    PlanarMeasurement(int nDim = 1);
+    PlanarMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId, TrackPoint* trackPoint);
 
- public:
+    virtual ~PlanarMeasurement() {;}
 
-  ClassDefOverride(PlanarMeasurement,1)
+    virtual AbsMeasurement* clone() const override {return new PlanarMeasurement(*this);}
 
-};
+    int getPlaneId() const {return planeId_;}
+
+    virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const override;
+
+    virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const override;
+
+    virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const override;
+
+    virtual void setPlane(const SharedPlanePtr& physicalPlane, int planeId = -1) {physicalPlane_ = physicalPlane; planeId_ = planeId;}
+
+    /** @brief Use if the coordinate for 1D hits measured in V direction.
+     *
+     * Per default for 1D planar hits, the coordinate is measured in U direction.
+     * With this function you can set it to be measured in V direction.
+     * This affects the outcoe of constructHMatrix().
+     */
+    void setStripV(bool v = true) {stripV_ = v;}
+
+  protected:
+    SharedPlanePtr physicalPlane_;   //! This is persistent, but '!' makes ROOT shut up.
+    int planeId_; // planeId id is -1 per default
+    bool stripV_;
+
+  public:
+
+    ClassDefOverride(PlanarMeasurement, 1)
+
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/measurements/include/ProlateSpacepointMeasurement.h
+++ b/measurements/include/ProlateSpacepointMeasurement.h
@@ -28,45 +28,46 @@
 
 namespace genfit {
 
-/** @brief Class for measurements implementing a space point hit geometry with a very prolate
- * form of the covariance matrix.
- *
- *  @author Johannes Rauch (Technische Universit&auml;t M&uuml;nchen, original author)
- *
- * Measurements from detectors measuring 3D space points with errors in one direction
- * much larger than the errors perpendicular should use this class.
- *
- * For these hits, a virtual detector plane lying in the POCA and
- * perpendicular to the track yields wrong results. Instead, the plane should contain the
- * direction of the largest error.
- *
- * The largest error direction can be set. Standard is in z.
- *
- */
-class ProlateSpacepointMeasurement : public SpacepointMeasurement {
+  /** @brief Class for measurements implementing a space point hit geometry with a very prolate
+   * form of the covariance matrix.
+   *
+   *  @author Johannes Rauch (Technische Universit&auml;t M&uuml;nchen, original author)
+   *
+   * Measurements from detectors measuring 3D space points with errors in one direction
+   * much larger than the errors perpendicular should use this class.
+   *
+   * For these hits, a virtual detector plane lying in the POCA and
+   * perpendicular to the track yields wrong results. Instead, the plane should contain the
+   * direction of the largest error.
+   *
+   * The largest error direction can be set. Standard is in z.
+   *
+   */
+  class ProlateSpacepointMeasurement : public SpacepointMeasurement {
 
- public:
-  ProlateSpacepointMeasurement(int nDim = 3);
-  ProlateSpacepointMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId, TrackPoint* trackPoint);
+  public:
+    ProlateSpacepointMeasurement(int nDim = 3);
+    ProlateSpacepointMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId,
+                                 TrackPoint* trackPoint);
 
-  virtual ~ProlateSpacepointMeasurement() {;}
+    virtual ~ProlateSpacepointMeasurement() {;}
 
-  virtual AbsMeasurement* clone() const {return new ProlateSpacepointMeasurement(*this);}
+    virtual AbsMeasurement* clone() const {return new ProlateSpacepointMeasurement(*this);}
 
-  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const;
+    virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const;
 
 
-  const TVector3& getLargestErrorDirection(){return largestErrorDirection_;}
-  void setLargestErrorDirection(const TVector3& dir){largestErrorDirection_ = dir.Unit();}
+    const TVector3& getLargestErrorDirection() {return largestErrorDirection_;}
+    void setLargestErrorDirection(const TVector3& dir) {largestErrorDirection_ = dir.Unit();}
 
- protected:
-  TVector3 largestErrorDirection_; // direction of largest error
+  protected:
+    TVector3 largestErrorDirection_; // direction of largest error
 
- public:
+  public:
 
-  ClassDef(ProlateSpacepointMeasurement,1)
+    ClassDef(ProlateSpacepointMeasurement, 1)
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/measurements/include/SpacepointMeasurement.h
+++ b/measurements/include/SpacepointMeasurement.h
@@ -29,66 +29,66 @@
 
 namespace genfit {
 
-/** @brief Class for measurements implementing a space point hit geometry.
- *
- *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
- *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
- *  @author Johannes Rauch  (Technische Universit&auml;t M&uuml;nchen, original author)
- *
- * For a space point the detector plane has to be defined with respect to
- * a track representation. SpacepointMeasurement implements a scheme where the
- * detectorplane is chosen perpendicular to the track.
- * In a track fit, only two of the three coordinates of a space point are
- * independent (the track is a one-dimensional object). Therefore the 3D
- * data of the hit is used to define a proper detector plane into which the
- * hit coordinates are then projected.
- */
-class SpacepointMeasurement : public AbsMeasurement {
-
- public:
-  SpacepointMeasurement(int nDim = 3);
-  SpacepointMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId, TrackPoint* trackPoint,
-      bool weightedPlaneContruction = true, bool cutCov = true);
-
-  virtual ~SpacepointMeasurement() {;}
-
-  virtual AbsMeasurement* clone() const override {return new SpacepointMeasurement(*this);}
-
-  /**
-   * @brief Contruct the virtual detector plane
+  /** @brief Class for measurements implementing a space point hit geometry.
    *
-   * Per default, the plane will be constructed such that it contains the measurement and POCA to the measurement in cartesian space.
-   * The plane is perpendicular to the track (at the POCA).
+   *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
+   *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
+   *  @author Johannes Rauch  (Technische Universit&auml;t M&uuml;nchen, original author)
    *
-   *  If weightedPlaneContruction_ is set, the POCA will be calculated in a space weighted with the inverse of the 3D covariance.
-   *  E.g. if the covariance is very oblate, the plane will be almost defined by the covariance shape.
-   *  If the covariance is very prolate, the behaviour will be very similar to the ProlateSpacepointHit.
+   * For a space point the detector plane has to be defined with respect to
+   * a track representation. SpacepointMeasurement implements a scheme where the
+   * detectorplane is chosen perpendicular to the track.
+   * In a track fit, only two of the three coordinates of a space point are
+   * independent (the track is a one-dimensional object). Therefore the 3D
+   * data of the hit is used to define a proper detector plane into which the
+   * hit coordinates are then projected.
    */
-  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const override;
+  class SpacepointMeasurement : public AbsMeasurement {
 
-  virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const override;
+  public:
+    SpacepointMeasurement(int nDim = 3);
+    SpacepointMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId, TrackPoint* trackPoint,
+                          bool weightedPlaneContruction = true, bool cutCov = true);
 
-  virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const override;
+    virtual ~SpacepointMeasurement() {;}
 
-  /// false: project 3D cov onto DetPlane. true: cut 3D cov with DetPlane
-  bool getWeightedPlaneConstruction() const     { return weightedPlaneContruction_; }
-  void setWeightedPlaneConstruction(bool value) { weightedPlaneContruction_ = value; }
+    virtual AbsMeasurement* clone() const override {return new SpacepointMeasurement(*this);}
 
-  /// false: use POCA to construct DetPlane. true: Use metric G to construct POCA
-  bool getCutCov() const     { return cutCov_; }
-  void setCutCov(bool value) { cutCov_ = value; }
+    /**
+     * @brief Contruct the virtual detector plane
+     *
+     * Per default, the plane will be constructed such that it contains the measurement and POCA to the measurement in cartesian space.
+     * The plane is perpendicular to the track (at the POCA).
+     *
+     *  If weightedPlaneContruction_ is set, the POCA will be calculated in a space weighted with the inverse of the 3D covariance.
+     *  E.g. if the covariance is very oblate, the plane will be almost defined by the covariance shape.
+     *  If the covariance is very prolate, the behaviour will be very similar to the ProlateSpacepointHit.
+     */
+    virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const override;
 
- protected:
-  void initG();
+    virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const override;
 
- private:
+    virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const override;
 
-  bool weightedPlaneContruction_; // false: use POCA to construct DetPlane. true: Use metric G to construct POCA (default)
-  TMatrixDSym G_; //! inverse of 3x3 cov
-  bool cutCov_; // false: project 3D cov onto DetPlane. true: cut 3D cov with DetPlane (default)
+    /// false: project 3D cov onto DetPlane. true: cut 3D cov with DetPlane
+    bool getWeightedPlaneConstruction() const     { return weightedPlaneContruction_; }
+    void setWeightedPlaneConstruction(bool value) { weightedPlaneContruction_ = value; }
 
-  ClassDefOverride(SpacepointMeasurement,3)
-};
+    /// false: use POCA to construct DetPlane. true: Use metric G to construct POCA
+    bool getCutCov() const     { return cutCov_; }
+    void setCutCov(bool value) { cutCov_ = value; }
+
+  protected:
+    void initG();
+
+  private:
+
+    bool weightedPlaneContruction_; // false: use POCA to construct DetPlane. true: Use metric G to construct POCA (default)
+    TMatrixDSym G_; //! inverse of 3x3 cov
+    bool cutCov_; // false: project 3D cov onto DetPlane. true: cut 3D cov with DetPlane (default)
+
+    ClassDefOverride(SpacepointMeasurement, 3)
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/measurements/include/WireMeasurement.h
+++ b/measurements/include/WireMeasurement.h
@@ -30,78 +30,78 @@
 
 namespace genfit {
 
-/** @brief Class for measurements in wire detectors (Straw tubes and drift chambers)
- *  which do not measure the coordinate along the wire.
- *
- *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
- *  @author Lia Lavezzi (INFN Pavia, original author)
- *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
- *  @author Johannes Rauch  (Technische Universit&auml;t M&uuml;nchen, original author)
- *
- * This hit class is not valid for any kind of plane orientation
- * choice: to use it you MUST choose a plane described by u
- * and v axes with v coincident with the wire (and u orthogonal
- * to it, obviously).
- * The hit will be described by 7 coordinates:
- * w_x1, w_y1, w_z1, w_x2, w_y2, w_z2, rdrift
- * where w_ji (with j = x, y, z and i = 1, 2) are the wire
- * extremities coordinates; rdrift = distance from the wire (u
- * coordinate in the plane)
- *
- */
-class WireMeasurement : public AbsMeasurement {
-
- public:
-  WireMeasurement(int nDim = 7);
-  WireMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId, TrackPoint* trackPoint);
-
-  virtual ~WireMeasurement() {;}
-
-  virtual AbsMeasurement* clone() const override {return new WireMeasurement(*this);}
-
-  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const override;
-
-  /**  Hits with a small drift distance get a higher weight, whereas hits with
-    * big drift distances become weighted down.
-    * When these initial weights are used by the DAF, the smoothed track will be closer to the real
-    * trajectory than if both sides are weighted with 0.5 regardless of the drift distance.
-    * This helps a lot when resolving l/r ambiguities with the DAF.
-    * The idea is that for the first iteration of the DAF, the wire positions are taken.
-    * For small drift radii, the wire position does not bend the fit away from the
-    * trajectory, whereas the wire position for hits with large drift radii is further away
-    * from the trajectory and will therefore bias the fit if not weighted down.
-    */
-  virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const override;
-
-  virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const override;
-
-  /** Set maximum drift distance. This is used to calculate the start weights of the two
-   * measurementsOnPlane.
+  /** @brief Class for measurements in wire detectors (Straw tubes and drift chambers)
+   *  which do not measure the coordinate along the wire.
+   *
+   *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
+   *  @author Lia Lavezzi (INFN Pavia, original author)
+   *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
+   *  @author Johannes Rauch  (Technische Universit&auml;t M&uuml;nchen, original author)
+   *
+   * This hit class is not valid for any kind of plane orientation
+   * choice: to use it you MUST choose a plane described by u
+   * and v axes with v coincident with the wire (and u orthogonal
+   * to it, obviously).
+   * The hit will be described by 7 coordinates:
+   * w_x1, w_y1, w_z1, w_x2, w_y2, w_z2, rdrift
+   * where w_ji (with j = x, y, z and i = 1, 2) are the wire
+   * extremities coordinates; rdrift = distance from the wire (u
+   * coordinate in the plane)
+   *
    */
-  void setMaxDistance(double d){maxDistance_ = d;}
-  /**
-   * select how to resolve the left/right ambiguity:
-   * -1: negative (left) side on vector (track direction) x (wire direction)
-   * 0: auto select (take side with smallest distance to track)
-   * 1: positive (right) side on vector (track direction) x (wire direction)
-   */
-  void setLeftRightResolution(int lr);
+  class WireMeasurement : public AbsMeasurement {
 
-  virtual bool isLeftRightMeasurement() const override {return true;}
-  virtual int getLeftRightResolution() const override {return leftRight_;}
+  public:
+    WireMeasurement(int nDim = 7);
+    WireMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId, TrackPoint* trackPoint);
 
-  double getMaxDistance(){return maxDistance_;}
+    virtual ~WireMeasurement() {;}
 
- protected:
+    virtual AbsMeasurement* clone() const override {return new WireMeasurement(*this);}
 
-  double maxDistance_;
-  signed char leftRight_;
+    virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const override;
 
- public:
+    /**  Hits with a small drift distance get a higher weight, whereas hits with
+      * big drift distances become weighted down.
+      * When these initial weights are used by the DAF, the smoothed track will be closer to the real
+      * trajectory than if both sides are weighted with 0.5 regardless of the drift distance.
+      * This helps a lot when resolving l/r ambiguities with the DAF.
+      * The idea is that for the first iteration of the DAF, the wire positions are taken.
+      * For small drift radii, the wire position does not bend the fit away from the
+      * trajectory, whereas the wire position for hits with large drift radii is further away
+      * from the trajectory and will therefore bias the fit if not weighted down.
+      */
+    virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const override;
 
-  ClassDefOverride(WireMeasurement, 2)
+    virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const override;
 
-};
+    /** Set maximum drift distance. This is used to calculate the start weights of the two
+     * measurementsOnPlane.
+     */
+    void setMaxDistance(double d) {maxDistance_ = d;}
+    /**
+     * select how to resolve the left/right ambiguity:
+     * -1: negative (left) side on vector (track direction) x (wire direction)
+     * 0: auto select (take side with smallest distance to track)
+     * 1: positive (right) side on vector (track direction) x (wire direction)
+     */
+    void setLeftRightResolution(int lr);
+
+    virtual bool isLeftRightMeasurement() const override {return true;}
+    virtual int getLeftRightResolution() const override {return leftRight_;}
+
+    double getMaxDistance() {return maxDistance_;}
+
+  protected:
+
+    double maxDistance_;
+    signed char leftRight_;
+
+  public:
+
+    ClassDefOverride(WireMeasurement, 2)
+
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/measurements/include/WireMeasurementNew.h
+++ b/measurements/include/WireMeasurementNew.h
@@ -31,87 +31,88 @@
 
 namespace genfit {
 
-/** @brief Class for measurements in wire detectors (Straw tubes and drift chambers)
- *  which do not measure the coordinate along the wire.
- *
- *  @author Tobias Schlüter
- *
- * This is similar to WireMeasurement, but since WireMeasurement
- * stores a 7x7 covariance matrix for what is a one-dimensional
- * measurement, this class is preferable.  Protected inheritance of
- * rawHitCoords_ and rawHitCov_ makes it impossible to rewrite
- * WireMeasurement, as subclasses will access these members.
- *
- * This hit class is not valid for arbitrary choices of plane
- * orientation: to use it you MUST choose a plane described by u
- * and v axes with v coincident with the wire (and u orthogonal
- * to it, obviously).
- * The hit will be described by 7 coordinates:
- * w_x1, w_y1, w_z1, w_x2, w_y2, w_z2, rdrift
- * where w_ji (with j = x, y, z and i = 1, 2) are the wire
- * extremities coordinates; rdrift = distance from the wire (u
- * coordinate in the plane)
- *
- */
-class WireMeasurementNew : public AbsMeasurement {
-
- public:
-  WireMeasurementNew();
-  WireMeasurementNew(double driftDistance, double driftDistanceError, const TVector3& endPoint1, const TVector3& endPoint2, int detId, int hitId, TrackPoint* trackPoint);
-
-  virtual ~WireMeasurementNew() {;}
-
-  virtual WireMeasurementNew* clone() const override {return new WireMeasurementNew(*this);}
-
-  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const override;
-
-  /**  Hits with a small drift distance get a higher weight, whereas hits with
-    * big drift distances become weighted down.
-    * When these initial weights are used by the DAF, the smoothed track will be closer to the real
-    * trajectory than if both sides are weighted with 0.5 regardless of the drift distance.
-    * This helps a lot when resolving l/r ambiguities with the DAF.
-    * The idea is that for the first iteration of the DAF, the wire positions are taken.
-    * For small drift radii, the wire position does not bend the fit away from the
-    * trajectory, whereas the wire position for hits with large drift radii is further away
-    * from the trajectory and will therefore bias the fit if not weighted down.
-    */
-  virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const override;
-
-  virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const override;
-
-  /** Reset the wire end points.
+  /** @brief Class for measurements in wire detectors (Straw tubes and drift chambers)
+   *  which do not measure the coordinate along the wire.
+   *
+   *  @author Tobias Schlüter
+   *
+   * This is similar to WireMeasurement, but since WireMeasurement
+   * stores a 7x7 covariance matrix for what is a one-dimensional
+   * measurement, this class is preferable.  Protected inheritance of
+   * rawHitCoords_ and rawHitCov_ makes it impossible to rewrite
+   * WireMeasurement, as subclasses will access these members.
+   *
+   * This hit class is not valid for arbitrary choices of plane
+   * orientation: to use it you MUST choose a plane described by u
+   * and v axes with v coincident with the wire (and u orthogonal
+   * to it, obviously).
+   * The hit will be described by 7 coordinates:
+   * w_x1, w_y1, w_z1, w_x2, w_y2, w_z2, rdrift
+   * where w_ji (with j = x, y, z and i = 1, 2) are the wire
+   * extremities coordinates; rdrift = distance from the wire (u
+   * coordinate in the plane)
+   *
    */
-  void setWireEndPoints(const TVector3& endPoint1, const TVector3& endPoint2);
+  class WireMeasurementNew : public AbsMeasurement {
 
-  /** Set maximum drift distance. This is used to calculate the start weights of the two
-   * measurementsOnPlane.
-   */
-  void setMaxDistance(double d){maxDistance_ = d;}
-  /**
-   * select how to resolve the left/right ambiguity:
-   * -1: negative (left) side on vector (wire direction) x (track direction)
-   * 0: mirrors enter with same weight, DAF will decide.
-   * 1: positive (right) side on vector (wire direction) x (track direction)
-   * where the wire direction is pointing from endPoint1 to endPoint2
-   */
-  void setLeftRightResolution(int lr);
+  public:
+    WireMeasurementNew();
+    WireMeasurementNew(double driftDistance, double driftDistanceError, const TVector3& endPoint1, const TVector3& endPoint2, int detId,
+                       int hitId, TrackPoint* trackPoint);
 
-  virtual bool isLeftRigthMeasurement() const {return true;}
-  double getMaxDistance(){return maxDistance_;}
-  int getLeftRightResolution() const override {return leftRight_;}
+    virtual ~WireMeasurementNew() {;}
 
- protected:
+    virtual WireMeasurementNew* clone() const override {return new WireMeasurementNew(*this);}
 
-  double wireEndPoint1_[3]; //! Wire end point 1 (X, Y, Z)
-  double wireEndPoint2_[3]; //! Wire end point 2 (X, Y, Z)
-  double maxDistance_;
-  double leftRight_;
+    virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const override;
 
- public:
+    /**  Hits with a small drift distance get a higher weight, whereas hits with
+      * big drift distances become weighted down.
+      * When these initial weights are used by the DAF, the smoothed track will be closer to the real
+      * trajectory than if both sides are weighted with 0.5 regardless of the drift distance.
+      * This helps a lot when resolving l/r ambiguities with the DAF.
+      * The idea is that for the first iteration of the DAF, the wire positions are taken.
+      * For small drift radii, the wire position does not bend the fit away from the
+      * trajectory, whereas the wire position for hits with large drift radii is further away
+      * from the trajectory and will therefore bias the fit if not weighted down.
+      */
+    virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const override;
 
-  ClassDefOverride(WireMeasurementNew, 1)
+    virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const override;
 
-};
+    /** Reset the wire end points.
+     */
+    void setWireEndPoints(const TVector3& endPoint1, const TVector3& endPoint2);
+
+    /** Set maximum drift distance. This is used to calculate the start weights of the two
+     * measurementsOnPlane.
+     */
+    void setMaxDistance(double d) {maxDistance_ = d;}
+    /**
+     * select how to resolve the left/right ambiguity:
+     * -1: negative (left) side on vector (wire direction) x (track direction)
+     * 0: mirrors enter with same weight, DAF will decide.
+     * 1: positive (right) side on vector (wire direction) x (track direction)
+     * where the wire direction is pointing from endPoint1 to endPoint2
+     */
+    void setLeftRightResolution(int lr);
+
+    virtual bool isLeftRigthMeasurement() const {return true;}
+    double getMaxDistance() {return maxDistance_;}
+    int getLeftRightResolution() const override {return leftRight_;}
+
+  protected:
+
+    double wireEndPoint1_[3]; //! Wire end point 1 (X, Y, Z)
+    double wireEndPoint2_[3]; //! Wire end point 2 (X, Y, Z)
+    double maxDistance_;
+    double leftRight_;
+
+  public:
+
+    ClassDefOverride(WireMeasurementNew, 1)
+
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/measurements/include/WirePointMeasurement.h
+++ b/measurements/include/WirePointMeasurement.h
@@ -28,48 +28,48 @@
 
 namespace genfit {
 
-/** @brief Class for measurements in wire detectors (Straw tubes and drift chambers)
- *  which can measure the coordinate along the wire
- *
- *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
- *  @author Lia Lavezzi (INFN Pavia, original author)
- *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
- *  @author Johannes Rauch  (Technische Universit&auml;t M&uuml;nchen, original author)
- *
- * This  is not valid for any kind of plane orientation
- * choice: to use it you MUST choose a plane described by u
- * and v axes with v coincident with the wire (and u orthogonal
- * to it, obviously).
- * The hit will be described by 8 coordinates:
- * w_x1, w_y1, w_z1, w_x2, w_y2, w_z2, rdrift, zreco
- * where w_ji (with j = x, y, z and i = 1, 2) are the wire
- * extremities coordinates; rdrift = distance from the wire (u
- * coordinate in the plane) and zreco = coordinate along the
- * wire (w2 -w1) (in the plane reference frame, v coordinate).
- *
- */
-class WirePointMeasurement : public WireMeasurement {
+  /** @brief Class for measurements in wire detectors (Straw tubes and drift chambers)
+   *  which can measure the coordinate along the wire
+   *
+   *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
+   *  @author Lia Lavezzi (INFN Pavia, original author)
+   *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
+   *  @author Johannes Rauch  (Technische Universit&auml;t M&uuml;nchen, original author)
+   *
+   * This  is not valid for any kind of plane orientation
+   * choice: to use it you MUST choose a plane described by u
+   * and v axes with v coincident with the wire (and u orthogonal
+   * to it, obviously).
+   * The hit will be described by 8 coordinates:
+   * w_x1, w_y1, w_z1, w_x2, w_y2, w_z2, rdrift, zreco
+   * where w_ji (with j = x, y, z and i = 1, 2) are the wire
+   * extremities coordinates; rdrift = distance from the wire (u
+   * coordinate in the plane) and zreco = coordinate along the
+   * wire (w2 -w1) (in the plane reference frame, v coordinate).
+   *
+   */
+  class WirePointMeasurement : public WireMeasurement {
 
- public:
-  WirePointMeasurement(int nDim = 8);
-  WirePointMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId, TrackPoint* trackPoint);
+  public:
+    WirePointMeasurement(int nDim = 8);
+    WirePointMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId, TrackPoint* trackPoint);
 
-  virtual ~WirePointMeasurement() {;}
+    virtual ~WirePointMeasurement() {;}
 
-  virtual AbsMeasurement* clone() const override {return new WirePointMeasurement(*this);}
+    virtual AbsMeasurement* clone() const override {return new WirePointMeasurement(*this);}
 
-  virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const override;
+    virtual SharedPlanePtr constructPlane(const StateOnPlane& state) const override;
 
-  virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const override;
+    virtual std::vector<MeasurementOnPlane*> constructMeasurementsOnPlane(const StateOnPlane& state) const override;
 
-  virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const override;
+    virtual const AbsHMatrix* constructHMatrix(const AbsTrackRep*) const override;
 
 
- public:
+  public:
 
-  ClassDefOverride(WirePointMeasurement,1)
+    ClassDefOverride(WirePointMeasurement, 1)
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/measurements/include/WireTrackCandHit.h
+++ b/measurements/include/WireTrackCandHit.h
@@ -28,60 +28,61 @@
 
 namespace genfit {
 
-/**
- * @brief Hit object for use in TrackCand. Provides additional left/right parameter.
- */
-class WireTrackCandHit : public TrackCandHit {
- public:
-
-  // Constructors/Destructors ---------
-  WireTrackCandHit(int detId   = -1,
-               int hitId   = -1,
-               int planeId = -1,
-               double sortingParameter  =  0.,
-               char leftRight = 0);
-
-  virtual ~WireTrackCandHit() {;}
-
-  virtual WireTrackCandHit* clone() const override {return new WireTrackCandHit(*this);}
-
-  // Accessors
-  int getLeftRightResolution() const {return leftRight_;}
-
-  // Modifiers
   /**
-   * select how to resolve the left/right ambiguity:
-   * -1: negative (left) side on vector (track direction) x (wire direction)
-   * 0: auto select (take side with smallest distance to track)
-   * 1: positive (right) side on vector (track direction) x (wire direction)
+   * @brief Hit object for use in TrackCand. Provides additional left/right parameter.
    */
-  void setLeftRightResolution(int leftRight){
-    if (leftRight==0) leftRight_ = 0;
-    else if (leftRight<0) leftRight_ = -1;
-    else leftRight_ = 1;
-  }
+  class WireTrackCandHit : public TrackCandHit {
+  public:
 
-  virtual void Print(Option_t* option = "") const override;
+    // Constructors/Destructors ---------
+    WireTrackCandHit(int detId   = -1,
+                     int hitId   = -1,
+                     int planeId = -1,
+                     double sortingParameter  =  0.,
+                     char leftRight = 0);
+
+    virtual ~WireTrackCandHit() {;}
+
+    virtual WireTrackCandHit* clone() const override {return new WireTrackCandHit(*this);}
+
+    // Accessors
+    int getLeftRightResolution() const {return leftRight_;}
+
+    // Modifiers
+    /**
+     * select how to resolve the left/right ambiguity:
+     * -1: negative (left) side on vector (track direction) x (wire direction)
+     * 0: auto select (take side with smallest distance to track)
+     * 1: positive (right) side on vector (track direction) x (wire direction)
+     */
+    void setLeftRightResolution(int leftRight)
+    {
+      if (leftRight == 0) leftRight_ = 0;
+      else if (leftRight < 0) leftRight_ = -1;
+      else leftRight_ = 1;
+    }
+
+    virtual void Print(Option_t* option = "") const override;
 
 
- protected:
+  protected:
 
-  //! protect from calling copy c'tor from outside the class. Use #clone() if you want a copy!
-  WireTrackCandHit(const WireTrackCandHit& other) :
-    TrackCandHit(other), leftRight_(other.leftRight_) {;}
-  //! protect from calling assignment operator from outside the class. Use #clone() instead!
-  WireTrackCandHit& operator=(const WireTrackCandHit&);
-
-
-  // Data Members ------------
-  signed char leftRight_; // left/right ambiguity handling
+    //! protect from calling copy c'tor from outside the class. Use #clone() if you want a copy!
+    WireTrackCandHit(const WireTrackCandHit& other) :
+      TrackCandHit(other), leftRight_(other.leftRight_) {;}
+    //! protect from calling assignment operator from outside the class. Use #clone() instead!
+    WireTrackCandHit& operator=(const WireTrackCandHit&);
 
 
- public:
+    // Data Members ------------
+    signed char leftRight_; // left/right ambiguity handling
 
-  ClassDefOverride(WireTrackCandHit, 2)
 
-};
+  public:
+
+    ClassDefOverride(WireTrackCandHit, 2)
+
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/measurements/src/FullMeasurement.cc
+++ b/measurements/src/FullMeasurement.cc
@@ -28,61 +28,65 @@
 
 namespace genfit {
 
-FullMeasurement::FullMeasurement(int nDim)
-  : AbsMeasurement(nDim), plane_()
-{
-  assert(nDim >= 1);
-}
-
-
-FullMeasurement::FullMeasurement(const MeasuredStateOnPlane& state, int detId, int hitId, TrackPoint* trackPoint)
-  : AbsMeasurement(state.getState(), state.getCov(), detId, hitId, trackPoint), plane_(state.getPlane())
-{
-  assert(rawHitCoords_.GetNrows() == (int)state.getRep()->getDim());
-}
-
-
-SharedPlanePtr FullMeasurement::constructPlane(const StateOnPlane&) const {
-  if (!plane_) {
-    Exception exc("FullMeasurement::constructPlane(): No plane has been set!", __LINE__,__FILE__);
-    throw exc;
-  }
-  return plane_;
-}
-
-
-std::vector<MeasurementOnPlane*> FullMeasurement::constructMeasurementsOnPlane(const StateOnPlane& state) const {
-
-  MeasurementOnPlane* mop = new MeasurementOnPlane(rawHitCoords_,
-       rawHitCov_,
-       state.getPlane(), state.getRep(), constructHMatrix(state.getRep()));
-
-  std::vector<MeasurementOnPlane*> retVal;
-  retVal.push_back(mop);
-  return retVal;
-}
-
-
-const AbsHMatrix* FullMeasurement::constructHMatrix(const AbsTrackRep* rep) const {
-
-  if (dynamic_cast<const RKTrackRep*>(rep) == nullptr) {
-    Exception exc("SpacepointMeasurement default implementation can only handle state vectors of type RKTrackRep!", __LINE__,__FILE__);
-    throw exc;
+  FullMeasurement::FullMeasurement(int nDim)
+    : AbsMeasurement(nDim), plane_()
+  {
+    assert(nDim >= 1);
   }
 
-  return new HMatrixUnit();
-}
+
+  FullMeasurement::FullMeasurement(const MeasuredStateOnPlane& state, int detId, int hitId, TrackPoint* trackPoint)
+    : AbsMeasurement(state.getState(), state.getCov(), detId, hitId, trackPoint), plane_(state.getPlane())
+  {
+    assert(rawHitCoords_.GetNrows() == (int)state.getRep()->getDim());
+  }
 
 
-void FullMeasurement::Streamer(TBuffer &R__b)
-{
-   // Stream an object of class genfit::FullMeasurement.
+  SharedPlanePtr FullMeasurement::constructPlane(const StateOnPlane&) const
+  {
+    if (!plane_) {
+      Exception exc("FullMeasurement::constructPlane(): No plane has been set!", __LINE__, __FILE__);
+      throw exc;
+    }
+    return plane_;
+  }
 
-   //This works around a msvc bug and should be harmless on other platforms
-   typedef ::genfit::FullMeasurement thisClass;
-   UInt_t R__s, R__c;
-   if (R__b.IsReading()) {
-      Version_t R__v = R__b.ReadVersion(&R__s, &R__c); if (R__v) { }
+
+  std::vector<MeasurementOnPlane*> FullMeasurement::constructMeasurementsOnPlane(const StateOnPlane& state) const
+  {
+
+    MeasurementOnPlane* mop = new MeasurementOnPlane(rawHitCoords_,
+                                                     rawHitCov_,
+                                                     state.getPlane(), state.getRep(), constructHMatrix(state.getRep()));
+
+    std::vector<MeasurementOnPlane*> retVal;
+    retVal.push_back(mop);
+    return retVal;
+  }
+
+
+  const AbsHMatrix* FullMeasurement::constructHMatrix(const AbsTrackRep* rep) const
+  {
+
+    if (dynamic_cast<const RKTrackRep*>(rep) == nullptr) {
+      Exception exc("SpacepointMeasurement default implementation can only handle state vectors of type RKTrackRep!", __LINE__, __FILE__);
+      throw exc;
+    }
+
+    return new HMatrixUnit();
+  }
+
+
+  void FullMeasurement::Streamer(TBuffer& R__b)
+  {
+    // Stream an object of class genfit::FullMeasurement.
+
+    //This works around a msvc bug and should be harmless on other platforms
+    typedef ::genfit::FullMeasurement thisClass;
+    UInt_t R__s, R__c;
+    if (R__b.IsReading()) {
+      Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+      if (R__v) { }
       //This works around a msvc bug and should be harmless on other platforms
       typedef genfit::AbsMeasurement baseClass0;
       baseClass0::Streamer(R__b);
@@ -94,7 +98,7 @@ void FullMeasurement::Streamer(TBuffer &R__b)
         plane_->Streamer(R__b);
       }
       R__b.CheckByteCount(R__s, R__c, thisClass::IsA());
-   } else {
+    } else {
       R__c = R__b.WriteVersion(thisClass::IsA(), kTRUE);
       //This works around a msvc bug and should be harmless on other platforms
       typedef genfit::AbsMeasurement baseClass0;
@@ -106,7 +110,7 @@ void FullMeasurement::Streamer(TBuffer &R__b)
         R__b << (char)0;
       }
       R__b.SetByteCount(R__c, kTRUE);
-   }
-}
+    }
+  }
 
 } /* End of namespace genfit */

--- a/measurements/src/HMatrixPhi.cc
+++ b/measurements/src/HMatrixPhi.cc
@@ -34,97 +34,104 @@ namespace genfit {
 // 0, 0, 0, cos(phi), sin(phi)
 
 
-HMatrixPhi::HMatrixPhi(double phi) :
-  phi_(phi),
-  cosPhi_(cos(phi)),
-  sinPhi_(sin(phi))
-{
-  ;
-}
-
-const TMatrixD& HMatrixPhi::getMatrix() const {
-  static const double HMatrixContent[5] = {0, 0, 0, cosPhi_, sinPhi_};
-
-  static const TMatrixD HMatrix(1,5, HMatrixContent);
-
-  return HMatrix;
-}
-
-
-TVectorD HMatrixPhi::Hv(const TVectorD& v) const {
-  assert (v.GetNrows() == 5);
-
-  double* retValArray =(double *)alloca(sizeof(double) * 1);
-
-  retValArray[0] = cosPhi_*v(3) + sinPhi_*v(4);
-
-  return TVectorD(1, retValArray);
-}
-
-
-TMatrixD HMatrixPhi::MHt(const TMatrixDSym& M) const {
-  assert (M.GetNcols() == 5);
-
-  double* retValArray =(double *)alloca(sizeof(double) * 5);
-  const double* MatArray = M.GetMatrixArray();
-
-  for (unsigned int i=0; i<5; ++i) {
-    retValArray[i] = cosPhi_*MatArray[i*5 + 3] + sinPhi_*MatArray[i*5 + 4];
+  HMatrixPhi::HMatrixPhi(double phi) :
+    phi_(phi),
+    cosPhi_(cos(phi)),
+    sinPhi_(sin(phi))
+  {
+    ;
   }
 
-  return TMatrixD(5,1, retValArray);
-}
+  const TMatrixD& HMatrixPhi::getMatrix() const
+  {
+    static const double HMatrixContent[5] = {0, 0, 0, cosPhi_, sinPhi_};
 
+    static const TMatrixD HMatrix(1, 5, HMatrixContent);
 
-TMatrixD HMatrixPhi::MHt(const TMatrixD& M) const {
-  assert (M.GetNcols() == 5);
-
-  double* retValArray =(double *)alloca(sizeof(double) * M.GetNrows());
-  const double* MatArray = M.GetMatrixArray();
-
-  for (int i = 0; i < M.GetNrows(); ++i) {
-    retValArray[i] = cosPhi_*MatArray[i*5 + 3] + sinPhi_*MatArray[i*5 + 4];
+    return HMatrix;
   }
 
-  return TMatrixD(M.GetNrows(),1, retValArray);
-}
 
+  TVectorD HMatrixPhi::Hv(const TVectorD& v) const
+  {
+    assert(v.GetNrows() == 5);
 
-void HMatrixPhi::HMHt(TMatrixDSym& M) const {
-  assert (M.GetNrows() == 5);
+    double* retValArray = (double*)alloca(sizeof(double) * 1);
 
-  M(0,0) =   cosPhi_ * (cosPhi_*M(3,3) + sinPhi_*M(3,4))
-           + sinPhi_ * (cosPhi_*M(4,3) + sinPhi_*M(4,4));
+    retValArray[0] = cosPhi_ * v(3) + sinPhi_ * v(4);
 
-  M.ResizeTo(1,1);
-}
-
-
-bool HMatrixPhi::isEqual(const AbsHMatrix& other) const {
-  if (dynamic_cast<const HMatrixPhi*>(&other) == nullptr)
-    return false;
-
-  return (phi_ == static_cast<const HMatrixPhi*>(&other)->phi_);
-}
-
-void HMatrixPhi::Print(const Option_t*) const
-{
-  printOut << "phi = " << phi_ << std::endl;
-}
-
-void HMatrixPhi::Streamer(TBuffer &R__b) {
-  // Stream an object of class genfit::HMatrixPhi.
-
-  // Modified from auto-generated streamer to set non-persistent members after reading
-
-  if (R__b.IsReading()) {
-    R__b.ReadClassBuffer(genfit::HMatrixPhi::Class(),this);
-    cosPhi_ = cos(phi_);
-    sinPhi_ = sin(phi_);
-  } else {
-    R__b.WriteClassBuffer(genfit::HMatrixPhi::Class(),this);
+    return TVectorD(1, retValArray);
   }
-}
+
+
+  TMatrixD HMatrixPhi::MHt(const TMatrixDSym& M) const
+  {
+    assert(M.GetNcols() == 5);
+
+    double* retValArray = (double*)alloca(sizeof(double) * 5);
+    const double* MatArray = M.GetMatrixArray();
+
+    for (unsigned int i = 0; i < 5; ++i) {
+      retValArray[i] = cosPhi_ * MatArray[i * 5 + 3] + sinPhi_ * MatArray[i * 5 + 4];
+    }
+
+    return TMatrixD(5, 1, retValArray);
+  }
+
+
+  TMatrixD HMatrixPhi::MHt(const TMatrixD& M) const
+  {
+    assert(M.GetNcols() == 5);
+
+    double* retValArray = (double*)alloca(sizeof(double) * M.GetNrows());
+    const double* MatArray = M.GetMatrixArray();
+
+    for (int i = 0; i < M.GetNrows(); ++i) {
+      retValArray[i] = cosPhi_ * MatArray[i * 5 + 3] + sinPhi_ * MatArray[i * 5 + 4];
+    }
+
+    return TMatrixD(M.GetNrows(), 1, retValArray);
+  }
+
+
+  void HMatrixPhi::HMHt(TMatrixDSym& M) const
+  {
+    assert(M.GetNrows() == 5);
+
+    M(0, 0) =   cosPhi_ * (cosPhi_ * M(3, 3) + sinPhi_ * M(3, 4))
+                + sinPhi_ * (cosPhi_ * M(4, 3) + sinPhi_ * M(4, 4));
+
+    M.ResizeTo(1, 1);
+  }
+
+
+  bool HMatrixPhi::isEqual(const AbsHMatrix& other) const
+  {
+    if (dynamic_cast<const HMatrixPhi*>(&other) == nullptr)
+      return false;
+
+    return (phi_ == static_cast<const HMatrixPhi*>(&other)->phi_);
+  }
+
+  void HMatrixPhi::Print(const Option_t*) const
+  {
+    printOut << "phi = " << phi_ << std::endl;
+  }
+
+  void HMatrixPhi::Streamer(TBuffer& R__b)
+  {
+    // Stream an object of class genfit::HMatrixPhi.
+
+    // Modified from auto-generated streamer to set non-persistent members after reading
+
+    if (R__b.IsReading()) {
+      R__b.ReadClassBuffer(genfit::HMatrixPhi::Class(), this);
+      cosPhi_ = cos(phi_);
+      sinPhi_ = sin(phi_);
+    } else {
+      R__b.WriteClassBuffer(genfit::HMatrixPhi::Class(), this);
+    }
+  }
 
 
 } /* End of namespace genfit */

--- a/measurements/src/HMatrixU.cc
+++ b/measurements/src/HMatrixU.cc
@@ -30,66 +30,72 @@ namespace genfit {
 
 // 0, 0, 0, 1, 0
 
-const TMatrixD& HMatrixU::getMatrix() const {
-  static const double HMatrixContent[5] = {0, 0, 0, 1, 0};
+  const TMatrixD& HMatrixU::getMatrix() const
+  {
+    static const double HMatrixContent[5] = {0, 0, 0, 1, 0};
 
-  static const TMatrixD HMatrix(1,5, HMatrixContent);
+    static const TMatrixD HMatrix(1, 5, HMatrixContent);
 
-  return HMatrix;
-}
-
-
-TVectorD HMatrixU::Hv(const TVectorD& v) const {
-  assert (v.GetNrows() == 5);
-
-  double* retValArray =(double *)alloca(sizeof(double) * 1);
-
-  retValArray[0] = v(3); // u
-
-  return TVectorD(1, retValArray);
-}
-
-
-TMatrixD HMatrixU::MHt(const TMatrixDSym& M) const {
-  assert (M.GetNcols() == 5);
-
-  double* retValArray =(double *)alloca(sizeof(double) * 5);
-  const double* MatArray = M.GetMatrixArray();
-
-  for (unsigned int i=0; i<5; ++i) {
-    retValArray[i] = MatArray[i*5 + 3];
+    return HMatrix;
   }
 
-  return TMatrixD(5,1, retValArray);
-}
 
+  TVectorD HMatrixU::Hv(const TVectorD& v) const
+  {
+    assert(v.GetNrows() == 5);
 
-TMatrixD HMatrixU::MHt(const TMatrixD& M) const {
-  assert (M.GetNcols() == 5);
+    double* retValArray = (double*)alloca(sizeof(double) * 1);
 
-  double* retValArray =(double *)alloca(sizeof(double) * M.GetNrows());
-  const double* MatArray = M.GetMatrixArray();
+    retValArray[0] = v(3); // u
 
-  for (int i = 0; i < M.GetNrows(); ++i) {
-    retValArray[i] = MatArray[i*5 + 3];
+    return TVectorD(1, retValArray);
   }
 
-  return TMatrixD(M.GetNrows(),1, retValArray);
-}
+
+  TMatrixD HMatrixU::MHt(const TMatrixDSym& M) const
+  {
+    assert(M.GetNcols() == 5);
+
+    double* retValArray = (double*)alloca(sizeof(double) * 5);
+    const double* MatArray = M.GetMatrixArray();
+
+    for (unsigned int i = 0; i < 5; ++i) {
+      retValArray[i] = MatArray[i * 5 + 3];
+    }
+
+    return TMatrixD(5, 1, retValArray);
+  }
 
 
-void HMatrixU::HMHt(TMatrixDSym& M) const {
-  assert (M.GetNrows() == 5);
+  TMatrixD HMatrixU::MHt(const TMatrixD& M) const
+  {
+    assert(M.GetNcols() == 5);
 
-  M(0,0) = M(3,3);
+    double* retValArray = (double*)alloca(sizeof(double) * M.GetNrows());
+    const double* MatArray = M.GetMatrixArray();
 
-  M.ResizeTo(1,1);
-}
+    for (int i = 0; i < M.GetNrows(); ++i) {
+      retValArray[i] = MatArray[i * 5 + 3];
+    }
+
+    return TMatrixD(M.GetNrows(), 1, retValArray);
+  }
 
 
-void HMatrixU::Print(const Option_t*) const {
-  printOut << "U" << std::endl;
-}
+  void HMatrixU::HMHt(TMatrixDSym& M) const
+  {
+    assert(M.GetNrows() == 5);
+
+    M(0, 0) = M(3, 3);
+
+    M.ResizeTo(1, 1);
+  }
+
+
+  void HMatrixU::Print(const Option_t*) const
+  {
+    printOut << "U" << std::endl;
+  }
 
 
 } /* End of namespace genfit */

--- a/measurements/src/HMatrixUV.cc
+++ b/measurements/src/HMatrixUV.cc
@@ -30,81 +30,88 @@ namespace genfit {
 // 0, 0, 0, 1, 0
 // 0, 0, 0, 0, 1
 
-const TMatrixD& HMatrixUV::getMatrix() const {
-  static const double HMatrixContent[2*5] = {0, 0, 0, 1, 0,
-                                             0, 0, 0, 0, 1};
+  const TMatrixD& HMatrixUV::getMatrix() const
+  {
+    static const double HMatrixContent[2 * 5] = {0, 0, 0, 1, 0,
+                                                 0, 0, 0, 0, 1
+                                                };
 
-  static const TMatrixD HMatrix(2,5, HMatrixContent);
+    static const TMatrixD HMatrix(2, 5, HMatrixContent);
 
-  return HMatrix;
-}
-
-
-TVectorD HMatrixUV::Hv(const TVectorD& v) const {
-  assert (v.GetNrows() == 5);
-
-  double* retValArray =(double *)alloca(sizeof(double) * 2);
-  const double* VecArray = v.GetMatrixArray();
-
-  retValArray[0] = VecArray[3]; // u
-  retValArray[1] = VecArray[4]; // v
-
-  return TVectorD(2, retValArray);
-}
-
-
-TMatrixD HMatrixUV::MHt(const TMatrixDSym& M) const {
-  assert (M.GetNcols() == 5);
-
-  double* retValArray =(double *)alloca(sizeof(double) * 5*2);
-  const double* MatArray = M.GetMatrixArray();
-
-  for (unsigned int i=0; i<5; ++i) {
-    retValArray[i*2] = MatArray[i*5 + 3];
-    retValArray[i*2 + 1] = MatArray[i*5 + 4];
+    return HMatrix;
   }
 
-  return TMatrixD(5,2, retValArray);
-}
 
+  TVectorD HMatrixUV::Hv(const TVectorD& v) const
+  {
+    assert(v.GetNrows() == 5);
 
-TMatrixD HMatrixUV::MHt(const TMatrixD& M) const {
-  assert (M.GetNcols() == 5);
+    double* retValArray = (double*)alloca(sizeof(double) * 2);
+    const double* VecArray = v.GetMatrixArray();
 
-  double* retValArray =(double *)alloca(sizeof(double) * M.GetNrows()*2);
-  const double* MatArray = M.GetMatrixArray();
+    retValArray[0] = VecArray[3]; // u
+    retValArray[1] = VecArray[4]; // v
 
-  for (int i = 0; i < M.GetNrows(); ++i) {
-    retValArray[i*2] = MatArray[i*5 + 3];
-    retValArray[i*2 + 1] = MatArray[i*5 + 4];
+    return TVectorD(2, retValArray);
   }
 
-  return TMatrixD(M.GetNrows(),2, retValArray);
-}
+
+  TMatrixD HMatrixUV::MHt(const TMatrixDSym& M) const
+  {
+    assert(M.GetNcols() == 5);
+
+    double* retValArray = (double*)alloca(sizeof(double) * 5 * 2);
+    const double* MatArray = M.GetMatrixArray();
+
+    for (unsigned int i = 0; i < 5; ++i) {
+      retValArray[i * 2] = MatArray[i * 5 + 3];
+      retValArray[i * 2 + 1] = MatArray[i * 5 + 4];
+    }
+
+    return TMatrixD(5, 2, retValArray);
+  }
 
 
-void HMatrixUV::HMHt(TMatrixDSym& M) const {
-  assert (M.GetNrows() == 5);
-  double* MatArray = M.GetMatrixArray();
+  TMatrixD HMatrixUV::MHt(const TMatrixD& M) const
+  {
+    assert(M.GetNcols() == 5);
 
-  //
-  //  HMH^t = ( M_33  M_34 ) where M_34 == M_43
-  //          ( M_43  M_44 )
-  //
-  double uu = MatArray[3*5 + 3];
-  double uv = MatArray[3*5 + 4];
-  double vv = MatArray[4*5 + 4];
+    double* retValArray = (double*)alloca(sizeof(double) * M.GetNrows() * 2);
+    const double* MatArray = M.GetMatrixArray();
 
-  M.ResizeTo(2,2);
-  MatArray = M.GetMatrixArray();
-  MatArray[0] = uu; MatArray[1] = uv;
-  MatArray[2] = uv; MatArray[3] = vv;
-}
+    for (int i = 0; i < M.GetNrows(); ++i) {
+      retValArray[i * 2] = MatArray[i * 5 + 3];
+      retValArray[i * 2 + 1] = MatArray[i * 5 + 4];
+    }
+
+    return TMatrixD(M.GetNrows(), 2, retValArray);
+  }
 
 
-void HMatrixUV::Print(const Option_t*) const {
-  printOut << "UV" << std::endl;
-}
+  void HMatrixUV::HMHt(TMatrixDSym& M) const
+  {
+    assert(M.GetNrows() == 5);
+    double* MatArray = M.GetMatrixArray();
+
+    //
+    //  HMH^t = ( M_33  M_34 ) where M_34 == M_43
+    //          ( M_43  M_44 )
+    //
+    double uu = MatArray[3 * 5 + 3];
+    double uv = MatArray[3 * 5 + 4];
+    double vv = MatArray[4 * 5 + 4];
+
+    M.ResizeTo(2, 2);
+    MatArray = M.GetMatrixArray();
+    MatArray[0] = uu; MatArray[1] = uv;
+    MatArray[2] = uv; MatArray[3] = vv;
+  }
+
+
+  void HMatrixUV::Print(const Option_t*) const
+  {
+    printOut << "UV" << std::endl;
+  }
 
 
 } /* End of namespace genfit */

--- a/measurements/src/HMatrixUnit.cc
+++ b/measurements/src/HMatrixUnit.cc
@@ -33,20 +33,23 @@ namespace genfit {
 // 0, 0, 0, 1, 0,
 // 0, 0, 0, 0, 1
 
-const TMatrixD& HMatrixUnit::getMatrix() const {
-  static const double HMatrixContent[5*5] = {1, 0, 0, 0, 0,
-                                               0, 1, 0, 0, 0,
-                                               0, 0, 1, 0, 0,
-                                               0, 0, 0, 1, 0,
-                                               0, 0, 0, 0, 1};
+  const TMatrixD& HMatrixUnit::getMatrix() const
+  {
+    static const double HMatrixContent[5 * 5] = {1, 0, 0, 0, 0,
+                                                 0, 1, 0, 0, 0,
+                                                 0, 0, 1, 0, 0,
+                                                 0, 0, 0, 1, 0,
+                                                 0, 0, 0, 0, 1
+                                                };
 
-  static const TMatrixD HMatrix(5,5, HMatrixContent);
+    static const TMatrixD HMatrix(5, 5, HMatrixContent);
 
-  return HMatrix;
-}
+    return HMatrix;
+  }
 
-void HMatrixUnit::Print(const Option_t*) const {
-  printOut << "Unit" << std::endl;
-}
+  void HMatrixUnit::Print(const Option_t*) const
+  {
+    printOut << "Unit" << std::endl;
+  }
 
 } /* End of namespace genfit */

--- a/measurements/src/HMatrixV.cc
+++ b/measurements/src/HMatrixV.cc
@@ -29,65 +29,71 @@ namespace genfit {
 
 // 0, 0, 0, 0, 1
 
-const TMatrixD& HMatrixV::getMatrix() const {
-  static const double HMatrixContent[5] = {0, 0, 0, 0, 1};
+  const TMatrixD& HMatrixV::getMatrix() const
+  {
+    static const double HMatrixContent[5] = {0, 0, 0, 0, 1};
 
-  static const TMatrixD HMatrix(1,5, HMatrixContent);
+    static const TMatrixD HMatrix(1, 5, HMatrixContent);
 
-  return HMatrix;
-}
-
-
-TVectorD HMatrixV::Hv(const TVectorD& v) const {
-  assert (v.GetNrows() == 5);
-
-  double* retValArray =(double *)alloca(sizeof(double) * 1);
-
-  retValArray[0] = v(4); // v
-
-  return TVectorD(1, retValArray);
-}
-
-
-TMatrixD HMatrixV::MHt(const TMatrixDSym& M) const {
-  assert (M.GetNcols() == 5);
-
-  double* retValArray =(double *)alloca(sizeof(double) * 5);
-  const double* MatArray = M.GetMatrixArray();
-
-  for (unsigned int i=0; i<5; ++i) {
-    retValArray[i] = MatArray[i*5 + 4];
+    return HMatrix;
   }
 
-  return TMatrixD(5,1, retValArray);
-}
 
+  TVectorD HMatrixV::Hv(const TVectorD& v) const
+  {
+    assert(v.GetNrows() == 5);
 
-TMatrixD HMatrixV::MHt(const TMatrixD& M) const {
-  assert (M.GetNcols() == 5);
+    double* retValArray = (double*)alloca(sizeof(double) * 1);
 
-  double* retValArray =(double *)alloca(sizeof(double) * M.GetNrows());
-  const double* MatArray = M.GetMatrixArray();
+    retValArray[0] = v(4); // v
 
-  for (int i = 0; i < M.GetNrows(); ++i) {
-    retValArray[i] = MatArray[i*5 + 4];
+    return TVectorD(1, retValArray);
   }
 
-  return TMatrixD(M.GetNrows(),1, retValArray);
-}
+
+  TMatrixD HMatrixV::MHt(const TMatrixDSym& M) const
+  {
+    assert(M.GetNcols() == 5);
+
+    double* retValArray = (double*)alloca(sizeof(double) * 5);
+    const double* MatArray = M.GetMatrixArray();
+
+    for (unsigned int i = 0; i < 5; ++i) {
+      retValArray[i] = MatArray[i * 5 + 4];
+    }
+
+    return TMatrixD(5, 1, retValArray);
+  }
 
 
-void HMatrixV::HMHt(TMatrixDSym& M) const {
-  assert (M.GetNrows() == 5);
+  TMatrixD HMatrixV::MHt(const TMatrixD& M) const
+  {
+    assert(M.GetNcols() == 5);
 
-  M(0,0) = M(4,4);
+    double* retValArray = (double*)alloca(sizeof(double) * M.GetNrows());
+    const double* MatArray = M.GetMatrixArray();
 
-  M.ResizeTo(1,1);
-}
+    for (int i = 0; i < M.GetNrows(); ++i) {
+      retValArray[i] = MatArray[i * 5 + 4];
+    }
+
+    return TMatrixD(M.GetNrows(), 1, retValArray);
+  }
 
 
-void HMatrixV::Print(const Option_t*) const {
-  printOut << "V" << std::endl;
-}
+  void HMatrixV::HMHt(TMatrixDSym& M) const
+  {
+    assert(M.GetNrows() == 5);
+
+    M(0, 0) = M(4, 4);
+
+    M.ResizeTo(1, 1);
+  }
+
+
+  void HMatrixV::Print(const Option_t*) const
+  {
+    printOut << "V" << std::endl;
+  }
 
 } /* End of namespace genfit */

--- a/measurements/src/PlanarMeasurement.cc
+++ b/measurements/src/PlanarMeasurement.cc
@@ -30,72 +30,78 @@
 
 namespace genfit {
 
-PlanarMeasurement::PlanarMeasurement(int nDim)
-  : AbsMeasurement(nDim), physicalPlane_(), planeId_(-1), stripV_(false)
-{
-  assert(nDim >= 1);
-}
-
-PlanarMeasurement::PlanarMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId, TrackPoint* trackPoint)
-  : AbsMeasurement(rawHitCoords, rawHitCov, detId, hitId, trackPoint), physicalPlane_(), planeId_(-1), stripV_(false)
-{
-  assert(rawHitCoords_.GetNrows() >= 1);
-}
-
-
-SharedPlanePtr PlanarMeasurement::constructPlane(const StateOnPlane&) const {
-  if (!physicalPlane_) {
-    Exception exc("PlanarMeasurement::constructPlane(): No plane has been set!", __LINE__,__FILE__);
-    throw exc;
-  }
-  return physicalPlane_;
-}
-
-
-std::vector<MeasurementOnPlane*> PlanarMeasurement::constructMeasurementsOnPlane(const StateOnPlane& state) const {
-
-  MeasurementOnPlane* mop = new MeasurementOnPlane(rawHitCoords_,
-       rawHitCov_,
-       state.getPlane(), state.getRep(), constructHMatrix(state.getRep()));
-
-  std::vector<MeasurementOnPlane*> retVal;
-  retVal.push_back(mop);
-  return retVal;
-}
-
-
-const AbsHMatrix* PlanarMeasurement::constructHMatrix(const AbsTrackRep* rep) const {
-
-  if (dynamic_cast<const RKTrackRep*>(rep) == nullptr) {
-    Exception exc("SpacepointMeasurement default implementation can only handle state vectors of type RKTrackRep!", __LINE__,__FILE__);
-    throw exc;
+  PlanarMeasurement::PlanarMeasurement(int nDim)
+    : AbsMeasurement(nDim), physicalPlane_(), planeId_(-1), stripV_(false)
+  {
+    assert(nDim >= 1);
   }
 
-  switch(rawHitCoords_.GetNrows()) {
-  case 1:
-    if (stripV_)
-      return new HMatrixV();
-    return new HMatrixU();
-
-  case 2:
-    return new HMatrixUV();
-
-  default:
-    Exception exc("PlanarMeasurement default implementation can only handle 1D (strip) or 2D (pixel) measurements!", __LINE__,__FILE__);
-    throw exc;
+  PlanarMeasurement::PlanarMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId,
+                                       TrackPoint* trackPoint)
+    : AbsMeasurement(rawHitCoords, rawHitCov, detId, hitId, trackPoint), physicalPlane_(), planeId_(-1), stripV_(false)
+  {
+    assert(rawHitCoords_.GetNrows() >= 1);
   }
 
-}
 
-void PlanarMeasurement::Streamer(TBuffer &R__b)
-{
-   // Stream an object of class genfit::PlanarMeasurement.
+  SharedPlanePtr PlanarMeasurement::constructPlane(const StateOnPlane&) const
+  {
+    if (!physicalPlane_) {
+      Exception exc("PlanarMeasurement::constructPlane(): No plane has been set!", __LINE__, __FILE__);
+      throw exc;
+    }
+    return physicalPlane_;
+  }
 
-   //This works around a msvc bug and should be harmless on other platforms
-   typedef ::genfit::PlanarMeasurement thisClass;
-   UInt_t R__s, R__c;
-   if (R__b.IsReading()) {
-      Version_t R__v = R__b.ReadVersion(&R__s, &R__c); if (R__v) { }
+
+  std::vector<MeasurementOnPlane*> PlanarMeasurement::constructMeasurementsOnPlane(const StateOnPlane& state) const
+  {
+
+    MeasurementOnPlane* mop = new MeasurementOnPlane(rawHitCoords_,
+                                                     rawHitCov_,
+                                                     state.getPlane(), state.getRep(), constructHMatrix(state.getRep()));
+
+    std::vector<MeasurementOnPlane*> retVal;
+    retVal.push_back(mop);
+    return retVal;
+  }
+
+
+  const AbsHMatrix* PlanarMeasurement::constructHMatrix(const AbsTrackRep* rep) const
+  {
+
+    if (dynamic_cast<const RKTrackRep*>(rep) == nullptr) {
+      Exception exc("SpacepointMeasurement default implementation can only handle state vectors of type RKTrackRep!", __LINE__, __FILE__);
+      throw exc;
+    }
+
+    switch (rawHitCoords_.GetNrows()) {
+      case 1:
+        if (stripV_)
+          return new HMatrixV();
+        return new HMatrixU();
+
+      case 2:
+        return new HMatrixUV();
+
+      default:
+        Exception exc("PlanarMeasurement default implementation can only handle 1D (strip) or 2D (pixel) measurements!", __LINE__,
+                      __FILE__);
+        throw exc;
+    }
+
+  }
+
+  void PlanarMeasurement::Streamer(TBuffer& R__b)
+  {
+    // Stream an object of class genfit::PlanarMeasurement.
+
+    //This works around a msvc bug and should be harmless on other platforms
+    typedef ::genfit::PlanarMeasurement thisClass;
+    UInt_t R__s, R__c;
+    if (R__b.IsReading()) {
+      Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+      if (R__v) { }
       //This works around a msvc bug and should be harmless on other platforms
       typedef genfit::AbsMeasurement baseClass0;
       baseClass0::Streamer(R__b);
@@ -108,7 +114,7 @@ void PlanarMeasurement::Streamer(TBuffer &R__b)
       }
       R__b >> planeId_;
       R__b.CheckByteCount(R__s, R__c, thisClass::IsA());
-   } else {
+    } else {
       R__c = R__b.WriteVersion(thisClass::IsA(), kTRUE);
       //This works around a msvc bug and should be harmless on other platforms
       typedef genfit::AbsMeasurement baseClass0;
@@ -121,7 +127,7 @@ void PlanarMeasurement::Streamer(TBuffer &R__b)
       }
       R__b << planeId_;
       R__b.SetByteCount(R__c, kTRUE);
-   }
-}
+    }
+  }
 
 } /* End of namespace genfit */

--- a/measurements/src/ProlateSpacepointMeasurement.cc
+++ b/measurements/src/ProlateSpacepointMeasurement.cc
@@ -27,44 +27,47 @@
 
 namespace genfit {
 
-ProlateSpacepointMeasurement::ProlateSpacepointMeasurement(int nDim)
-  : SpacepointMeasurement(nDim), largestErrorDirection_(0,0,1)
-{
-  ;
-}
-
-ProlateSpacepointMeasurement::ProlateSpacepointMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId, TrackPoint* trackPoint)
-  : SpacepointMeasurement(rawHitCoords, rawHitCov, detId, hitId, trackPoint), largestErrorDirection_(0,0,1)
-{
-  ;
-}
-
-
-SharedPlanePtr ProlateSpacepointMeasurement::constructPlane(const StateOnPlane& state) const {
-
-  // copy state. Neglect covariance.
-  StateOnPlane st(state);
-
-
-  const TVector3 wire1(rawHitCoords_(0), rawHitCoords_(1), rawHitCoords_(2));
-
-  const AbsTrackRep* rep = state.getRep();
-  rep->extrapolateToLine(st, wire1, largestErrorDirection_);
-
-  TVector3 dirInPoca = rep->getMom(st);
-  dirInPoca.SetMag(1.);
-
-  // check if direction is parallel to wire
-  if (fabs(largestErrorDirection_.Angle(dirInPoca)) < 0.01){
-    Exception exc("ProlateSpacepointMeasurement::constructPlane(): Cannot construct detector plane, track direction is parallel to largest error direction", __LINE__,__FILE__);
-    throw exc;
+  ProlateSpacepointMeasurement::ProlateSpacepointMeasurement(int nDim)
+    : SpacepointMeasurement(nDim), largestErrorDirection_(0, 0, 1)
+  {
+    ;
   }
 
-  // construct orthogonal vector
-  TVector3 U = largestErrorDirection_.Cross(dirInPoca);
+  ProlateSpacepointMeasurement::ProlateSpacepointMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId,
+                                                             int hitId, TrackPoint* trackPoint)
+    : SpacepointMeasurement(rawHitCoords, rawHitCov, detId, hitId, trackPoint), largestErrorDirection_(0, 0, 1)
+  {
+    ;
+  }
 
-  return SharedPlanePtr(new DetPlane(wire1, U, largestErrorDirection_));
-}
+
+  SharedPlanePtr ProlateSpacepointMeasurement::constructPlane(const StateOnPlane& state) const
+  {
+
+    // copy state. Neglect covariance.
+    StateOnPlane st(state);
+
+
+    const TVector3 wire1(rawHitCoords_(0), rawHitCoords_(1), rawHitCoords_(2));
+
+    const AbsTrackRep* rep = state.getRep();
+    rep->extrapolateToLine(st, wire1, largestErrorDirection_);
+
+    TVector3 dirInPoca = rep->getMom(st);
+    dirInPoca.SetMag(1.);
+
+    // check if direction is parallel to wire
+    if (fabs(largestErrorDirection_.Angle(dirInPoca)) < 0.01) {
+      Exception exc("ProlateSpacepointMeasurement::constructPlane(): Cannot construct detector plane, track direction is parallel to largest error direction",
+                    __LINE__, __FILE__);
+      throw exc;
+    }
+
+    // construct orthogonal vector
+    TVector3 U = largestErrorDirection_.Cross(dirInPoca);
+
+    return SharedPlanePtr(new DetPlane(wire1, U, largestErrorDirection_));
+  }
 
 
 } /* End of namespace genfit */

--- a/measurements/src/SpacepointMeasurement.cc
+++ b/measurements/src/SpacepointMeasurement.cc
@@ -30,123 +30,126 @@
 
 namespace genfit {
 
-SpacepointMeasurement::SpacepointMeasurement(int nDim)
-  : AbsMeasurement(nDim), weightedPlaneContruction_(true), G_(3), cutCov_(true)
-{
-  assert(nDim >= 3);
+  SpacepointMeasurement::SpacepointMeasurement(int nDim)
+    : AbsMeasurement(nDim), weightedPlaneContruction_(true), G_(3), cutCov_(true)
+  {
+    assert(nDim >= 3);
 
-  //this->initG();
-}
-
-SpacepointMeasurement::SpacepointMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId, TrackPoint* trackPoint,
-    bool weightedPlaneContruction, bool cutCov)
-  : AbsMeasurement(rawHitCoords, rawHitCov, detId, hitId, trackPoint),
-    weightedPlaneContruction_(weightedPlaneContruction), cutCov_(cutCov)
-{
-  assert(rawHitCoords_.GetNrows() >= 3);
-
-  if (weightedPlaneContruction_)
-    this->initG();
-}
-
-
-SharedPlanePtr SpacepointMeasurement::constructPlane(const StateOnPlane& state) const {
-
-  // copy state. Neglect covariance.
-  StateOnPlane st(state);
-
-  const TVector3 point(rawHitCoords_(0), rawHitCoords_(1), rawHitCoords_(2));
-
-  if (weightedPlaneContruction_)
-    st.extrapolateToPoint(point, G_);
-  else
-    st.extrapolateToPoint(point);
-
-  return st.getPlane();
-}
-
-
-std::vector<MeasurementOnPlane*> SpacepointMeasurement::constructMeasurementsOnPlane(const StateOnPlane& state) const
-{
-  MeasurementOnPlane* mop = new MeasurementOnPlane(TVectorD(2),
-       TMatrixDSym(3), // will be resized to 2x2 by Similarity later
-       state.getPlane(), state.getRep(), constructHMatrix(state.getRep()));
-
-  TVectorD& m = mop->getState();
-  TMatrixDSym& V = mop->getCov();
-
-  const TVector3& o(state.getPlane()->getO());
-  const TVector3& u(state.getPlane()->getU());
-  const TVector3& v(state.getPlane()->getV());
-
-  // m
-  m(0) = (rawHitCoords_(0)-o.X()) * u.X() +
-         (rawHitCoords_(1)-o.Y()) * u.Y() +
-         (rawHitCoords_(2)-o.Z()) * u.Z();
-
-  m(1) = (rawHitCoords_(0)-o.X()) * v.X() +
-         (rawHitCoords_(1)-o.Y()) * v.Y() +
-         (rawHitCoords_(2)-o.Z()) * v.Z();
-
-  //
-  // V
-  //
-  V = rawHitCov_;
-
-  // jac = dF_i/dx_j = s_unitvec * t_untivec, with s=u,v and t=x,y,z
-  TMatrixD jac(3,2);
-  jac(0,0) = u.X();
-  jac(1,0) = u.Y();
-  jac(2,0) = u.Z();
-  jac(0,1) = v.X();
-  jac(1,1) = v.Y();
-  jac(2,1) = v.Z();
-
-  if (cutCov_) { // cut (default)
-    tools::invertMatrix(V);
-    V.SimilarityT(jac);
-    tools::invertMatrix(V);
-  }
-  else { // projection
-    V.SimilarityT(jac);
+    //this->initG();
   }
 
-  std::vector<MeasurementOnPlane*> retVal;
-  retVal.push_back(mop);
-  return retVal;
-}
+  SpacepointMeasurement::SpacepointMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId,
+                                               TrackPoint* trackPoint,
+                                               bool weightedPlaneContruction, bool cutCov)
+    : AbsMeasurement(rawHitCoords, rawHitCov, detId, hitId, trackPoint),
+      weightedPlaneContruction_(weightedPlaneContruction), cutCov_(cutCov)
+  {
+    assert(rawHitCoords_.GetNrows() >= 3);
 
-
-const AbsHMatrix* SpacepointMeasurement::constructHMatrix(const AbsTrackRep* rep) const {
-  if (dynamic_cast<const RKTrackRep*>(rep) == nullptr) {
-    Exception exc("SpacepointMeasurement default implementation can only handle state vectors of type RKTrackRep!", __LINE__,__FILE__);
-    throw exc;
+    if (weightedPlaneContruction_)
+      this->initG();
   }
 
-  return new HMatrixUV();
-}
+
+  SharedPlanePtr SpacepointMeasurement::constructPlane(const StateOnPlane& state) const
+  {
+
+    // copy state. Neglect covariance.
+    StateOnPlane st(state);
+
+    const TVector3 point(rawHitCoords_(0), rawHitCoords_(1), rawHitCoords_(2));
+
+    if (weightedPlaneContruction_)
+      st.extrapolateToPoint(point, G_);
+    else
+      st.extrapolateToPoint(point);
+
+    return st.getPlane();
+  }
 
 
-void SpacepointMeasurement::initG() {
-  rawHitCov_.GetSub(0, 2, G_);
-  tools::invertMatrix(G_);
-}
+  std::vector<MeasurementOnPlane*> SpacepointMeasurement::constructMeasurementsOnPlane(const StateOnPlane& state) const
+  {
+    MeasurementOnPlane* mop = new MeasurementOnPlane(TVectorD(2),
+                                                     TMatrixDSym(3), // will be resized to 2x2 by Similarity later
+                                                     state.getPlane(), state.getRep(), constructHMatrix(state.getRep()));
+
+    TVectorD& m = mop->getState();
+    TMatrixDSym& V = mop->getCov();
+
+    const TVector3& o(state.getPlane()->getO());
+    const TVector3& u(state.getPlane()->getU());
+    const TVector3& v(state.getPlane()->getV());
+
+    // m
+    m(0) = (rawHitCoords_(0) - o.X()) * u.X() +
+           (rawHitCoords_(1) - o.Y()) * u.Y() +
+           (rawHitCoords_(2) - o.Z()) * u.Z();
+
+    m(1) = (rawHitCoords_(0) - o.X()) * v.X() +
+           (rawHitCoords_(1) - o.Y()) * v.Y() +
+           (rawHitCoords_(2) - o.Z()) * v.Z();
+
+    //
+    // V
+    //
+    V = rawHitCov_;
+
+    // jac = dF_i/dx_j = s_unitvec * t_untivec, with s=u,v and t=x,y,z
+    TMatrixD jac(3, 2);
+    jac(0, 0) = u.X();
+    jac(1, 0) = u.Y();
+    jac(2, 0) = u.Z();
+    jac(0, 1) = v.X();
+    jac(1, 1) = v.Y();
+    jac(2, 1) = v.Z();
+
+    if (cutCov_) { // cut (default)
+      tools::invertMatrix(V);
+      V.SimilarityT(jac);
+      tools::invertMatrix(V);
+    } else { // projection
+      V.SimilarityT(jac);
+    }
+
+    std::vector<MeasurementOnPlane*> retVal;
+    retVal.push_back(mop);
+    return retVal;
+  }
+
+
+  const AbsHMatrix* SpacepointMeasurement::constructHMatrix(const AbsTrackRep* rep) const
+  {
+    if (dynamic_cast<const RKTrackRep*>(rep) == nullptr) {
+      Exception exc("SpacepointMeasurement default implementation can only handle state vectors of type RKTrackRep!", __LINE__, __FILE__);
+      throw exc;
+    }
+
+    return new HMatrixUV();
+  }
+
+
+  void SpacepointMeasurement::initG()
+  {
+    rawHitCov_.GetSub(0, 2, G_);
+    tools::invertMatrix(G_);
+  }
 
 
 // Modified from auto-generated Streamer to account for non-persistent G_
-void SpacepointMeasurement::Streamer(TBuffer &R__b)
-{
-   // Stream an object of class genfit::SpacepointMeasurement.
+  void SpacepointMeasurement::Streamer(TBuffer& R__b)
+  {
+    // Stream an object of class genfit::SpacepointMeasurement.
 
-   if (R__b.IsReading()) {
-      R__b.ReadClassBuffer(genfit::SpacepointMeasurement::Class(),this);
+    if (R__b.IsReading()) {
+      R__b.ReadClassBuffer(genfit::SpacepointMeasurement::Class(), this);
 
       if (weightedPlaneContruction_)
         this->initG();
-   } else {
-      R__b.WriteClassBuffer(genfit::SpacepointMeasurement::Class(),this);
-   }
-}
+    } else {
+      R__b.WriteClassBuffer(genfit::SpacepointMeasurement::Class(), this);
+    }
+  }
 
 
 } /* End of namespace genfit */

--- a/measurements/src/WireMeasurementNew.cc
+++ b/measurements/src/WireMeasurementNew.cc
@@ -36,124 +36,126 @@
 namespace genfit {
 
 
-WireMeasurementNew::WireMeasurementNew()
-  : AbsMeasurement(1), maxDistance_(2), leftRight_(0)
-{
-  memset(wireEndPoint1_, 0, 3*sizeof(double));
-  memset(wireEndPoint2_, 0, 3*sizeof(double));
-}
-
-WireMeasurementNew::WireMeasurementNew(double driftDistance, double driftDistanceError, const TVector3& endPoint1, const TVector3& endPoint2, int detId, int hitId, TrackPoint* trackPoint)
-  : AbsMeasurement(1), maxDistance_(2), leftRight_(0)
-{
-  TVectorD coords(1);
-  coords[0] = driftDistance;
-  this->setRawHitCoords(coords);
-
-  TMatrixDSym cov(1);
-  cov(0,0) = driftDistanceError*driftDistanceError;
-  this->setRawHitCov(cov);
-
-  this->setWireEndPoints(endPoint1, endPoint2);
-
-  this->setDetId(detId);
-  this->setHitId(hitId);
-  this->setTrackPoint(trackPoint);
-}
-
-SharedPlanePtr WireMeasurementNew::constructPlane(const StateOnPlane& state) const {
-
-  // copy state. Neglect covariance.
-  StateOnPlane st(state);
-
-  TVector3 wire1(wireEndPoint1_);
-  TVector3 wire2(wireEndPoint2_);
-
-  // unit vector along the wire (V)
-  TVector3 wireDirection = wire2 - wire1; 
-  wireDirection.SetMag(1.);
-
-  // point of closest approach
-  const AbsTrackRep* rep = state.getRep();
-  rep->extrapolateToLine(st, wire1, wireDirection);
-  const TVector3& poca = rep->getPos(st);
-  TVector3 dirInPoca = rep->getMom(st);
-  dirInPoca.SetMag(1.);
-  const TVector3& pocaOnWire = wire1 + wireDirection.Dot(poca - wire1)*wireDirection;
- 
-  // check if direction is parallel to wire
-  if (fabs(wireDirection.Angle(dirInPoca)) < 0.01){
-    Exception exc("WireMeasurementNew::detPlane(): Cannot construct detector plane, direction is parallel to wire", __LINE__,__FILE__);
-    throw exc;
-  }
-  
-  // construct orthogonal vector
-  TVector3 U = wireDirection.Cross(dirInPoca);
-  // U.SetMag(1.); automatically assured
-
-  return SharedPlanePtr(new DetPlane(pocaOnWire, U, wireDirection));
-}
-
-
-std::vector<MeasurementOnPlane*> WireMeasurementNew::constructMeasurementsOnPlane(const StateOnPlane& state) const
-{
-  double mR = getRawHitCoords()(0);
-  double mL = -mR;
-
-  MeasurementOnPlane* mopL = new MeasurementOnPlane(TVectorD(1, &mL),
-       getRawHitCov(),
-       state.getPlane(), state.getRep(), constructHMatrix(state.getRep()));
-
-  MeasurementOnPlane* mopR = new MeasurementOnPlane(TVectorD(1, &mR),
-       getRawHitCov(),
-       state.getPlane(), state.getRep(), constructHMatrix(state.getRep()));
-
-  // set left/right weights
-  if (leftRight_ < 0) {
-    mopL->setWeight(1);
-    mopR->setWeight(0);
-  }
-  else if (leftRight_ > 0) {
-    mopL->setWeight(0);
-    mopR->setWeight(1);
-  }
-  else {
-    double val = 0.5 * pow(std::max(0., 1 - mR/maxDistance_), 2.);
-    mopL->setWeight(val);
-    mopR->setWeight(val);
+  WireMeasurementNew::WireMeasurementNew()
+    : AbsMeasurement(1), maxDistance_(2), leftRight_(0)
+  {
+    memset(wireEndPoint1_, 0, 3 * sizeof(double));
+    memset(wireEndPoint2_, 0, 3 * sizeof(double));
   }
 
-  std::vector<MeasurementOnPlane*> retVal;
-  retVal.push_back(mopL);
-  retVal.push_back(mopR);
-  return retVal;
-}
+  WireMeasurementNew::WireMeasurementNew(double driftDistance, double driftDistanceError, const TVector3& endPoint1,
+                                         const TVector3& endPoint2, int detId, int hitId, TrackPoint* trackPoint)
+    : AbsMeasurement(1), maxDistance_(2), leftRight_(0)
+  {
+    TVectorD coords(1);
+    coords[0] = driftDistance;
+    this->setRawHitCoords(coords);
 
-const AbsHMatrix* WireMeasurementNew::constructHMatrix(const AbsTrackRep* rep) const {
-  if (dynamic_cast<const RKTrackRep*>(rep) == nullptr) {
-    Exception exc("WireMeasurementNew default implementation can only handle state vectors of type RKTrackRep!", __LINE__,__FILE__);
-    throw exc;
+    TMatrixDSym cov(1);
+    cov(0, 0) = driftDistanceError * driftDistanceError;
+    this->setRawHitCov(cov);
+
+    this->setWireEndPoints(endPoint1, endPoint2);
+
+    this->setDetId(detId);
+    this->setHitId(hitId);
+    this->setTrackPoint(trackPoint);
   }
 
-  return new HMatrixU();
-}
+  SharedPlanePtr WireMeasurementNew::constructPlane(const StateOnPlane& state) const
+  {
 
-void WireMeasurementNew::setWireEndPoints(const TVector3& endPoint1, const TVector3& endPoint2)
-{
-  wireEndPoint1_[0] = endPoint1.X();
-  wireEndPoint1_[1] = endPoint1.Y();
-  wireEndPoint1_[2] = endPoint1.Z();
+    // copy state. Neglect covariance.
+    StateOnPlane st(state);
 
-  wireEndPoint2_[0] = endPoint2.X();
-  wireEndPoint2_[1] = endPoint2.Y();
-  wireEndPoint2_[2] = endPoint2.Z();
-}
+    TVector3 wire1(wireEndPoint1_);
+    TVector3 wire2(wireEndPoint2_);
 
-void WireMeasurementNew::setLeftRightResolution(int lr){
-  if (lr==0) leftRight_ = 0;
-  else if (lr<0) leftRight_ = -1;
-  else leftRight_ = 1;
-}
+    // unit vector along the wire (V)
+    TVector3 wireDirection = wire2 - wire1;
+    wireDirection.SetMag(1.);
+
+    // point of closest approach
+    const AbsTrackRep* rep = state.getRep();
+    rep->extrapolateToLine(st, wire1, wireDirection);
+    const TVector3& poca = rep->getPos(st);
+    TVector3 dirInPoca = rep->getMom(st);
+    dirInPoca.SetMag(1.);
+    const TVector3& pocaOnWire = wire1 + wireDirection.Dot(poca - wire1) * wireDirection;
+
+    // check if direction is parallel to wire
+    if (fabs(wireDirection.Angle(dirInPoca)) < 0.01) {
+      Exception exc("WireMeasurementNew::detPlane(): Cannot construct detector plane, direction is parallel to wire", __LINE__, __FILE__);
+      throw exc;
+    }
+
+    // construct orthogonal vector
+    TVector3 U = wireDirection.Cross(dirInPoca);
+    // U.SetMag(1.); automatically assured
+
+    return SharedPlanePtr(new DetPlane(pocaOnWire, U, wireDirection));
+  }
+
+
+  std::vector<MeasurementOnPlane*> WireMeasurementNew::constructMeasurementsOnPlane(const StateOnPlane& state) const
+  {
+    double mR = getRawHitCoords()(0);
+    double mL = -mR;
+
+    MeasurementOnPlane* mopL = new MeasurementOnPlane(TVectorD(1, &mL),
+                                                      getRawHitCov(),
+                                                      state.getPlane(), state.getRep(), constructHMatrix(state.getRep()));
+
+    MeasurementOnPlane* mopR = new MeasurementOnPlane(TVectorD(1, &mR),
+                                                      getRawHitCov(),
+                                                      state.getPlane(), state.getRep(), constructHMatrix(state.getRep()));
+
+    // set left/right weights
+    if (leftRight_ < 0) {
+      mopL->setWeight(1);
+      mopR->setWeight(0);
+    } else if (leftRight_ > 0) {
+      mopL->setWeight(0);
+      mopR->setWeight(1);
+    } else {
+      double val = 0.5 * pow(std::max(0., 1 - mR / maxDistance_), 2.);
+      mopL->setWeight(val);
+      mopR->setWeight(val);
+    }
+
+    std::vector<MeasurementOnPlane*> retVal;
+    retVal.push_back(mopL);
+    retVal.push_back(mopR);
+    return retVal;
+  }
+
+  const AbsHMatrix* WireMeasurementNew::constructHMatrix(const AbsTrackRep* rep) const
+  {
+    if (dynamic_cast<const RKTrackRep*>(rep) == nullptr) {
+      Exception exc("WireMeasurementNew default implementation can only handle state vectors of type RKTrackRep!", __LINE__, __FILE__);
+      throw exc;
+    }
+
+    return new HMatrixU();
+  }
+
+  void WireMeasurementNew::setWireEndPoints(const TVector3& endPoint1, const TVector3& endPoint2)
+  {
+    wireEndPoint1_[0] = endPoint1.X();
+    wireEndPoint1_[1] = endPoint1.Y();
+    wireEndPoint1_[2] = endPoint1.Z();
+
+    wireEndPoint2_[0] = endPoint2.X();
+    wireEndPoint2_[1] = endPoint2.Y();
+    wireEndPoint2_[2] = endPoint2.Z();
+  }
+
+  void WireMeasurementNew::setLeftRightResolution(int lr)
+  {
+    if (lr == 0) leftRight_ = 0;
+    else if (lr < 0) leftRight_ = -1;
+    else leftRight_ = 1;
+  }
 
 
 } /* End of namespace genfit */

--- a/measurements/src/WirePointMeasurement.cc
+++ b/measurements/src/WirePointMeasurement.cc
@@ -29,99 +29,100 @@
 
 namespace genfit {
 
-WirePointMeasurement::WirePointMeasurement(int nDim)
-  : WireMeasurement(nDim)
-{
-  assert(nDim >= 8);
-}
-
-WirePointMeasurement::WirePointMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId, TrackPoint* trackPoint)
-  : WireMeasurement(rawHitCoords, rawHitCov, detId, hitId, trackPoint)
-{
-  assert(rawHitCoords_.GetNrows() >= 8);
-}
-
-
-SharedPlanePtr WirePointMeasurement::constructPlane(const StateOnPlane& state) const {
-
-  // copy state. Neglect covariance.
-  StateOnPlane st(state);
-
-  TVector3 wire1(rawHitCoords_(0), rawHitCoords_(1), rawHitCoords_(2));
-  TVector3 wire2(rawHitCoords_(3), rawHitCoords_(4), rawHitCoords_(5));
-
-  // unit vector along the wire (V)
-  TVector3 wireDirection = wire2 - wire1;
-  wireDirection.SetMag(1.);
-
-  // point of closest approach
-  const AbsTrackRep* rep = state.getRep();
-  rep->extrapolateToLine(st, wire1, wireDirection);
-  //const TVector3& poca = rep->getPos(st);
-  TVector3 dirInPoca = rep->getMom(st);
-  dirInPoca.SetMag(1.);
-  //const TVector3& pocaOnWire = wire1 + wireDirection.Dot(poca - wire1)*wireDirection;
-
-  // check if direction is parallel to wire
-  if (fabs(wireDirection.Angle(dirInPoca)) < 0.01){
-    Exception exc("WireMeasurement::detPlane(): Cannot construct detector plane, direction is parallel to wire", __LINE__,__FILE__);
-    throw exc;
+  WirePointMeasurement::WirePointMeasurement(int nDim)
+    : WireMeasurement(nDim)
+  {
+    assert(nDim >= 8);
   }
 
-  // construct orthogonal vector
-  TVector3 U = dirInPoca.Cross(wireDirection);
-  // U.SetMag(1.); automatically assured
-
-  return SharedPlanePtr(new DetPlane(wire1, U, wireDirection));
-}
-
-
-std::vector<MeasurementOnPlane*> WirePointMeasurement::constructMeasurementsOnPlane(const StateOnPlane& state) const
-{
-  MeasurementOnPlane* mopR = new MeasurementOnPlane(TVectorD(2),
-       TMatrixDSym(2),
-       state.getPlane(), state.getRep(), constructHMatrix(state.getRep()));
-
-  mopR->getState()(0) = rawHitCoords_(6);
-  mopR->getState()(1) = rawHitCoords_(7);
-
-  mopR->getCov()(0,0) = rawHitCov_(6,6);
-  mopR->getCov()(1,0) = rawHitCov_(7,6);
-  mopR->getCov()(0,1) = rawHitCov_(6,7);
-  mopR->getCov()(1,1) = rawHitCov_(7,7);
-
-
-  MeasurementOnPlane* mopL = new MeasurementOnPlane(*mopR);
-  mopL->getState()(0) *= -1;
-
-  // set left/right weights
-  if (leftRight_ < 0) {
-    mopL->setWeight(1);
-    mopR->setWeight(0);
-  }
-  else if (leftRight_ > 0) {
-    mopL->setWeight(0);
-    mopR->setWeight(1);
-  }
-  else {
-    double val = 0.5 * pow(std::max(0., 1 - rawHitCoords_(6)/maxDistance_), 2.);
-    mopL->setWeight(val);
-    mopR->setWeight(val);
+  WirePointMeasurement::WirePointMeasurement(const TVectorD& rawHitCoords, const TMatrixDSym& rawHitCov, int detId, int hitId,
+                                             TrackPoint* trackPoint)
+    : WireMeasurement(rawHitCoords, rawHitCov, detId, hitId, trackPoint)
+  {
+    assert(rawHitCoords_.GetNrows() >= 8);
   }
 
-  std::vector<MeasurementOnPlane*> retVal;
-  retVal.push_back(mopL);
-  retVal.push_back(mopR);
-  return retVal;
-}
 
-const AbsHMatrix* WirePointMeasurement::constructHMatrix(const AbsTrackRep* rep) const {
-  if (dynamic_cast<const RKTrackRep*>(rep) == nullptr) {
-    Exception exc("WirePointMeasurement default implementation can only handle state vectors of type RKTrackRep!", __LINE__,__FILE__);
-    throw exc;
+  SharedPlanePtr WirePointMeasurement::constructPlane(const StateOnPlane& state) const
+  {
+
+    // copy state. Neglect covariance.
+    StateOnPlane st(state);
+
+    TVector3 wire1(rawHitCoords_(0), rawHitCoords_(1), rawHitCoords_(2));
+    TVector3 wire2(rawHitCoords_(3), rawHitCoords_(4), rawHitCoords_(5));
+
+    // unit vector along the wire (V)
+    TVector3 wireDirection = wire2 - wire1;
+    wireDirection.SetMag(1.);
+
+    // point of closest approach
+    const AbsTrackRep* rep = state.getRep();
+    rep->extrapolateToLine(st, wire1, wireDirection);
+    //const TVector3& poca = rep->getPos(st);
+    TVector3 dirInPoca = rep->getMom(st);
+    dirInPoca.SetMag(1.);
+    //const TVector3& pocaOnWire = wire1 + wireDirection.Dot(poca - wire1)*wireDirection;
+
+    // check if direction is parallel to wire
+    if (fabs(wireDirection.Angle(dirInPoca)) < 0.01) {
+      Exception exc("WireMeasurement::detPlane(): Cannot construct detector plane, direction is parallel to wire", __LINE__, __FILE__);
+      throw exc;
+    }
+
+    // construct orthogonal vector
+    TVector3 U = dirInPoca.Cross(wireDirection);
+    // U.SetMag(1.); automatically assured
+
+    return SharedPlanePtr(new DetPlane(wire1, U, wireDirection));
   }
 
-  return new HMatrixUV();
-}
+
+  std::vector<MeasurementOnPlane*> WirePointMeasurement::constructMeasurementsOnPlane(const StateOnPlane& state) const
+  {
+    MeasurementOnPlane* mopR = new MeasurementOnPlane(TVectorD(2),
+                                                      TMatrixDSym(2),
+                                                      state.getPlane(), state.getRep(), constructHMatrix(state.getRep()));
+
+    mopR->getState()(0) = rawHitCoords_(6);
+    mopR->getState()(1) = rawHitCoords_(7);
+
+    mopR->getCov()(0, 0) = rawHitCov_(6, 6);
+    mopR->getCov()(1, 0) = rawHitCov_(7, 6);
+    mopR->getCov()(0, 1) = rawHitCov_(6, 7);
+    mopR->getCov()(1, 1) = rawHitCov_(7, 7);
+
+
+    MeasurementOnPlane* mopL = new MeasurementOnPlane(*mopR);
+    mopL->getState()(0) *= -1;
+
+    // set left/right weights
+    if (leftRight_ < 0) {
+      mopL->setWeight(1);
+      mopR->setWeight(0);
+    } else if (leftRight_ > 0) {
+      mopL->setWeight(0);
+      mopR->setWeight(1);
+    } else {
+      double val = 0.5 * pow(std::max(0., 1 - rawHitCoords_(6) / maxDistance_), 2.);
+      mopL->setWeight(val);
+      mopR->setWeight(val);
+    }
+
+    std::vector<MeasurementOnPlane*> retVal;
+    retVal.push_back(mopL);
+    retVal.push_back(mopR);
+    return retVal;
+  }
+
+  const AbsHMatrix* WirePointMeasurement::constructHMatrix(const AbsTrackRep* rep) const
+  {
+    if (dynamic_cast<const RKTrackRep*>(rep) == nullptr) {
+      Exception exc("WirePointMeasurement default implementation can only handle state vectors of type RKTrackRep!", __LINE__, __FILE__);
+      throw exc;
+    }
+
+    return new HMatrixUV();
+  }
 
 } /* End of namespace genfit */

--- a/measurements/src/WireTrackCandHit.cc
+++ b/measurements/src/WireTrackCandHit.cc
@@ -23,24 +23,25 @@
 
 namespace genfit {
 
-WireTrackCandHit::WireTrackCandHit(int detId,
-                               int hitId,
-                               int planeId,
-                               double sortingParameter,
-                               char leftRight)
-  : TrackCandHit(detId, hitId, planeId, sortingParameter),
-    leftRight_(leftRight)
-{
-  ;
-}
+  WireTrackCandHit::WireTrackCandHit(int detId,
+                                     int hitId,
+                                     int planeId,
+                                     double sortingParameter,
+                                     char leftRight)
+    : TrackCandHit(detId, hitId, planeId, sortingParameter),
+      leftRight_(leftRight)
+  {
+    ;
+  }
 
 
-void WireTrackCandHit::Print(Option_t*) const {
-  printOut << "  WireTrackCandHit. DetId = " << detId_
-           << " \t HitId = " << hitId_
-           << " \t PlaneId = " << planeId_
-           << " \t SortingParameter = " << sortingParameter_
-           << " \t leftRight = " << (int)leftRight_ << "\n";
-}
+  void WireTrackCandHit::Print(Option_t*) const
+  {
+    printOut << "  WireTrackCandHit. DetId = " << detId_
+             << " \t HitId = " << hitId_
+             << " \t PlaneId = " << planeId_
+             << " \t SortingParameter = " << sortingParameter_
+             << " \t leftRight = " << (int)leftRight_ << "\n";
+  }
 
 } /* End of namespace genfit */

--- a/test/fitterTests/main.cc
+++ b/test/fitterTests/main.cc
@@ -69,8 +69,9 @@
 #include <memory>
 
 
-void handler(int sig) {
-  void *array[10];
+void handler(int sig)
+{
+  void* array[10];
   size_t size;
 
   // get void*'s for all entries on the stack
@@ -82,33 +83,35 @@ void handler(int sig) {
   exit(1);
 }
 
-int randomPdg() {
+int randomPdg()
+{
   int pdg;
 
-  switch(int(gRandom->Uniform(8))) {
-  case 1:
-    pdg = -11; break;
-  case 2:
-    pdg = 11; break;
-  case 3:
-    pdg = 13; break;
-  case 4:
-    pdg = -13; break;
-  case 5:
-    pdg = 211; break;
-  case 6:
-    pdg = -211; break;
-  case 7:
-    pdg = 2212; break;
-  default:
-    pdg = 211;
+  switch (int(gRandom->Uniform(8))) {
+    case 1:
+      pdg = -11; break;
+    case 2:
+      pdg = 11; break;
+    case 3:
+      pdg = 13; break;
+    case 4:
+      pdg = -13; break;
+    case 5:
+      pdg = 211; break;
+    case 6:
+      pdg = -211; break;
+    case 7:
+      pdg = 2212; break;
+    default:
+      pdg = 211;
   }
 
   return pdg;
 }
 
 
-int randomSign() {
+int randomSign()
+{
   if (gRandom->Uniform(1) > 0.5)
     return 1;
   return -1;
@@ -123,15 +126,16 @@ int randomSign() {
 //#define VALGRIND
 
 #ifdef VALGRIND
-  #include <valgrind/callgrind.h>
+#include <valgrind/callgrind.h>
 #else
 #define CALLGRIND_START_INSTRUMENTATION
 #define CALLGRIND_STOP_INSTRUMENTATION
 #define CALLGRIND_DUMP_STATS
 #endif
 
-int main() {
-  std::cout<<"main"<<std::endl;
+int main()
+{
+  std::cout << "main" << std::endl;
   gRandom->SetSeed(14);
 
 
@@ -145,8 +149,8 @@ int main() {
   const double pointDist = 3.;      // cm; approx. distance between measurements
   const double resolution = 0.05;   // cm; resolution of generated measurements
 
-  const double resolutionWire = 5*resolution;   // cm; resolution of generated measurements
-  const TVector3 wireDir(0,0,1);
+  const double resolutionWire = 5 * resolution; // cm; resolution of generated measurements
+  const TVector3 wireDir(0, 0, 1);
   const double skewAngle(5);
   const bool useSkew = true;
   const int nSuperLayer = 10;
@@ -190,8 +194,8 @@ int main() {
 
   const bool smearPosMom = true;     // init the Reps with smeared pos and mom
   const double chargeSwitchProb = -0.1; // probability to seed with wrong charge sign
-  const double posSmear = 10*resolution;     // cm
-  const double momSmear = 5. /180.*TMath::Pi();     // rad
+  const double posSmear = 10 * resolution;   // cm
+  const double momSmear = 5. / 180.*TMath::Pi();    // rad
   const double momMagSmear = 0.2;   // relative
   const double zSmearFac = 2;
 
@@ -202,8 +206,8 @@ int main() {
   const bool onlyDisplayFailed = false; // only load non-converged tracks into the display
 
   std::vector<genfit::eMeasurementType> measurementTypes;
-  for (unsigned int i = 0; i<nMeasurements; ++i) {
-    measurementTypes.push_back(genfit::eMeasurementType(i%8));
+  for (unsigned int i = 0; i < nMeasurements; ++i) {
+    measurementTypes.push_back(genfit::eMeasurementType(i % 8));
   }
 
   signal(SIGSEGV, handler);   // install our handler
@@ -262,11 +266,11 @@ int main() {
   // init geometry and mag. field
   new TGeoManager("Geometry", "Geane geometry");
   TGeoManager::Import("genfitGeom.root");
-  genfit::FieldManager::getInstance()->init(new genfit::ConstField(0.,0.,BField));
+  genfit::FieldManager::getInstance()->init(new genfit::ConstField(0., 0., BField));
   genfit::FieldManager::getInstance()->useCache(true, 8);
   genfit::MaterialEffects::getInstance()->init(new genfit::TGeoMaterialInterface());
 
-  const double charge = TDatabasePDG::Instance()->GetParticle(pdg)->Charge()/(3.);
+  const double charge = TDatabasePDG::Instance()->GetParticle(pdg)->Charge() / (3.);
 
   // init event display
 #ifndef VALGRIND
@@ -281,23 +285,24 @@ int main() {
   gStyle->SetPalette(1);
   gStyle->SetOptFit(1111);
 
-  TH1D *hmomRes = new TH1D("hmomRes","mom res",500,-20*resolution*momentum/nMeasurements,20*resolution*momentum/nMeasurements);
-  TH1D *hupRes = new TH1D("hupRes","u' res",500,-15*resolution/nMeasurements, 15*resolution/nMeasurements);
-  TH1D *hvpRes = new TH1D("hvpRes","v' res",500,-15*resolution/nMeasurements, 15*resolution/nMeasurements);
-  TH1D *huRes = new TH1D("huRes","u res",500,-15*resolution, 15*resolution);
-  TH1D *hvRes = new TH1D("hvRes","v res",500,-15*resolution, 15*resolution);
+  TH1D* hmomRes = new TH1D("hmomRes", "mom res", 500, -20 * resolution * momentum / nMeasurements,
+                           20 * resolution * momentum / nMeasurements);
+  TH1D* hupRes = new TH1D("hupRes", "u' res", 500, -15 * resolution / nMeasurements, 15 * resolution / nMeasurements);
+  TH1D* hvpRes = new TH1D("hvpRes", "v' res", 500, -15 * resolution / nMeasurements, 15 * resolution / nMeasurements);
+  TH1D* huRes = new TH1D("huRes", "u res", 500, -15 * resolution, 15 * resolution);
+  TH1D* hvRes = new TH1D("hvRes", "v res", 500, -15 * resolution, 15 * resolution);
 
-  TH1D *hqopPu = new TH1D("hqopPu","q/p pull",200,-6.,6.);
-  TH1D *pVal = new TH1D("pVal","p-value",100,0.,1.00000001);
+  TH1D* hqopPu = new TH1D("hqopPu", "q/p pull", 200, -6., 6.);
+  TH1D* pVal = new TH1D("pVal", "p-value", 100, 0., 1.00000001);
   pVal->SetMinimum(0);
-  TH1D *hupPu = new TH1D("hupPu","u' pull",200,-6.,6.);
-  TH1D *hvpPu = new TH1D("hvpPu","v' pull",200,-6.,6.);
-  TH1D *huPu = new TH1D("huPu","u pull",200,-6.,6.);
-  TH1D *hvPu = new TH1D("hvPu","v pull",200,-6.,6.);
+  TH1D* hupPu = new TH1D("hupPu", "u' pull", 200, -6., 6.);
+  TH1D* hvpPu = new TH1D("hvpPu", "v' pull", 200, -6., 6.);
+  TH1D* huPu = new TH1D("huPu", "u pull", 200, -6., 6.);
+  TH1D* hvPu = new TH1D("hvPu", "v pull", 200, -6., 6.);
 
-  TH1D *weights = new TH1D("weights","Daf vs true weights",500,-1.01,1.01);
+  TH1D* weights = new TH1D("weights", "Daf vs true weights", 500, -1.01, 1.01);
 
-  TH1D *trackLenRes = new TH1D("trackLenRes","(trueLen - FittedLen) / trueLen",500,-0.01,0.01);
+  TH1D* trackLenRes = new TH1D("trackLenRes", "(trueLen - FittedLen) / trueLen", 500, -0.01, 0.01);
 #endif
 
   double maxWeight(0);
@@ -317,468 +322,458 @@ int main() {
   genfit::Track* secondTrack(nullptr);
 
   // main loop
-  for (unsigned int iEvent=0; iEvent<nEvents; ++iEvent){
+  for (unsigned int iEvent = 0; iEvent < nEvents; ++iEvent) {
 
-      /*measurementTypes.clear();
-      for (unsigned int i = 0; i < nMeasurements; ++i)
-        measurementTypes.push_back(genfit::eMeasurementType(gRandom->Uniform(8)));*/
-
-
-      if (debug || (iEvent)%10==0)
-        std::cout << "Event Nr. " << iEvent << " ";
-      else std::cout << ". ";
-      if (debug || (iEvent+1)%10==0)
-        std::cout << "\n";
+    /*measurementTypes.clear();
+    for (unsigned int i = 0; i < nMeasurements; ++i)
+      measurementTypes.push_back(genfit::eMeasurementType(gRandom->Uniform(8)));*/
 
 
-      // clean up
-      delete fitTrack;
-      fitTrack = nullptr;
-      delete secondTrack;
-      secondTrack = nullptr;
+    if (debug || (iEvent) % 10 == 0)
+      std::cout << "Event Nr. " << iEvent << " ";
+    else std::cout << ". ";
+    if (debug || (iEvent + 1) % 10 == 0)
+      std::cout << "\n";
 
 
-      // true start values
-      TVector3 pos(0, 0, 0);
-      TVector3 mom(1.,0,0);
-      mom.SetPhi(gRandom->Uniform(0.,2*TMath::Pi()));
-      //mom.SetTheta(gRandom->Uniform(0.5*TMath::Pi(),0.9*TMath::Pi()));
-      mom.SetTheta(theta*TMath::Pi()/180);
-      mom.SetMag(momentum);
-      TMatrixDSym covM(6);
-      for (int i = 0; i < 3; ++i)
-        covM(i,i) = resolution*resolution;
-      for (int i = 3; i < 6; ++i)
-        covM(i,i) = pow(resolution / nMeasurements / sqrt(3), 2);
+    // clean up
+    delete fitTrack;
+    fitTrack = nullptr;
+    delete secondTrack;
+    secondTrack = nullptr;
 
-      if (debug) {
-        std::cout << "start values \n";
-        pos.Print();
-        mom.Print();
+
+    // true start values
+    TVector3 pos(0, 0, 0);
+    TVector3 mom(1., 0, 0);
+    mom.SetPhi(gRandom->Uniform(0., 2 * TMath::Pi()));
+    //mom.SetTheta(gRandom->Uniform(0.5*TMath::Pi(),0.9*TMath::Pi()));
+    mom.SetTheta(theta * TMath::Pi() / 180);
+    mom.SetMag(momentum);
+    TMatrixDSym covM(6);
+    for (int i = 0; i < 3; ++i)
+      covM(i, i) = resolution * resolution;
+    for (int i = 3; i < 6; ++i)
+      covM(i, i) = pow(resolution / nMeasurements / sqrt(3), 2);
+
+    if (debug) {
+      std::cout << "start values \n";
+      pos.Print();
+      mom.Print();
+    }
+
+    // calc helix parameters
+    genfit::HelixTrackModel* helix = new genfit::HelixTrackModel(pos, mom, charge);
+    measurementCreator.setTrackModel(helix);
+
+    // smeared start values
+    TVector3 posM(pos);
+    TVector3 momM(mom);
+    if (smearPosMom) {
+      posM.SetX(gRandom->Gaus(posM.X(), posSmear));
+      posM.SetY(gRandom->Gaus(posM.Y(), posSmear));
+      posM.SetZ(gRandom->Gaus(posM.Z(), zSmearFac * posSmear));
+
+      momM.SetPhi(gRandom->Gaus(mom.Phi(), momSmear));
+      momM.SetTheta(gRandom->Gaus(mom.Theta(), momSmear));
+      momM.SetMag(gRandom->Gaus(mom.Mag(), momMagSmear * mom.Mag()));
+    }
+
+
+    // trackrep for creating measurements
+    double sign(1.);
+    if (chargeSwitchProb > gRandom->Uniform(1.))
+      sign = -1.;
+    genfit::AbsTrackRep* rep = new genfit::RKTrackRep(sign * pdg);
+    sign = 1.;
+    if (chargeSwitchProb > gRandom->Uniform(1.))
+      sign = -1.;
+    genfit::AbsTrackRep* secondRep = new genfit::RKTrackRep(sign * -211);
+    genfit::MeasuredStateOnPlane stateRef(rep);
+    rep->setPosMomCov(stateRef, pos, mom, covM);
+
+    // smeared start state
+    genfit::MeasuredStateOnPlane stateSmeared(rep);
+    rep->setPosMomCov(stateSmeared, posM, momM, covM);
+
+    //rep->setPropDir(1);
+
+    if (!matFX) genfit::MaterialEffects::getInstance()->setNoEffects();
+
+    // remember original initial state
+    const genfit::StateOnPlane stateRefOrig(stateRef);
+
+    // create smeared measurements
+    std::vector< std::vector<genfit::AbsMeasurement*> > measurements;
+
+    std::vector<bool> outlierTrue;
+    bool outlier;
+    // true values for left right. 0 for non wire measurements
+    std::vector<int> leftRightTrue;
+    int lr;
+
+    double trueLen(-1);
+
+    try {
+      for (unsigned int i = 0; i < measurementTypes.size(); ++i) {
+        trueLen = i * pointDist;
+
+        measurements.push_back(measurementCreator.create(measurementTypes[i], trueLen, outlier, lr));
+        outlierTrue.push_back(outlier);
+        leftRightTrue.push_back(lr);
       }
+      assert(measurementTypes.size() == leftRightTrue.size());
+      assert(measurementTypes.size() == outlierTrue.size());
+    } catch (genfit::Exception& e) {
+      std::cerr << "Exception, next track" << std::endl;
+      std::cerr << e.what();
+      continue; // here is a memleak!
+    }
 
-      // calc helix parameters
-      genfit::HelixTrackModel* helix = new genfit::HelixTrackModel(pos, mom, charge);
-      measurementCreator.setTrackModel(helix);
-
-      // smeared start values
-      TVector3 posM(pos);
-      TVector3 momM(mom);
-      if (smearPosMom) {
-        posM.SetX(gRandom->Gaus(posM.X(),posSmear));
-        posM.SetY(gRandom->Gaus(posM.Y(),posSmear));
-        posM.SetZ(gRandom->Gaus(posM.Z(),zSmearFac*posSmear));
-
-        momM.SetPhi(gRandom->Gaus(mom.Phi(),momSmear));
-        momM.SetTheta(gRandom->Gaus(mom.Theta(),momSmear));
-        momM.SetMag(gRandom->Gaus(mom.Mag(), momMagSmear*mom.Mag()));
-      }
-
-
-      // trackrep for creating measurements
-      double sign(1.);
-      if (chargeSwitchProb > gRandom->Uniform(1.))
-        sign = -1.;
-      genfit::AbsTrackRep* rep = new genfit::RKTrackRep(sign*pdg);
-      sign = 1.;
-      if (chargeSwitchProb > gRandom->Uniform(1.))
-        sign = -1.;
-      genfit::AbsTrackRep* secondRep = new genfit::RKTrackRep(sign*-211);
-      genfit::MeasuredStateOnPlane stateRef(rep);
-      rep->setPosMomCov(stateRef, pos, mom, covM);
-
-      // smeared start state
-      genfit::MeasuredStateOnPlane stateSmeared(rep);
-      rep->setPosMomCov(stateSmeared, posM, momM, covM);
-
-      //rep->setPropDir(1);
-
-      if (!matFX) genfit::MaterialEffects::getInstance()->setNoEffects();
-
-      // remember original initial state
-      const genfit::StateOnPlane stateRefOrig(stateRef);
-
-      // create smeared measurements
-      std::vector< std::vector<genfit::AbsMeasurement*> > measurements;
-
-      std::vector<bool> outlierTrue;
-      bool outlier;
-      // true values for left right. 0 for non wire measurements
-      std::vector<int> leftRightTrue;
-      int lr;
-
-      double trueLen(-1);
-
-      try{
-        for (unsigned int i=0; i<measurementTypes.size(); ++i){
-          trueLen = i*pointDist;
-
-          measurements.push_back(measurementCreator.create(measurementTypes[i], trueLen, outlier, lr));
-          outlierTrue.push_back(outlier);
-          leftRightTrue.push_back(lr);
-        }
-        assert(measurementTypes.size() == leftRightTrue.size());
-        assert(measurementTypes.size() == outlierTrue.size());
-      }
-      catch(genfit::Exception& e){
-        std::cerr<<"Exception, next track"<<std::endl;
-        std::cerr << e.what();
-        continue; // here is a memleak!
-      }
-
-      if (debug) std::cout << "... done creating measurements \n";
+    if (debug) std::cout << "... done creating measurements \n";
 
 
 
-      // create track
-      TVectorD seedState(6);
-      TMatrixDSym seedCov(6);
-      rep->get6DStateCov(stateSmeared, seedState, seedCov);
-      fitTrack = new genfit::Track(rep, seedState, seedCov); //initialized with smeared rep
-      secondTrack = new genfit::Track(rep->clone(), seedState, seedCov); //initialized with smeared rep
-      if (twoReps) {
-        fitTrack->addTrackRep(secondRep);
-        secondTrack->addTrackRep(secondRep->clone());
-      }
+    // create track
+    TVectorD seedState(6);
+    TMatrixDSym seedCov(6);
+    rep->get6DStateCov(stateSmeared, seedState, seedCov);
+    fitTrack = new genfit::Track(rep, seedState, seedCov); //initialized with smeared rep
+    secondTrack = new genfit::Track(rep->clone(), seedState, seedCov); //initialized with smeared rep
+    if (twoReps) {
+      fitTrack->addTrackRep(secondRep);
+      secondTrack->addTrackRep(secondRep->clone());
+    } else
+      delete secondRep;
+    //if (debug) fitTrack->Print("C");
+
+    fitTrack->checkConsistency();
+    //fitTrack->addTrackRep(rep->clone()); // check if everything works fine with more than one rep
+
+    // add measurements
+    for (unsigned int i = 0; i < measurements.size(); ++i) {
+      if (splitTrack > 0 && (int)i >= splitTrack)
+        break;
+      if (i > 0 && hitSwitchProb > gRandom->Uniform(1.))
+        fitTrack->insertPoint(new genfit::TrackPoint(measurements[i], fitTrack), -2);
       else
-        delete secondRep;
-      //if (debug) fitTrack->Print("C");
+        fitTrack->insertPoint(new genfit::TrackPoint(measurements[i], fitTrack));
 
       fitTrack->checkConsistency();
-      //fitTrack->addTrackRep(rep->clone()); // check if everything works fine with more than one rep
+      //if (debug) fitTrack->Print("C");
+    }
 
-      // add measurements
-      for(unsigned int i=0; i<measurements.size(); ++i){
-        if (splitTrack > 0 && (int)i >= splitTrack)
-          break;
-        if (i>0 && hitSwitchProb > gRandom->Uniform(1.))
-          fitTrack->insertPoint(new genfit::TrackPoint(measurements[i], fitTrack), -2);
+    if (splitTrack > 0) {
+      for (unsigned int i = splitTrack; i < measurements.size(); ++i) {
+        if (i > 0 && hitSwitchProb > gRandom->Uniform(1.))
+          secondTrack->insertPoint(new genfit::TrackPoint(measurements[i], secondTrack), -2);
         else
-          fitTrack->insertPoint(new genfit::TrackPoint(measurements[i], fitTrack));
+          secondTrack->insertPoint(new genfit::TrackPoint(measurements[i], secondTrack));
 
-        fitTrack->checkConsistency();
         //if (debug) fitTrack->Print("C");
       }
+    }
 
-      if (splitTrack > 0) {
-        for(unsigned int i=splitTrack; i<measurements.size(); ++i){
-          if (i>0 && hitSwitchProb > gRandom->Uniform(1.))
-            secondTrack->insertPoint(new genfit::TrackPoint(measurements[i], secondTrack), -2);
-          else
-            secondTrack->insertPoint(new genfit::TrackPoint(measurements[i], secondTrack));
+    fitTrack->checkConsistency();
+    secondTrack->checkConsistency();
 
-          //if (debug) fitTrack->Print("C");
-        }
+    //if (debug) fitTrack->Print();
+
+    // do the fit
+    try {
+      if (debug) std::cout << "Starting the fitter" << std::endl;
+
+      if (prefit) {
+        genfit::KalmanFitter prefitter(1, dPVal);
+        prefitter.setMultipleMeasurementHandling(genfit::weightedClosestToPrediction);
+        prefitter.processTrackWithRep(fitTrack, fitTrack->getCardinalRep());
       }
 
-      fitTrack->checkConsistency();
-      secondTrack->checkConsistency();
+      fitter->processTrack(fitTrack, resort);
+      if (splitTrack > 0)
+        fitter->processTrack(secondTrack, resort);
 
-      //if (debug) fitTrack->Print();
+      if (debug) std::cout << "fitter is finished!" << std::endl;
+    } catch (genfit::Exception& e) {
+      std::cerr << e.what();
+      std::cerr << "Exception, next track" << std::endl;
+      continue;
+    }
 
-      // do the fit
-      try{
-        if (debug) std::cout<<"Starting the fitter"<<std::endl;
+    if (splitTrack > 0) {
+      if (debug) fitTrack->Print("C");
+      if (debug) secondTrack->Print("C");
 
-        if (prefit) {
-          genfit::KalmanFitter prefitter(1, dPVal);
-          prefitter.setMultipleMeasurementHandling(genfit::weightedClosestToPrediction);
-          prefitter.processTrackWithRep(fitTrack, fitTrack->getCardinalRep());
-        }
+      if (fullMeasurement) {
+        genfit::FullMeasurement* fullM = new genfit::FullMeasurement(secondTrack->getFittedState());
+        fitTrack->insertPoint(new genfit::TrackPoint(fullM, fitTrack));
+      } else
+        fitTrack->mergeTrack(secondTrack);
 
+      if (debug) fitTrack->Print("C");
+
+      try {
+        if (debug) std::cout << "Starting the fitter" << std::endl;
         fitter->processTrack(fitTrack, resort);
-        if (splitTrack > 0)
-          fitter->processTrack(secondTrack, resort);
-
-        if (debug) std::cout<<"fitter is finished!"<<std::endl;
-      }
-      catch(genfit::Exception& e){
+        if (debug) std::cout << "fitter is finished!" << std::endl;
+      } catch (genfit::Exception& e) {
         std::cerr << e.what();
         std::cerr << "Exception, next track" << std::endl;
         continue;
       }
-
-      if (splitTrack > 0) {
-        if (debug) fitTrack->Print("C");
-        if (debug) secondTrack->Print("C");
-
-        if (fullMeasurement) {
-          genfit::FullMeasurement* fullM = new genfit::FullMeasurement(secondTrack->getFittedState());
-          fitTrack->insertPoint(new genfit::TrackPoint(fullM, fitTrack));
-        }
-        else
-          fitTrack->mergeTrack(secondTrack);
-
-        if (debug) fitTrack->Print("C");
-
-        try{
-          if (debug) std::cout<<"Starting the fitter"<<std::endl;
-          fitter->processTrack(fitTrack, resort);
-          if (debug) std::cout<<"fitter is finished!"<<std::endl;
-        }
-        catch(genfit::Exception& e){
-          std::cerr << e.what();
-          std::cerr << "Exception, next track" << std::endl;
-          continue;
-        }
-      }
+    }
 
 
-      if (refit && !fitTrack->getFitStatus(rep)->isFitConverged()) {
-        std::cout<<"Trying to fit again "<<std::endl;
-        fitter->processTrack(fitTrack, resort);
-      }
+    if (refit && !fitTrack->getFitStatus(rep)->isFitConverged()) {
+      std::cout << "Trying to fit again " << std::endl;
+      fitter->processTrack(fitTrack, resort);
+    }
 
 
 
-      if (debug) {
-        fitTrack->Print("C");
-        fitTrack->getFitStatus(rep)->Print();
-      }
+    if (debug) {
+      fitTrack->Print("C");
+      fitTrack->getFitStatus(rep)->Print();
+    }
 
-      fitTrack->checkConsistency();
-      secondTrack->checkConsistency();
+    fitTrack->checkConsistency();
+    secondTrack->checkConsistency();
 
 #ifndef VALGRIND
-      if (!onlyDisplayFailed && iEvent < 1000) {
-        std::vector<genfit::Track*> event;
-        event.push_back(fitTrack);
-        if (splitTrack > 0)
-          event.push_back(secondTrack);
-        display->addEvent(event);
-      }
-      else if (onlyDisplayFailed &&
+    if (!onlyDisplayFailed && iEvent < 1000) {
+      std::vector<genfit::Track*> event;
+      event.push_back(fitTrack);
+      if (splitTrack > 0)
+        event.push_back(secondTrack);
+      display->addEvent(event);
+    } else if (onlyDisplayFailed &&
                (!fitTrack->getFitStatus(rep)->isFitConverged() ||
                 fitTrack->getFitStatus(rep)->getPVal() < 0.01)) {
-        // add track to event display
-        display->addEvent(fitTrack);
-      }
+      // add track to event display
+      display->addEvent(fitTrack);
+    }
 #endif
 
 
-      if (fitTrack->getFitStatus(rep)->isFitConverged()) {
-        nTotalIterConverged += static_cast<genfit::KalmanFitStatus*>(fitTrack->getFitStatus(rep))->getNumIterations();
-        nConvergedFits += 1;
-      }
-      else {
-        nTotalIterNotConverged += static_cast<genfit::KalmanFitStatus*>(fitTrack->getFitStatus(rep))->getNumIterations();
-        nUNConvergedFits += 1;
-      }
+    if (fitTrack->getFitStatus(rep)->isFitConverged()) {
+      nTotalIterConverged += static_cast<genfit::KalmanFitStatus*>(fitTrack->getFitStatus(rep))->getNumIterations();
+      nConvergedFits += 1;
+    } else {
+      nTotalIterNotConverged += static_cast<genfit::KalmanFitStatus*>(fitTrack->getFitStatus(rep))->getNumIterations();
+      nUNConvergedFits += 1;
+    }
 
-      if (twoReps) {
-        if (fitTrack->getFitStatus(secondRep)->isFitConverged()) {
-          nTotalIterSecondConverged += static_cast<genfit::KalmanFitStatus*>(fitTrack->getFitStatus(secondRep))->getNumIterations();
-          nConvergedFitsSecond += 1;
-        }
-        else {
-          nTotalIterSecondNotConverged += static_cast<genfit::KalmanFitStatus*>(fitTrack->getFitStatus(secondRep))->getNumIterations();
-          nUNConvergedFitsSecond += 1;
-        }
+    if (twoReps) {
+      if (fitTrack->getFitStatus(secondRep)->isFitConverged()) {
+        nTotalIterSecondConverged += static_cast<genfit::KalmanFitStatus*>(fitTrack->getFitStatus(secondRep))->getNumIterations();
+        nConvergedFitsSecond += 1;
+      } else {
+        nTotalIterSecondNotConverged += static_cast<genfit::KalmanFitStatus*>(fitTrack->getFitStatus(secondRep))->getNumIterations();
+        nUNConvergedFitsSecond += 1;
       }
+    }
 
 
-      // check if fit was successful
-      if (! fitTrack->getFitStatus(rep)->isFitConverged()) {
-        std::cout << "Track could not be fitted successfully! Fit is not converged! \n";
-        continue;
-      }
+    // check if fit was successful
+    if (! fitTrack->getFitStatus(rep)->isFitConverged()) {
+      std::cout << "Track could not be fitted successfully! Fit is not converged! \n";
+      continue;
+    }
 
 
-      genfit::TrackPoint* tp = fitTrack->getPointWithMeasurementAndFitterInfo(0, rep);
-      if (tp == nullptr) {
-        std::cout << "Track has no TrackPoint with fitterInfo! \n";
-        continue;
-      }
-      genfit::KalmanFittedStateOnPlane kfsop(*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate()));
-      if (debug) {
-        std::cout << "state before extrapolating back to reference plane \n";
-        kfsop.Print();
-      }
+    genfit::TrackPoint* tp = fitTrack->getPointWithMeasurementAndFitterInfo(0, rep);
+    if (tp == nullptr) {
+      std::cout << "Track has no TrackPoint with fitterInfo! \n";
+      continue;
+    }
+    genfit::KalmanFittedStateOnPlane kfsop(*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate()));
+    if (debug) {
+      std::cout << "state before extrapolating back to reference plane \n";
+      kfsop.Print();
+    }
 
-      // extrapolate back to reference plane.
-      try{
-        rep->extrapolateToPlane(kfsop, stateRefOrig.getPlane());;
-      }
-      catch(genfit::Exception& e){
-        std::cerr<<"Exception, next track"<<std::endl;
-        std::cerr << e.what();
-        continue;
-      }
+    // extrapolate back to reference plane.
+    try {
+      rep->extrapolateToPlane(kfsop, stateRefOrig.getPlane());;
+    } catch (genfit::Exception& e) {
+      std::cerr << "Exception, next track" << std::endl;
+      std::cerr << e.what();
+      continue;
+    }
 
 #ifndef VALGRIND
-      // calculate pulls
-      const TVectorD& referenceState = stateRefOrig.getState();
+    // calculate pulls
+    const TVectorD& referenceState = stateRefOrig.getState();
 
-      const TVectorD& state = kfsop.getState();
-      const TMatrixDSym& cov = kfsop.getCov();
+    const TVectorD& state = kfsop.getState();
+    const TMatrixDSym& cov = kfsop.getCov();
 
-      double pval = fitter->getPVal(fitTrack, rep);
-      //assert( fabs(pval - static_cast<genfit::KalmanFitStatus*>(fitTrack->getFitStatus(rep))->getBackwardPVal()) < 1E-10 );
+    double pval = fitter->getPVal(fitTrack, rep);
+    //assert( fabs(pval - static_cast<genfit::KalmanFitStatus*>(fitTrack->getFitStatus(rep))->getBackwardPVal()) < 1E-10 );
 
-      hmomRes->Fill( (charge/state[0]-momentum));
-      hupRes->Fill(  (state[1]-referenceState[1]));
-      hvpRes->Fill(  (state[2]-referenceState[2]));
-      huRes->Fill(   (state[3]-referenceState[3]));
-      hvRes->Fill(   (state[4]-referenceState[4]));
+    hmomRes->Fill((charge / state[0] - momentum));
+    hupRes->Fill((state[1] - referenceState[1]));
+    hvpRes->Fill((state[2] - referenceState[2]));
+    huRes->Fill((state[3] - referenceState[3]));
+    hvRes->Fill((state[4] - referenceState[4]));
 
-      hqopPu->Fill( (state[0]-referenceState[0]) / sqrt(cov[0][0]) );
-      pVal->Fill(   pval);
-      hupPu->Fill(  (state[1]-referenceState[1]) / sqrt(cov[1][1]) );
-      hvpPu->Fill(  (state[2]-referenceState[2]) / sqrt(cov[2][2]) );
-      huPu->Fill(   (state[3]-referenceState[3]) / sqrt(cov[3][3]) );
-      hvPu->Fill(   (state[4]-referenceState[4]) / sqrt(cov[4][4]) );
+    hqopPu->Fill((state[0] - referenceState[0]) / sqrt(cov[0][0]));
+    pVal->Fill(pval);
+    hupPu->Fill((state[1] - referenceState[1]) / sqrt(cov[1][1]));
+    hvpPu->Fill((state[2] - referenceState[2]) / sqrt(cov[2][2]));
+    huPu->Fill((state[3] - referenceState[3]) / sqrt(cov[3][3]));
+    hvPu->Fill((state[4] - referenceState[4]) / sqrt(cov[4][4]));
 
 
-      try {
-        trackLenRes->Fill( (trueLen - fitTrack->getTrackLen(rep)) / trueLen );
+    try {
+      trackLenRes->Fill((trueLen - fitTrack->getTrackLen(rep)) / trueLen);
+
+      if (debug) {
+        std::cout << "true track length = " << trueLen << "; fitted length = " << fitTrack->getTrackLen(rep) << "\n";
+        std::cout << "fitted tof = " << fitTrack->getTOF(rep) << " ns\n";
+      }
+    } catch (genfit::Exception& e) {
+      std::cerr << e.what();
+      std::cout << "could not get TrackLen or TOF! \n";
+    }
+
+
+
+    // check l/r resolution and outlier rejection
+    if (dynamic_cast<genfit::DAF*>(fitter) != nullptr) {
+      for (unsigned int i = 0; i < fitTrack->getNumPointsWithMeasurement(); ++i) {
+
+        if (! fitTrack->getPointWithMeasurement(i)->hasFitterInfo(rep))
+          continue;
 
         if (debug) {
-          std::cout << "true track length = " << trueLen << "; fitted length = " << fitTrack->getTrackLen(rep) << "\n";
-          std::cout << "fitted tof = " << fitTrack->getTOF(rep) << " ns\n";
+          std::vector<double> dafWeights = dynamic_cast<genfit::KalmanFitterInfo*>(fitTrack->getPointWithMeasurement(i)->getFitterInfo(
+                                             rep))->getWeights();
+          std::cout << "hit " << i;
+          if (outlierTrue[i]) std::cout << " is an OUTLIER";
+          std::cout << " weights: ";
+          for (unsigned int j = 0; j < dafWeights.size(); ++j) {
+            std::cout << dafWeights[j] << "  ";
+          }
+          std::cout << "   l/r: " << leftRightTrue[i];
+          std::cout << "\n";
+        }
+        int trueSide = leftRightTrue[i];
+        if (trueSide == 0) continue; // not a wire measurement
+        if (outlierTrue[i]) continue; // an outlier
+        std::vector<double> dafWeightLR = dynamic_cast<genfit::KalmanFitterInfo*>(fitTrack->getPointWithMeasurement(i)->getFitterInfo(
+                                            rep))->getWeights();
+        if (dafWeightLR.size() != 2)
+          continue;
+
+        double weightCorrectSide, weightWrongSide;
+
+        if (trueSide < 0) {
+          weightCorrectSide = dafWeightLR[0];
+          weightWrongSide =  dafWeightLR[1];
+        } else {
+          weightCorrectSide = dafWeightLR[1];
+          weightWrongSide =  dafWeightLR[0];
+        }
+        weightWrongSide -= 1.;
+
+        weights->Fill(weightCorrectSide);
+        weights->Fill(weightWrongSide);
+
+        if (weightCorrectSide > maxWeight) maxWeight = weightCorrectSide;
+      }
+
+      for (unsigned int i = 0; i < fitTrack->getNumPointsWithMeasurement(); ++i) {
+        if (! fitTrack->getPointWithMeasurement(i)->hasFitterInfo(rep))
+          continue;
+
+        std::vector<double> dafWeights = dynamic_cast<genfit::KalmanFitterInfo*>(fitTrack->getPointWithMeasurement(i)->getFitterInfo(
+                                           rep))->getWeights();
+
+        if (outlierTrue[i]) { // an outlier
+          for (unsigned int j = 0; j < dafWeights.size(); ++j) {
+            weights->Fill(dafWeights[j] - 1);
+          }
+        } else if (leftRightTrue[i] == 0) { // only for non wire hits
+          for (unsigned int j = 0; j < dafWeights.size(); ++j) {
+            weights->Fill(dafWeights[j]);
+          }
         }
       }
-      catch (genfit::Exception& e) {
-        std::cerr << e.what();
-        std::cout << "could not get TrackLen or TOF! \n";
-      }
 
+    }
 
+    if (checkPruning) { //check pruning
+      //std::cout<<"\n";
+      //std::cout<<"get stFirst ";
+      genfit::MeasuredStateOnPlane stFirst = fitTrack->getFittedState();
+      //std::cout<<"get stLast ";
+      genfit::MeasuredStateOnPlane stLast = fitTrack->getFittedState(-1);
 
-      // check l/r resolution and outlier rejection
-      if (dynamic_cast<genfit::DAF*>(fitter) != nullptr) {
-        for (unsigned int i=0; i<fitTrack->getNumPointsWithMeasurement(); ++i){
+      for (unsigned int i = 0; i < 1; ++i) {
+        genfit::Track trClone(*fitTrack);
+        trClone.checkConsistency();
 
-          if (! fitTrack->getPointWithMeasurement(i)->hasFitterInfo(rep))
-            continue;
+        bool first(false), last(false);
+
+        TString opt("");
+        try {
+          if (gRandom->Uniform() < 0.5) trClone.prune("C");
+          if (gRandom->Uniform() < 0.5) {
+            opt.Append("F");
+            first = true;
+          }
+          if (gRandom->Uniform() < 0.5) {
+            opt.Append("L");
+            last = true;
+          }
+          if (gRandom->Uniform() < 0.5) opt.Append("W");
+          if (gRandom->Uniform() < 0.5) opt.Append("R");
+          if (gRandom->Uniform() < 0.5) opt.Append("M");
+          if (gRandom->Uniform() < 0.5) opt.Append("I");
+          if (gRandom->Uniform() < 0.5) opt.Append("U");
+
+          trClone.prune(opt);
+
+          try {
+            trClone.checkConsistency();
+          } catch (genfit::Exception& e) {
+            trClone.getFitStatus()->getPruneFlags().Print();
+          }
+
+          //std::cout<<"get stCloneFirst ";
+          genfit::MeasuredStateOnPlane stCloneFirst = trClone.getFittedState();
+          //std::cout<<"get stCloneLast ";
+          genfit::MeasuredStateOnPlane stCloneLast = trClone.getFittedState(-1);
+
+          if (first and !(stFirst.getState() == stCloneFirst.getState() and stFirst.getCov() == stCloneFirst.getCov())) {
+            //std::cout<<" failed first state ";
+            //stFirst.Print();
+            //stCloneFirst.Print();
+
+            if (debug)
+              trClone.getFitStatus()->getPruneFlags().Print();
+          }
+
+          if (last  and !(stLast.getState()  == stCloneLast.getState()  and stLast.getCov()  == stCloneLast.getCov())) {
+            //std::cout<<" failed last state ";
+            //stLast.Print();
+            //stCloneLast.Print();
+
+            if (debug)
+              trClone.getFitStatus()->getPruneFlags().Print();
+          }
 
           if (debug) {
-            std::vector<double> dafWeights = dynamic_cast<genfit::KalmanFitterInfo*>(fitTrack->getPointWithMeasurement(i)->getFitterInfo(rep))->getWeights();
-            std::cout << "hit " << i;
-            if (outlierTrue[i]) std::cout << " is an OUTLIER";
-            std::cout << " weights: ";
-            for (unsigned int j=0; j<dafWeights.size(); ++j){
-              std::cout << dafWeights[j] << "  ";
-            }
-            std::cout << "   l/r: " << leftRightTrue[i];
-            std::cout << "\n";
+            std::cout << " pruned track: ";
+            trClone.Print();
           }
-          int trueSide = leftRightTrue[i];
-          if (trueSide == 0) continue; // not a wire measurement
-          if (outlierTrue[i]) continue; // an outlier
-          std::vector<double> dafWeightLR = dynamic_cast<genfit::KalmanFitterInfo*>(fitTrack->getPointWithMeasurement(i)->getFitterInfo(rep))->getWeights();
-          if(dafWeightLR.size() != 2)
-            continue;
-
-          double weightCorrectSide, weightWrongSide;
-
-          if (trueSide < 0) {
-            weightCorrectSide = dafWeightLR[0];
-            weightWrongSide =  dafWeightLR[1];
-          }
-          else {
-            weightCorrectSide = dafWeightLR[1];
-            weightWrongSide =  dafWeightLR[0];
-          }
-          weightWrongSide -= 1.;
-
-          weights->Fill(weightCorrectSide);
-          weights->Fill(weightWrongSide);
-
-          if (weightCorrectSide>maxWeight) maxWeight = weightCorrectSide;
+        } catch (genfit::Exception& e) {
+          std::cerr << e.what();
         }
-
-        for (unsigned int i=0; i<fitTrack->getNumPointsWithMeasurement(); ++i){
-          if (! fitTrack->getPointWithMeasurement(i)->hasFitterInfo(rep))
-            continue;
-
-          std::vector<double> dafWeights = dynamic_cast<genfit::KalmanFitterInfo*>(fitTrack->getPointWithMeasurement(i)->getFitterInfo(rep))->getWeights();
-
-          if (outlierTrue[i]) { // an outlier
-            for (unsigned int j=0; j<dafWeights.size(); ++j){
-              weights->Fill(dafWeights[j]-1);
-            }
-          }
-          else if (leftRightTrue[i] == 0) { // only for non wire hits
-            for (unsigned int j=0; j<dafWeights.size(); ++j){
-              weights->Fill(dafWeights[j]);
-            }
-          }
-        }
-
       }
 
-      if (checkPruning) { //check pruning
-        //std::cout<<"\n";
-        //std::cout<<"get stFirst ";
-        genfit::MeasuredStateOnPlane stFirst = fitTrack->getFittedState();
-        //std::cout<<"get stLast ";
-        genfit::MeasuredStateOnPlane stLast = fitTrack->getFittedState(-1);
-
-        for (unsigned int i=0; i<1; ++i) {
-          genfit::Track trClone(*fitTrack);
-          trClone.checkConsistency();
-
-          bool first(false), last(false);
-
-          TString opt("");
-          try {
-            if (gRandom->Uniform() < 0.5) trClone.prune("C");
-            if (gRandom->Uniform() < 0.5) {
-              opt.Append("F");
-              first = true;
-            }
-            if (gRandom->Uniform() < 0.5) {
-              opt.Append("L");
-              last = true;
-            }
-            if (gRandom->Uniform() < 0.5) opt.Append("W");
-            if (gRandom->Uniform() < 0.5) opt.Append("R");
-            if (gRandom->Uniform() < 0.5) opt.Append("M");
-            if (gRandom->Uniform() < 0.5) opt.Append("I");
-            if (gRandom->Uniform() < 0.5) opt.Append("U");
-
-            trClone.prune(opt);
-
-            try {
-              trClone.checkConsistency();
-            } catch (genfit::Exception& e) {
-              trClone.getFitStatus()->getPruneFlags().Print();
-            }
-
-            //std::cout<<"get stCloneFirst ";
-            genfit::MeasuredStateOnPlane stCloneFirst = trClone.getFittedState();
-            //std::cout<<"get stCloneLast ";
-            genfit::MeasuredStateOnPlane stCloneLast = trClone.getFittedState(-1);
-
-            if (first and ! (stFirst.getState() == stCloneFirst.getState() and stFirst.getCov() == stCloneFirst.getCov() )) {
-              //std::cout<<" failed first state ";
-              //stFirst.Print();
-              //stCloneFirst.Print();
-
-              if (debug)
-                trClone.getFitStatus()->getPruneFlags().Print();
-            }
-
-            if (last  and ! (stLast.getState()  == stCloneLast.getState()  and stLast.getCov()  == stCloneLast.getCov() )) {
-              //std::cout<<" failed last state ";
-              //stLast.Print();
-              //stCloneLast.Print();
-
-              if (debug)
-                trClone.getFitStatus()->getPruneFlags().Print();
-            }
-
-            if (debug) {
-              std::cout<<" pruned track: ";
-              trClone.Print();
-            }
-          }
-          catch (genfit::Exception &e) {
-            std::cerr << e.what();
-          }
-        }
-
-      } // end check pruning
+    } // end check pruning
 
 #endif
 
@@ -792,17 +787,22 @@ int main() {
   CALLGRIND_STOP_INSTRUMENTATION;
   CALLGRIND_DUMP_STATS;
 
-  std::cout<<"maxWeight = " << maxWeight << std::endl;
-  std::cout<<"avg nr iterations =                     " << (double)(nTotalIterConverged + nTotalIterNotConverged)/(double)(nConvergedFits + nUNConvergedFits) << std::endl;
-  std::cout<<"avg nr iterations of converged fits =   " << (double)(nTotalIterConverged)/(double)(nConvergedFits) << std::endl;
-  std::cout<<"avg nr iterations of UNconverged fits = " << (double)(nTotalIterNotConverged)/(double)(nUNConvergedFits) << std::endl;
-  std::cout<<"fit efficiency =                        " << (double)nConvergedFits/nEvents << std::endl;
+  std::cout << "maxWeight = " << maxWeight << std::endl;
+  std::cout << "avg nr iterations =                     " << (double)(nTotalIterConverged + nTotalIterNotConverged) / (double)(
+              nConvergedFits + nUNConvergedFits) << std::endl;
+  std::cout << "avg nr iterations of converged fits =   " << (double)(nTotalIterConverged) / (double)(nConvergedFits) << std::endl;
+  std::cout << "avg nr iterations of UNconverged fits = " << (double)(nTotalIterNotConverged) / (double)(
+              nUNConvergedFits) << std::endl;
+  std::cout << "fit efficiency =                        " << (double)nConvergedFits / nEvents << std::endl;
 
   if (twoReps) {
-    std::cout<<"second rep: \navg nr iterations =                     " << (double)(nTotalIterSecondConverged + nTotalIterSecondNotConverged)/(double)(nConvergedFitsSecond + nUNConvergedFitsSecond) << std::endl;
-    std::cout<<"avg nr iterations of converged fits =   " << (double)(nTotalIterSecondConverged)/(double)(nConvergedFitsSecond) << std::endl;
-    std::cout<<"avg nr iterations of UNconverged fits = " << (double)(nTotalIterSecondNotConverged)/(double)(nUNConvergedFitsSecond) << std::endl;
-    std::cout<<"fit efficiency =                        " << (double)nConvergedFitsSecond/nEvents << std::endl;
+    std::cout << "second rep: \navg nr iterations =                     " << (double)(nTotalIterSecondConverged +
+              nTotalIterSecondNotConverged) / (double)(nConvergedFitsSecond + nUNConvergedFitsSecond) << std::endl;
+    std::cout << "avg nr iterations of converged fits =   " << (double)(nTotalIterSecondConverged) / (double)(
+                nConvergedFitsSecond) << std::endl;
+    std::cout << "avg nr iterations of UNconverged fits = " << (double)(nTotalIterSecondNotConverged) / (double)(
+                nUNConvergedFitsSecond) << std::endl;
+    std::cout << "fit efficiency =                        " << (double)nConvergedFitsSecond / nEvents << std::endl;
   }
 
 
@@ -812,10 +812,10 @@ int main() {
 
 #ifndef VALGRIND
 
-  if (debug) std::cout<<"Draw histograms ...";
+  if (debug) std::cout << "Draw histograms ...";
   // fit and draw histograms
   TCanvas* c1 = new TCanvas();
-  c1->Divide(2,3);
+  c1->Divide(2, 3);
 
   c1->cd(1);
   hmomRes->Fit("gaus");
@@ -843,7 +843,7 @@ int main() {
   c1->Write();
 
   TCanvas* c2 = new TCanvas();
-  c2->Divide(2,3);
+  c2->Divide(2, 3);
 
   c2->cd(1);
   hqopPu->Fit("gaus");
@@ -881,7 +881,7 @@ int main() {
 
   c3->Write();
 
-  if (debug) std::cout<<"... done"<<std::endl;
+  if (debug) std::cout << "... done" << std::endl;
 
   // open event display
   display->setOptions("ABDEFHMPT"); // G show geometry

--- a/test/measurementFactoryExample/main.cc
+++ b/test/measurementFactoryExample/main.cc
@@ -35,7 +35,8 @@
 
 
 
-int main() {
+int main()
+{
 
   gRandom->SetSeed(14);
 
@@ -46,7 +47,7 @@ int main() {
   // init geometry and mag. field
   new TGeoManager("Geometry", "Geane geometry");
   TGeoManager::Import("genfitGeom.root");
-  genfit::FieldManager::getInstance()->init(new genfit::ConstField(0.,0., 15.)); // 15 kGauss
+  genfit::FieldManager::getInstance()->init(new genfit::ConstField(0., 0., 15.)); // 15 kGauss
   genfit::MaterialEffects::getInstance()->init(new genfit::TGeoMaterialInterface());
 
 
@@ -68,7 +69,7 @@ int main() {
 
 
   // main loop
-  for (unsigned int iEvent=0; iEvent<100; ++iEvent){
+  for (unsigned int iEvent = 0; iEvent < 100; ++iEvent) {
 
     myDetectorHitArray.Clear();
 
@@ -77,15 +78,15 @@ int main() {
 
     // true start values
     TVector3 pos(0, 0, 0);
-    TVector3 mom(1.,0,0);
-    mom.SetPhi(gRandom->Uniform(0.,2*TMath::Pi()));
-    mom.SetTheta(gRandom->Uniform(0.4*TMath::Pi(),0.6*TMath::Pi()));
+    TVector3 mom(1., 0, 0);
+    mom.SetPhi(gRandom->Uniform(0., 2 * TMath::Pi()));
+    mom.SetTheta(gRandom->Uniform(0.4 * TMath::Pi(), 0.6 * TMath::Pi()));
     mom.SetMag(gRandom->Uniform(0.2, 1.));
 
 
     // helix track model
     const int pdg = 13;               // particle pdg code
-    const double charge = TDatabasePDG::Instance()->GetParticle(pdg)->Charge()/(3.);
+    const double charge = TDatabasePDG::Instance()->GetParticle(pdg)->Charge() / (3.);
     genfit::HelixTrackModel* helix = new genfit::HelixTrackModel(pos, mom, charge);
     measurementCreator.setTrackModel(helix);
 
@@ -96,11 +97,11 @@ int main() {
     double resolution = 0.01;
     TMatrixDSym cov(3);
     for (int i = 0; i < 3; ++i)
-      cov(i,i) = resolution*resolution;
+      cov(i, i) = resolution * resolution;
 
-    for (unsigned int i=0; i<nMeasurements; ++i) {
+    for (unsigned int i = 0; i < nMeasurements; ++i) {
       // "simulate" the detector
-      TVector3 currentPos = helix->getPos(i*2.);
+      TVector3 currentPos = helix->getPos(i * 2.);
       currentPos.SetX(gRandom->Gaus(currentPos.X(), resolution));
       currentPos.SetY(gRandom->Gaus(currentPos.Y(), resolution));
       currentPos.SetZ(gRandom->Gaus(currentPos.Z(), resolution));
@@ -108,7 +109,7 @@ int main() {
       // Fill the TClonesArray and the TrackCand
       // In a real experiment, you detector code would deliver mySpacepointDetectorHits and fill the TClonesArray.
       // The patternRecognition would create the TrackCand.
-      new(myDetectorHitArray[i]) genfit::mySpacepointDetectorHit(currentPos, cov);
+      new (myDetectorHitArray[i]) genfit::mySpacepointDetectorHit(currentPos, cov);
       myCand.addHit(myDetId, i);
     }
 
@@ -116,27 +117,27 @@ int main() {
     // smeared start values (would come from the pattern recognition)
     const bool smearPosMom = true;   // init the Reps with smeared pos and mom
     const double posSmear = 0.1;     // cm
-    const double momSmear = 3. /180.*TMath::Pi();     // rad
+    const double momSmear = 3. / 180.*TMath::Pi();    // rad
     const double momMagSmear = 0.1;   // relative
 
     TVector3 posM(pos);
     TVector3 momM(mom);
     if (smearPosMom) {
-      posM.SetX(gRandom->Gaus(posM.X(),posSmear));
-      posM.SetY(gRandom->Gaus(posM.Y(),posSmear));
-      posM.SetZ(gRandom->Gaus(posM.Z(),posSmear));
+      posM.SetX(gRandom->Gaus(posM.X(), posSmear));
+      posM.SetY(gRandom->Gaus(posM.Y(), posSmear));
+      posM.SetZ(gRandom->Gaus(posM.Z(), posSmear));
 
-      momM.SetPhi(gRandom->Gaus(mom.Phi(),momSmear));
-      momM.SetTheta(gRandom->Gaus(mom.Theta(),momSmear));
-      momM.SetMag(gRandom->Gaus(mom.Mag(), momMagSmear*mom.Mag()));
+      momM.SetPhi(gRandom->Gaus(mom.Phi(), momSmear));
+      momM.SetTheta(gRandom->Gaus(mom.Theta(), momSmear));
+      momM.SetMag(gRandom->Gaus(mom.Mag(), momMagSmear * mom.Mag()));
     }
 
     // initial guess for cov
     TMatrixDSym covSeed(6);
     for (int i = 0; i < 3; ++i)
-      covSeed(i,i) = resolution*resolution;
+      covSeed(i, i) = resolution * resolution;
     for (int i = 3; i < 6; ++i)
-      covSeed(i,i) = pow(resolution / nMeasurements / sqrt(3), 2);
+      covSeed(i, i) = pow(resolution / nMeasurements / sqrt(3), 2);
 
 
     // set start values and pdg to cand
@@ -149,10 +150,9 @@ int main() {
 
 
     // do the fit
-    try{
+    try {
       fitter->processTrack(&fitTrack);
-    }
-    catch(genfit::Exception& e){
+    } catch (genfit::Exception& e) {
       std::cerr << e.what();
       std::cerr << "Exception, next track" << std::endl;
       continue;

--- a/test/minimalFittingExample/main.cc
+++ b/test/minimalFittingExample/main.cc
@@ -28,7 +28,8 @@
 
 
 
-int main() {
+int main()
+{
 
   gRandom->SetSeed(14);
 
@@ -39,7 +40,7 @@ int main() {
   // init geometry and mag. field
   new TGeoManager("Geometry", "Geane geometry");
   TGeoManager::Import("genfitGeom.root");
-  genfit::FieldManager::getInstance()->init(new genfit::ConstField(0.,0., 15.)); // 15 kGauss
+  genfit::FieldManager::getInstance()->init(new genfit::ConstField(0., 0., 15.)); // 15 kGauss
   genfit::MaterialEffects::getInstance()->init(new genfit::TGeoMaterialInterface());
 
 
@@ -51,19 +52,19 @@ int main() {
   genfit::AbsKalmanFitter* fitter = new genfit::KalmanFitterRefTrack();
 
   // main loop
-  for (unsigned int iEvent=0; iEvent<100; ++iEvent){
+  for (unsigned int iEvent = 0; iEvent < 100; ++iEvent) {
 
     // true start values
     TVector3 pos(0, 0, 0);
-    TVector3 mom(1.,0,0);
-    mom.SetPhi(gRandom->Uniform(0.,2*TMath::Pi()));
-    mom.SetTheta(gRandom->Uniform(0.4*TMath::Pi(),0.6*TMath::Pi()));
+    TVector3 mom(1., 0, 0);
+    mom.SetPhi(gRandom->Uniform(0., 2 * TMath::Pi()));
+    mom.SetTheta(gRandom->Uniform(0.4 * TMath::Pi(), 0.6 * TMath::Pi()));
     mom.SetMag(gRandom->Uniform(0.2, 1.));
 
 
     // helix track model
     const int pdg = 13;               // particle pdg code
-    const double charge = TDatabasePDG::Instance()->GetParticle(pdg)->Charge()/(3.);
+    const double charge = TDatabasePDG::Instance()->GetParticle(pdg)->Charge() / (3.);
     genfit::HelixTrackModel* helix = new genfit::HelixTrackModel(pos, mom, charge);
     measurementCreator.setTrackModel(helix);
 
@@ -74,27 +75,27 @@ int main() {
     // smeared start values
     const bool smearPosMom = true;     // init the Reps with smeared pos and mom
     const double posSmear = 0.1;     // cm
-    const double momSmear = 3. /180.*TMath::Pi();     // rad
+    const double momSmear = 3. / 180.*TMath::Pi();    // rad
     const double momMagSmear = 0.1;   // relative
 
     TVector3 posM(pos);
     TVector3 momM(mom);
     if (smearPosMom) {
-      posM.SetX(gRandom->Gaus(posM.X(),posSmear));
-      posM.SetY(gRandom->Gaus(posM.Y(),posSmear));
-      posM.SetZ(gRandom->Gaus(posM.Z(),posSmear));
+      posM.SetX(gRandom->Gaus(posM.X(), posSmear));
+      posM.SetY(gRandom->Gaus(posM.Y(), posSmear));
+      posM.SetZ(gRandom->Gaus(posM.Z(), posSmear));
 
-      momM.SetPhi(gRandom->Gaus(mom.Phi(),momSmear));
-      momM.SetTheta(gRandom->Gaus(mom.Theta(),momSmear));
-      momM.SetMag(gRandom->Gaus(mom.Mag(), momMagSmear*mom.Mag()));
+      momM.SetPhi(gRandom->Gaus(mom.Phi(), momSmear));
+      momM.SetTheta(gRandom->Gaus(mom.Theta(), momSmear));
+      momM.SetMag(gRandom->Gaus(mom.Mag(), momMagSmear * mom.Mag()));
     }
     // approximate covariance
     TMatrixDSym covM(6);
     double resolution = 0.01;
     for (int i = 0; i < 3; ++i)
-      covM(i,i) = resolution*resolution;
+      covM(i, i) = resolution * resolution;
     for (int i = 3; i < 6; ++i)
-      covM(i,i) = pow(resolution / nMeasurements / sqrt(3), 2);
+      covM(i, i) = pow(resolution / nMeasurements / sqrt(3), 2);
 
 
     // trackrep
@@ -119,14 +120,13 @@ int main() {
 
 
     // create smeared measurements and add to track
-    try{
-      for (unsigned int i=0; i<measurementTypes.size(); ++i){
-        std::vector<genfit::AbsMeasurement*> measurements = measurementCreator.create(measurementTypes[i], i*5.);
+    try {
+      for (unsigned int i = 0; i < measurementTypes.size(); ++i) {
+        std::vector<genfit::AbsMeasurement*> measurements = measurementCreator.create(measurementTypes[i], i * 5.);
         fitTrack.insertPoint(new genfit::TrackPoint(measurements, &fitTrack));
       }
-    }
-    catch(genfit::Exception& e){
-      std::cerr<<"Exception, next track"<<std::endl;
+    } catch (genfit::Exception& e) {
+      std::cerr << "Exception, next track" << std::endl;
       std::cerr << e.what();
       continue;
     }

--- a/test/minimalFittingExample/main2.cc
+++ b/test/minimalFittingExample/main2.cc
@@ -25,13 +25,14 @@
 
 
 
-int main() {
+int main()
+{
 
   // init geometry and mag. field
   new TGeoManager("Geometry", "Geane geometry");
   TGeoManager::Import("genfitGeom.root");
   genfit::MaterialEffects::getInstance()->init(new genfit::TGeoMaterialInterface());
-  genfit::FieldManager::getInstance()->init(new genfit::ConstField(0. ,10., 0.)); // 1 T
+  genfit::FieldManager::getInstance()->init(new genfit::ConstField(0., 10., 0.)); // 1 T
 
 
   // init event display
@@ -64,7 +65,7 @@ int main() {
   double detectorResolution(0.001); // resolution of planar detectors
   TMatrixDSym hitCov(2);
   hitCov.UnitMatrix();
-  hitCov *= detectorResolution*detectorResolution;
+  hitCov *= detectorResolution * detectorResolution;
 
 
   // add some planar hits to track with coordinates I just made up
@@ -72,19 +73,22 @@ int main() {
   hitCoords[0] = 0;
   hitCoords[1] = 0;
   genfit::PlanarMeasurement* measurement = new genfit::PlanarMeasurement(hitCoords, hitCov, detId, ++hitId, nullptr);
-  measurement->setPlane(genfit::SharedPlanePtr(new genfit::DetPlane(TVector3(0,0,0), TVector3(1,0,0), TVector3(0,1,0))), ++planeId);
+  measurement->setPlane(genfit::SharedPlanePtr(new genfit::DetPlane(TVector3(0, 0, 0), TVector3(1, 0, 0), TVector3(0, 1, 0))),
+                        ++planeId);
   fitTrack.insertPoint(new genfit::TrackPoint(measurement, &fitTrack));
 
   hitCoords[0] = -0.15;
   hitCoords[1] = 0;
   measurement = new genfit::PlanarMeasurement(hitCoords, hitCov, detId, ++hitId, nullptr);
-  measurement->setPlane(genfit::SharedPlanePtr(new genfit::DetPlane(TVector3(0,0,10), TVector3(1,0,0), TVector3(0,1,0))), ++planeId);
+  measurement->setPlane(genfit::SharedPlanePtr(new genfit::DetPlane(TVector3(0, 0, 10), TVector3(1, 0, 0), TVector3(0, 1, 0))),
+                        ++planeId);
   fitTrack.insertPoint(new genfit::TrackPoint(measurement, &fitTrack));
 
   hitCoords[0] = -0.4;
   hitCoords[1] = 0;
   measurement = new genfit::PlanarMeasurement(hitCoords, hitCov, detId, ++hitId, nullptr);
-  measurement->setPlane(genfit::SharedPlanePtr(new genfit::DetPlane(TVector3(0,0,20), TVector3(1,0,0), TVector3(0,1,0))), ++planeId);
+  measurement->setPlane(genfit::SharedPlanePtr(new genfit::DetPlane(TVector3(0, 0, 20), TVector3(1, 0, 0), TVector3(0, 1, 0))),
+                        ++planeId);
   fitTrack.insertPoint(new genfit::TrackPoint(measurement, &fitTrack));
 
 

--- a/test/streamerTest/main.cc
+++ b/test/streamerTest/main.cc
@@ -38,9 +38,9 @@ constexpr bool verbose = false;
 
 bool emptyTrackTest()
 {
-  TFile *f = TFile::Open(FILENAME, "RECREATE");
+  TFile* f = TFile::Open(FILENAME, "RECREATE");
   f->cd();
-  genfit::Track *t = new genfit::Track();
+  genfit::Track* t = new genfit::Track();
   try {
     t->checkConsistency();
   } catch (genfit::Exception&) {
@@ -68,14 +68,15 @@ bool emptyTrackTest()
 }
 
 
-int main() {
+int main()
+{
   if (!emptyTrackTest()) {
     std::cout << "emptyTrackTest failed." << std::endl;
     return 1;
   }
 
 
-  // prepare output tree for Tracks 
+  // prepare output tree for Tracks
   // std::unique_ptr<genfit::Track> fitTrack(new genfit::Track());
   genfit::Track* fitTrack = new genfit::Track();
   TVectorD stateFinal;
@@ -104,7 +105,7 @@ int main() {
   // init geometry and mag. field
   new TGeoManager("Geometry", "Geane geometry");
   TGeoManager::Import("genfitGeom.root");
-  genfit::FieldManager::getInstance()->init(new genfit::ConstField(0.,0., 15.)); // 15 kGauss
+  genfit::FieldManager::getInstance()->init(new genfit::ConstField(0., 0., 15.)); // 15 kGauss
   genfit::MaterialEffects::getInstance()->init(new genfit::TGeoMaterialInterface());
 
 
@@ -114,19 +115,19 @@ int main() {
   unsigned int nEvents(100);
 
   // main loop
-  for (unsigned int iEvent=0; iEvent<nEvents; ++iEvent){
+  for (unsigned int iEvent = 0; iEvent < nEvents; ++iEvent) {
 
     // true start values
     TVector3 pos(0, 0, 0);
-    TVector3 mom(1.,0,0);
-    mom.SetPhi(gRandom->Uniform(0.,2*TMath::Pi()));
-    mom.SetTheta(gRandom->Uniform(0.4*TMath::Pi(),0.6*TMath::Pi()));
+    TVector3 mom(1., 0, 0);
+    mom.SetPhi(gRandom->Uniform(0., 2 * TMath::Pi()));
+    mom.SetTheta(gRandom->Uniform(0.4 * TMath::Pi(), 0.6 * TMath::Pi()));
     mom.SetMag(gRandom->Uniform(0.2, 1.));
 
 
     // helix track model
     const int pdg = 13;               // particle pdg code
-    const double charge = TDatabasePDG::Instance()->GetParticle(pdg)->Charge()/(3.);
+    const double charge = TDatabasePDG::Instance()->GetParticle(pdg)->Charge() / (3.);
     genfit::HelixTrackModel* helix = new genfit::HelixTrackModel(pos, mom, charge);
     measurementCreator.setTrackModel(helix);
 
@@ -137,27 +138,27 @@ int main() {
     // smeared start values
     const bool smearPosMom = true;     // init the Reps with smeared pos and mom
     const double posSmear = 0.1;     // cm
-    const double momSmear = 3. /180.*TMath::Pi();     // rad
+    const double momSmear = 3. / 180.*TMath::Pi();    // rad
     const double momMagSmear = 0.1;   // relative
 
     TVector3 posM(pos);
     TVector3 momM(mom);
     if (smearPosMom) {
-      posM.SetX(gRandom->Gaus(posM.X(),posSmear));
-      posM.SetY(gRandom->Gaus(posM.Y(),posSmear));
-      posM.SetZ(gRandom->Gaus(posM.Z(),posSmear));
+      posM.SetX(gRandom->Gaus(posM.X(), posSmear));
+      posM.SetY(gRandom->Gaus(posM.Y(), posSmear));
+      posM.SetZ(gRandom->Gaus(posM.Z(), posSmear));
 
-      momM.SetPhi(gRandom->Gaus(mom.Phi(),momSmear));
-      momM.SetTheta(gRandom->Gaus(mom.Theta(),momSmear));
-      momM.SetMag(gRandom->Gaus(mom.Mag(), momMagSmear*mom.Mag()));
+      momM.SetPhi(gRandom->Gaus(mom.Phi(), momSmear));
+      momM.SetTheta(gRandom->Gaus(mom.Theta(), momSmear));
+      momM.SetMag(gRandom->Gaus(mom.Mag(), momMagSmear * mom.Mag()));
     }
     // approximate covariance
     TMatrixDSym covM(6);
     double resolution = 0.01;
     for (int i = 0; i < 3; ++i)
-      covM(i,i) = resolution*resolution;
+      covM(i, i) = resolution * resolution;
     for (int i = 3; i < 6; ++i)
-      covM(i,i) = pow(resolution / nMeasurements / sqrt(3), 2);
+      covM(i, i) = pow(resolution / nMeasurements / sqrt(3), 2);
 
 
     // trackrep
@@ -182,20 +183,20 @@ int main() {
 
 
     // create smeared measurements and add to track
-    try{
-      for (unsigned int i=0; i<measurementTypes.size(); ++i){
-        std::vector<genfit::AbsMeasurement*> measurements = measurementCreator.create(measurementTypes[i], i*5.);
+    try {
+      for (unsigned int i = 0; i < measurementTypes.size(); ++i) {
+        std::vector<genfit::AbsMeasurement*> measurements = measurementCreator.create(measurementTypes[i], i * 5.);
         genfit::TrackPoint* tp = new genfit::TrackPoint(measurements, fitTrack);
         // test scatterers
-        genfit::ThinScatterer* sc = new genfit::ThinScatterer(genfit::SharedPlanePtr(new genfit::DetPlane(TVector3(1,1,1), TVector3(1,1,1))),
-                                                              genfit::Material(1,2,3,4,5));
+        genfit::ThinScatterer* sc = new genfit::ThinScatterer(genfit::SharedPlanePtr(new genfit::DetPlane(TVector3(1, 1, 1), TVector3(1, 1,
+                                                              1))),
+                                                              genfit::Material(1, 2, 3, 4, 5));
         tp->setScatterer(sc);
 
         fitTrack->insertPoint(tp);
       }
-    }
-    catch(genfit::Exception& e){
-      std::cerr<<"Exception, next track"<<std::endl;
+    } catch (genfit::Exception& e) {
+      std::cerr << "Exception, next track" << std::endl;
       std::cerr << e.what();
       delete fitTrack;
       fitTrack = 0;
@@ -217,20 +218,20 @@ int main() {
     planeFinal =  *(fitTrack->getFittedState().getPlane());
 
     switch (iEvent % 5) {
-    case 0:
-      break;
-    case 1:
-      fitTrack->prune("FL");
-      break;
-    case 2:
-      fitTrack->prune("W");
-      break;
-    case 3:
-      fitTrack->prune("RC");
-      break;
-    case 4:
-      fitTrack->prune("U");
-      break;
+      case 0:
+        break;
+      case 1:
+        fitTrack->prune("FL");
+        break;
+      case 2:
+        fitTrack->prune("W");
+        break;
+      case 3:
+        fitTrack->prune("RC");
+        break;
+      case 4:
+        fitTrack->prune("U");
+        break;
     }
 
     tResults->Fill();
@@ -277,8 +278,7 @@ int main() {
           *pMatrix == fitTrack->getFittedState().getCov() &&
           *plane ==  *(fitTrack->getFittedState().getPlane())) {
         // track ok
-      }
-      else {
+      } else {
         if (verbose) {
           std::cout << "stored track not equal, small differences can occur if some info has been pruned." << std::endl;
           pState->Print();
@@ -287,15 +287,14 @@ int main() {
           fitTrack->getFittedState().getCov().Print();
           plane->Print();
           fitTrack->getFittedState().getPlane()->Print();
-          }
+        }
         ++fail;
         //return 1;
       }
-    }
-    catch (genfit::Exception& e) {
-        if (verbose) {
-            std::cerr << e.what();
-        }
+    } catch (genfit::Exception& e) {
+      if (verbose) {
+        std::cerr << e.what();
+      }
       return 1;
     }
   }

--- a/test/unitTests/main.cc
+++ b/test/unitTests/main.cc
@@ -70,8 +70,9 @@ enum e_testStatus {
 
 constexpr bool verbose = false;
 
-void handler(int sig) {
-  void *array[10];
+void handler(int sig)
+{
+  void* array[10];
   size_t size;
 
   // get void*'s for all entries on the stack
@@ -83,61 +84,65 @@ void handler(int sig) {
   exit(1);
 }
 
-int randomPdg() {
+int randomPdg()
+{
   int pdg;
 
-  switch(int(gRandom->Uniform(8))) {
-  case 1:
-    pdg = -11; break;
-  case 2:
-    pdg = 11; break;
-  case 3:
-    pdg = 13; break;
-  case 4:
-    pdg = -13; break;
-  case 5:
-    pdg = 211; break;
-  case 6:
-    pdg = -211; break;
-  case 7:
-    pdg = 2212; break;
-  default:
-    pdg = 211;
+  switch (int(gRandom->Uniform(8))) {
+    case 1:
+      pdg = -11; break;
+    case 2:
+      pdg = 11; break;
+    case 3:
+      pdg = 13; break;
+    case 4:
+      pdg = -13; break;
+    case 5:
+      pdg = 211; break;
+    case 6:
+      pdg = -211; break;
+    case 7:
+      pdg = 2212; break;
+    default:
+      pdg = 211;
   }
 
   return pdg;
 }
 
 
-int randomSign() {
+int randomSign()
+{
   if (gRandom->Uniform(1) > 0.5)
     return 1;
   return -1;
 }
 
 
-e_testStatus compareMatrices(const TMatrixTBase<double>& A, const TMatrixTBase<double>& B, double maxRelErr) {
+e_testStatus compareMatrices(const TMatrixTBase<double>& A, const TMatrixTBase<double>& B, double maxRelErr)
+{
   e_testStatus retVal = kPassed;
 
   // search max abs value
   double max(0);
-  for (int i=0; i<A.GetNrows(); ++i) {
-    for (int j=0; j<A.GetNcols(); ++j) {
-      if (fabs(A(i,j)) > max)
-        max = fabs(A(i,j));
+  for (int i = 0; i < A.GetNrows(); ++i) {
+    for (int j = 0; j < A.GetNcols(); ++j) {
+      if (fabs(A(i, j)) > max)
+        max = fabs(A(i, j));
     }
   }
 
-  double maxAbsErr = maxRelErr*max;
+  double maxAbsErr = maxRelErr * max;
 
-  for (int i=0; i<A.GetNrows(); ++i) {
-    for (int j=0; j<A.GetNcols(); ++j) {
-      double absErr = A(i,j) - B(i,j);
-      if ( fabs(absErr) > maxAbsErr ) {
-        double relErr = A(i,j)/B(i,j) - 1;
-        if ( fabs(relErr) > maxRelErr ) {
+  for (int i = 0; i < A.GetNrows(); ++i) {
+    for (int j = 0; j < A.GetNcols(); ++j) {
+      double absErr = A(i, j) - B(i, j);
+      if (fabs(absErr) > maxAbsErr) {
+        double relErr = A(i, j) / B(i, j) - 1;
+        if (fabs(relErr) > maxRelErr) {
           if (verbose)  {
-            std::cout << "compareMatrices: A("<<i<<","<<j<<") = " << A(i,j) << "  B("<<i<<","<<j<<") = " << B(i,j) << "     absErr = " << absErr << "    relErr = " << relErr << "\n";
+            std::cout << "compareMatrices: A(" << i << "," << j << ") = " << A(i, j) << "  B(" << i << "," << j << ") = " << B(i,
+                      j) << "     absErr = " << absErr << "    relErr = " << relErr << "\n";
           }
           retVal = kFailed;
         }
@@ -147,7 +152,8 @@ e_testStatus compareMatrices(const TMatrixTBase<double>& A, const TMatrixTBase<d
   return retVal;
 }
 
-e_testStatus isCovMatrix(TMatrixTBase<double>& cov) {
+e_testStatus isCovMatrix(TMatrixTBase<double>& cov)
+{
 
   if (!(cov.IsSymmetric())) {
     if (verbose) {
@@ -156,20 +162,20 @@ e_testStatus isCovMatrix(TMatrixTBase<double>& cov) {
     return kFailed;
   }
 
-  for (int i=0; i<cov.GetNrows(); ++i) {
-    for (int j=0; j<cov.GetNcols(); ++j) {
-       if (std::isnan(cov(i,j))) {
-         if (verbose) {
-           std::cout << "isCovMatrix: element isnan\n";
-         }
-         return kFailed;
-       }
-       if (i==j && cov(i,j) < 0) {
-         if (verbose) {
-           std::cout << "isCovMatrix: negative diagonal element\n";
-         }
-         return kFailed;
-       }
+  for (int i = 0; i < cov.GetNrows(); ++i) {
+    for (int j = 0; j < cov.GetNcols(); ++j) {
+      if (std::isnan(cov(i, j))) {
+        if (verbose) {
+          std::cout << "isCovMatrix: element isnan\n";
+        }
+        return kFailed;
+      }
+      if (i == j && cov(i, j) < 0) {
+        if (verbose) {
+          std::cout << "isCovMatrix: negative diagonal element\n";
+        }
+        return kFailed;
+      }
     }
   }
 
@@ -178,7 +184,8 @@ e_testStatus isCovMatrix(TMatrixTBase<double>& cov) {
 
 
 
-e_testStatus checkSetGetPosMom(bool writeHisto = false) {
+e_testStatus checkSetGetPosMom(bool writeHisto = false)
+{
 
   if (writeHisto)
     return kPassed;
@@ -191,8 +198,8 @@ e_testStatus checkSetGetPosMom(bool writeHisto = false) {
   rep = new genfit::RKTrackRep(pdg);
 
   //TVector3 pos(0,0,0);
-  TVector3 pos(gRandom->Gaus(0,0.1),gRandom->Gaus(0,0.1),gRandom->Gaus(0,0.1));
-  TVector3 mom(0,0.5,gRandom->Gaus(0,0.3));
+  TVector3 pos(gRandom->Gaus(0, 0.1), gRandom->Gaus(0, 0.1), gRandom->Gaus(0, 0.1));
+  TVector3 mom(0, 0.5, gRandom->Gaus(0, 0.3));
   mom.SetMag(0.5);
   mom *= randomSign();
 
@@ -211,7 +218,7 @@ e_testStatus checkSetGetPosMom(bool writeHisto = false) {
     pos += gRandom->Gaus() * v;
 
     // new random momentum
-    mom.SetXYZ(0,0.5,gRandom->Gaus(0,0.3));
+    mom.SetXYZ(0, 0.5, gRandom->Gaus(0, 0.3));
     mom.SetMag(0.5);
     mom *= randomSign();
 
@@ -219,9 +226,9 @@ e_testStatus checkSetGetPosMom(bool writeHisto = false) {
 
     // check if plane has changed
     if (state.getPlane() != plane) {
-        if (verbose) {
-          std::cout << "plane has changed unexpectedly! \n";
-        }
+      if (verbose) {
+        std::cout << "plane has changed unexpectedly! \n";
+      }
       delete rep;
       return kFailed;
     }
@@ -249,14 +256,15 @@ e_testStatus checkSetGetPosMom(bool writeHisto = false) {
 }
 
 
-e_testStatus compareForthBackExtrapolation(bool writeHisto = false) {
+e_testStatus compareForthBackExtrapolation(bool writeHisto = false)
+{
   static std::map<int, std::vector<TH2D*> > histoMap;
 
   static const int nPDGs(5);
-  int pdgs[nPDGs]={0, 211,13,11,2212};
+  int pdgs[nPDGs] = {0, 211, 13, 11, 2212};
   static bool fill(true);
   if (fill) {
-    for (int i = 0; i<nPDGs; ++i) {
+    for (int i = 0; i < nPDGs; ++i) {
       int pdg = pdgs[i];
 
       std::string Result;//string which will contain the result
@@ -264,9 +272,12 @@ e_testStatus compareForthBackExtrapolation(bool writeHisto = false) {
       convert << pdg;//add the value of Number to the characters in the stream
       Result = convert.str();//set Result to the content of the stream
 
-      histoMap[pdg].push_back(new TH2D((std::string("deviationRel_")+Result).c_str(), "log(betaGamma) vs relative deviation", 100000, -1.e-2, 1.e-2, 50, -4, 8));
-      histoMap[pdg].push_back(new TH2D((std::string("deviationAbs_")+Result).c_str(), "log(betaGamma) vs absolute deviation; deviation (keV)", 100000, -90.0, 10.0, 50, -4, 8));
-      histoMap[pdg].push_back(new TH2D((std::string("ExtrapLen_")+Result).c_str(), "delta ExtrapLen vs relative deviation", 50000, -5.e-2, 5.e-2, 400, -0.1, 0.1));
+      histoMap[pdg].push_back(new TH2D((std::string("deviationRel_") + Result).c_str(), "log(betaGamma) vs relative deviation", 100000,
+                                       -1.e-2, 1.e-2, 50, -4, 8));
+      histoMap[pdg].push_back(new TH2D((std::string("deviationAbs_") + Result).c_str(),
+                                       "log(betaGamma) vs absolute deviation; deviation (keV)", 100000, -90.0, 10.0, 50, -4, 8));
+      histoMap[pdg].push_back(new TH2D((std::string("ExtrapLen_") + Result).c_str(), "delta ExtrapLen vs relative deviation", 50000,
+                                       -5.e-2, 5.e-2, 400, -0.1, 0.1));
     }
     fill = false;
   }
@@ -276,7 +287,7 @@ e_testStatus compareForthBackExtrapolation(bool writeHisto = false) {
     TFile outfile("deviation.root", "recreate");
     outfile.cd();
 
-    for (int i = 0; i<nPDGs; ++i) {
+    for (int i = 0; i < nPDGs; ++i) {
       int pdg = pdgs[i];
       histoMap[pdg][0]->Write();
       histoMap[pdg][1]->Write();
@@ -306,13 +317,13 @@ e_testStatus compareForthBackExtrapolation(bool writeHisto = false) {
   double mass = part->Mass(); // GeV
 
   //TVector3 pos(0,0,0);
-  TVector3 pos(gRandom->Gaus(0,0.1),gRandom->Gaus(0,0.1),gRandom->Gaus(0,0.1));
-  TVector3 mom(0,0.5,gRandom->Gaus(0,0.3));
-  mom.SetMag( exp(gRandom->Uniform(-4, 8)) * mass );
+  TVector3 pos(gRandom->Gaus(0, 0.1), gRandom->Gaus(0, 0.1), gRandom->Gaus(0, 0.1));
+  TVector3 mom(0, 0.5, gRandom->Gaus(0, 0.3));
+  mom.SetMag(exp(gRandom->Uniform(-4, 8)) * mass);
   mom *= randomSign();
 
 
-  double betaGamma = log(mom.Mag()/mass);
+  double betaGamma = log(mom.Mag() / mass);
 
   //mom.Print();
 
@@ -320,7 +331,7 @@ e_testStatus compareForthBackExtrapolation(bool writeHisto = false) {
   rep->setPosMom(state, pos, mom);
 
   genfit::SharedPlanePtr origPlane = state.getPlane();
-  genfit::SharedPlanePtr plane(new genfit::DetPlane(TVector3(0,randomSign()*10,0), TVector3(0,randomSign()*1,0)));
+  genfit::SharedPlanePtr plane(new genfit::DetPlane(TVector3(0, randomSign() * 10, 0), TVector3(0, randomSign() * 1, 0)));
 
   genfit::StateOnPlane origState(state);
 
@@ -333,12 +344,11 @@ e_testStatus compareForthBackExtrapolation(bool writeHisto = false) {
     extrapLen = rep->extrapolateToPlane(state, plane);
 
     mom2 = state.getMom();
-    momLoss1 = mom.Mag()-mom2.Mag();
+    momLoss1 = mom.Mag() - mom2.Mag();
 
     //mom2.Print();
     //std::cout << "MomLoss = " << momLoss1 << "\n";
-  }
-  catch (genfit::Exception& e) {
+  } catch (genfit::Exception& e) {
     if (verbose) {
       std::cerr << "Exception in forth Extrapolation. PDG = " << pdg << "; mom: \n";
       mom.Print();
@@ -356,23 +366,22 @@ e_testStatus compareForthBackExtrapolation(bool writeHisto = false) {
   try {
     backExtrapLen = rep->extrapolateToPlane(state, origPlane);
 
-    momLoss2 = mom2.Mag()-state.getMom().Mag();
+    momLoss2 = mom2.Mag() - state.getMom().Mag();
 
     //state.getMom().Print();
     //std::cout << "MomLoss = " << momLoss2 << "\n";
 
-    double deviation = 1. + momLoss1/momLoss2;
+    double deviation = 1. + momLoss1 / momLoss2;
     histoMap[abs(pdg)][0]->Fill(deviation, betaGamma);
-    histoMap[abs(pdg)][1]->Fill((mom.Mag() - state.getMom().Mag())*1e6, betaGamma);
-    histoMap[abs(pdg)][2]->Fill(deviation, extrapLen+backExtrapLen);
+    histoMap[abs(pdg)][1]->Fill((mom.Mag() - state.getMom().Mag()) * 1e6, betaGamma);
+    histoMap[abs(pdg)][2]->Fill(deviation, extrapLen + backExtrapLen);
 
     histoMap[0][0]->Fill(deviation, betaGamma);
-    histoMap[0][1]->Fill((mom.Mag() - state.getMom().Mag())*1e6, betaGamma);
-    histoMap[0][2]->Fill(deviation, extrapLen+backExtrapLen);
+    histoMap[0][1]->Fill((mom.Mag() - state.getMom().Mag()) * 1e6, betaGamma);
+    histoMap[0][2]->Fill(deviation, extrapLen + backExtrapLen);
 
     //std::cout << "deviation = " << deviation << "\n";
-  }
-  catch (genfit::Exception& e) {
+  } catch (genfit::Exception& e) {
     if (verbose) {
       std::cerr << "Exception in back Extrapolation. PDG = " << pdg << "; mom:  \n";
       mom.Print();
@@ -391,14 +400,14 @@ e_testStatus compareForthBackExtrapolation(bool writeHisto = false) {
       fabs(extrapLen + backExtrapLen) > epsilonLen) {
 
     if (verbose) {
-        origState.Print();
-        state.Print();
+      origState.Print();
+      state.Print();
 
-        std::cout << "pos difference = " << (rep->getPos(origState) - rep->getPos(state)).Mag() << "\n";
-        std::cout << "mom difference = " << (rep->getMom(origState) - rep->getMom(state)).Mag() << "\n";
-        std::cout << "len difference = " << extrapLen + backExtrapLen << "\n";
+      std::cout << "pos difference = " << (rep->getPos(origState) - rep->getPos(state)).Mag() << "\n";
+      std::cout << "mom difference = " << (rep->getMom(origState) - rep->getMom(state)).Mag() << "\n";
+      std::cout << "len difference = " << extrapLen + backExtrapLen << "\n";
 
-        std::cout << std::endl;
+      std::cout << std::endl;
     }
     delete rep;
     return kFailed;
@@ -410,14 +419,15 @@ e_testStatus compareForthBackExtrapolation(bool writeHisto = false) {
 }
 
 
-e_testStatus compareForthBackJacNoise(bool writeHisto = false) {
+e_testStatus compareForthBackJacNoise(bool writeHisto = false)
+{
 
   if (writeHisto)
     return kPassed;
 
   e_testStatus retVal(kPassed);
 
-  bool fx( randomSign() > 0);
+  bool fx(randomSign() > 0);
   genfit::MaterialEffects::getInstance()->setNoEffects(!fx);
 
   double deltaJac = 0.005; // relative
@@ -436,10 +446,10 @@ e_testStatus compareForthBackJacNoise(bool writeHisto = false) {
 
   //TVector3 pos(0,0,0);
   //TVector3 mom(0,1,2);
-  TVector3 pos(gRandom->Gaus(0,0.1),gRandom->Gaus(0,0.1),gRandom->Gaus(0,0.1));
+  TVector3 pos(gRandom->Gaus(0, 0.1), gRandom->Gaus(0, 0.1), gRandom->Gaus(0, 0.1));
   TVector3 mom(0, 0.5, gRandom->Gaus(0, 1));
   mom *= randomSign();
-  mom.SetMag(gRandom->Uniform(2)+0.3);
+  mom.SetMag(gRandom->Uniform(2) + 0.3);
   //mom.SetMag(3);
 
   TMatrixD jac_f, jac_fi, jac_b, jac_bi;
@@ -455,9 +465,9 @@ e_testStatus compareForthBackJacNoise(bool writeHisto = false) {
   TVector3 normal(mom);
   normal.SetMag(1);
   normal.SetXYZ(gRandom->Gaus(normal.X(), smear),
-      gRandom->Gaus(normal.Y(), smear),
-      gRandom->Gaus(normal.Z(), smear));
-  genfit::DetPlane* origPlanePtr = new genfit::DetPlane (pos, normal);
+                gRandom->Gaus(normal.Y(), smear),
+                gRandom->Gaus(normal.Z(), smear));
+  genfit::DetPlane* origPlanePtr = new genfit::DetPlane(pos, normal);
   //genfit::DetPlane* origPlanePtr = new genfit::DetPlane (pos, TVector3(1,0,0), TVector3(0,0,1));
   double rotAngleOrig = gRandom->Uniform(2.*TMath::Pi());
   origPlanePtr->rotate(rotAngleOrig);
@@ -472,21 +482,21 @@ e_testStatus compareForthBackJacNoise(bool writeHisto = false) {
   normal = mom;
   normal.SetMag(1);
   normal.SetXYZ(gRandom->Gaus(normal.X(), smear),
-      gRandom->Gaus(normal.Y(), smear),
-      gRandom->Gaus(normal.Z(), smear));
+                gRandom->Gaus(normal.Y(), smear),
+                gRandom->Gaus(normal.Z(), smear));
   TVector3 dest(mom);
   dest.SetMag(10);
-  genfit::DetPlane* planePtr = new genfit::DetPlane (dest, normal);
+  genfit::DetPlane* planePtr = new genfit::DetPlane(dest, normal);
   //genfit::DetPlane* planePtr = new genfit::DetPlane (dest, TVector3(1,0,0), TVector3(0,0,1));
   double rotAngle = gRandom->Uniform(2.*TMath::Pi());
   planePtr->rotate(rotAngle);
   genfit::SharedPlanePtr plane(planePtr);
 
- /* genfit::DetPlane* planePtr = new genfit::DetPlane (*origPlane);
-  planePtr->setO(TVector3(0,randomSign()*10,0));
-  //planePtr->rotate(rotAngle);
-  genfit::SharedPlanePtr plane(planePtr);
-*/
+  /* genfit::DetPlane* planePtr = new genfit::DetPlane (*origPlane);
+   planePtr->setO(TVector3(0,randomSign()*10,0));
+   //planePtr->rotate(rotAngle);
+   genfit::SharedPlanePtr plane(planePtr);
+  */
 
   // numerical calculation
   TMatrixD jac_f_num;
@@ -502,8 +512,7 @@ e_testStatus compareForthBackJacNoise(bool writeHisto = false) {
     extrapolatedState = state;
     rep->getForwardJacobianAndNoise(jac_f, noise_f, c_f);
     rep->getBackwardJacobianAndNoise(jac_fi, noise_fi, c_fi);
-  }
-  catch (genfit::Exception& e) {
+  } catch (genfit::Exception& e) {
     std::cerr << e.what();
 
     delete rep;
@@ -518,8 +527,7 @@ e_testStatus compareForthBackJacNoise(bool writeHisto = false) {
     //std::cout << "GET INFO FOR BACK EXTRAPOLATION \n";
     rep->getForwardJacobianAndNoise(jac_b, noise_b, c_b);
     rep->getBackwardJacobianAndNoise(jac_bi, noise_bi, c_bi);
-  }
-  catch (genfit::Exception& e) {
+  } catch (genfit::Exception& e) {
     std::cerr << e.what();
 
     delete rep;
@@ -529,7 +537,7 @@ e_testStatus compareForthBackJacNoise(bool writeHisto = false) {
 
 
   // compare
-  if (!((origState.getState() - state.getState()).Abs()  < deltaState) ) {
+  if (!((origState.getState() - state.getState()).Abs()  < deltaState)) {
     if (verbose) {
       std::cout << "(origState.getState() - state.getState()) ";
       (origState.getState() - state.getState()).Print();
@@ -542,7 +550,7 @@ e_testStatus compareForthBackJacNoise(bool writeHisto = false) {
   if (!((jac_f * origState.getState() + c_f  -  extrapolatedState.getState()).Abs() < deltaState) ||
       !((jac_bi * origState.getState() + c_bi  -  extrapolatedState.getState()).Abs() < deltaState) ||
       !((jac_b * extrapolatedState.getState() + c_b  -  origState.getState()).Abs() < deltaState) ||
-      !((jac_fi * extrapolatedState.getState() + c_fi  -  origState.getState()).Abs() < deltaState)   ) {
+      !((jac_fi * extrapolatedState.getState() + c_fi  -  origState.getState()).Abs() < deltaState)) {
 
     if (verbose) {
       std::cout << "(jac_f * origState.getState() + c_f  -  extrapolatedState.getState()) ";
@@ -632,7 +640,8 @@ e_testStatus compareForthBackJacNoise(bool writeHisto = false) {
 }
 
 
-e_testStatus checkStopAtBoundary(bool writeHisto = false) {
+e_testStatus checkStopAtBoundary(bool writeHisto = false)
+{
 
   if (writeHisto)
     return kPassed;
@@ -647,8 +656,8 @@ e_testStatus checkStopAtBoundary(bool writeHisto = false) {
   rep = new genfit::RKTrackRep(pdg);
 
   //TVector3 pos(0,0,0);
-  TVector3 pos(gRandom->Gaus(0,0.1),gRandom->Gaus(0,0.1),gRandom->Gaus(0,0.1));
-  TVector3 mom(0,0.5,gRandom->Gaus(0,0.1));
+  TVector3 pos(gRandom->Gaus(0, 0.1), gRandom->Gaus(0, 0.1), gRandom->Gaus(0, 0.1));
+  TVector3 mom(0, 0.5, gRandom->Gaus(0, 0.1));
   mom *= randomSign();
 
 
@@ -656,15 +665,14 @@ e_testStatus checkStopAtBoundary(bool writeHisto = false) {
   rep->setPosMom(state, pos, mom);
 
   genfit::SharedPlanePtr origPlane = state.getPlane();
-  genfit::SharedPlanePtr plane(new genfit::DetPlane(TVector3(0,randomSign()*10,0), TVector3(0,randomSign()*1,0)));
+  genfit::SharedPlanePtr plane(new genfit::DetPlane(TVector3(0, randomSign() * 10, 0), TVector3(0, randomSign() * 1, 0)));
 
   genfit::StateOnPlane origState(state);
 
   // forth
   try {
     rep->extrapolateToPlane(state, plane, true);
-  }
-  catch (genfit::Exception& e) {
+  } catch (genfit::Exception& e) {
     std::cerr << e.what();
 
     delete rep;
@@ -674,25 +682,26 @@ e_testStatus checkStopAtBoundary(bool writeHisto = false) {
 
   // compare
   if (fabs(rep->getPos(state).Perp() - matRadius) > epsilonLen) {
-      if (verbose) {
-        origState.Print();
-        state.Print();
+    if (verbose) {
+      origState.Print();
+      state.Print();
 
-        std::cerr << "radius difference = " << rep->getPos(state).Perp() - matRadius << "\n";
+      std::cerr << "radius difference = " << rep->getPos(state).Perp() - matRadius << "\n";
 
-        std::cerr << std::endl;
-      }
-      delete rep;
-      return kFailed;
+      std::cerr << std::endl;
     }
-
     delete rep;
-    return kPassed;
+    return kFailed;
+  }
+
+  delete rep;
+  return kPassed;
 
 }
 
 
-e_testStatus checkErrorPropagation(bool writeHisto = false) {
+e_testStatus checkErrorPropagation(bool writeHisto = false)
+{
 
   if (writeHisto)
     return kPassed;
@@ -705,8 +714,8 @@ e_testStatus checkErrorPropagation(bool writeHisto = false) {
   rep = new genfit::RKTrackRep(pdg);
 
   //TVector3 pos(0,0,0);
-  TVector3 pos(gRandom->Gaus(0,0.1),gRandom->Gaus(0,0.1),gRandom->Gaus(0,0.1));
-  TVector3 mom(0,0.5,gRandom->Gaus(0,0.1));
+  TVector3 pos(gRandom->Gaus(0, 0.1), gRandom->Gaus(0, 0.1), gRandom->Gaus(0, 0.1));
+  TVector3 mom(0, 0.5, gRandom->Gaus(0, 0.1));
   mom *= randomSign();
 
 
@@ -714,15 +723,14 @@ e_testStatus checkErrorPropagation(bool writeHisto = false) {
   rep->setPosMom(state, pos, mom);
 
   genfit::SharedPlanePtr origPlane = state.getPlane();
-  genfit::SharedPlanePtr plane(new genfit::DetPlane(TVector3(0,randomSign()*50,0), TVector3(0,randomSign()*1,0)));
+  genfit::SharedPlanePtr plane(new genfit::DetPlane(TVector3(0, randomSign() * 50, 0), TVector3(0, randomSign() * 1, 0)));
 
   genfit::MeasuredStateOnPlane origState(state);
 
   // forth
   try {
     rep->extrapolateToPlane(state, plane);
-  }
-  catch (genfit::Exception& e) {
+  } catch (genfit::Exception& e) {
     std::cerr << e.what();
 
     delete rep;
@@ -746,7 +754,8 @@ e_testStatus checkErrorPropagation(bool writeHisto = false) {
 }
 
 
-e_testStatus checkExtrapolateToLine(bool writeHisto = false) {
+e_testStatus checkExtrapolateToLine(bool writeHisto = false)
+{
 
   if (writeHisto)
     return kPassed;
@@ -759,8 +768,8 @@ e_testStatus checkExtrapolateToLine(bool writeHisto = false) {
   rep = new genfit::RKTrackRep(pdg);
 
   //TVector3 pos(0,0,0);
-  TVector3 pos(0+gRandom->Gaus(0,0.1),0+gRandom->Gaus(0,0.1),0+gRandom->Gaus(0,0.1));
-  TVector3 mom(0,0.5,0.);
+  TVector3 pos(0 + gRandom->Gaus(0, 0.1), 0 + gRandom->Gaus(0, 0.1), 0 + gRandom->Gaus(0, 0.1));
+  TVector3 mom(0, 0.5, 0.);
   mom *= randomSign();
 
 
@@ -770,14 +779,13 @@ e_testStatus checkExtrapolateToLine(bool writeHisto = false) {
   genfit::SharedPlanePtr origPlane = state.getPlane();
   genfit::StateOnPlane origState(state);
 
-  TVector3 linePoint(gRandom->Gaus(),randomSign()*10+gRandom->Gaus(),gRandom->Gaus());
-  TVector3 lineDirection(gRandom->Gaus(),gRandom->Gaus(),randomSign()*10+gRandom->Gaus());
+  TVector3 linePoint(gRandom->Gaus(), randomSign() * 10 + gRandom->Gaus(), gRandom->Gaus());
+  TVector3 lineDirection(gRandom->Gaus(), gRandom->Gaus(), randomSign() * 10 + gRandom->Gaus());
 
   // forth
   try {
     rep->extrapolateToLine(state, linePoint, lineDirection, false);
-  }
-  catch (genfit::Exception& e) {
+  } catch (genfit::Exception& e) {
     std::cerr << e.what();
 
     delete rep;
@@ -787,29 +795,30 @@ e_testStatus checkExtrapolateToLine(bool writeHisto = false) {
 
   // compare
   if (fabs(state.getPlane()->distance(linePoint)) > epsilonLen ||
-      fabs(state.getPlane()->distance(linePoint+lineDirection)) > epsilonLen ||
+      fabs(state.getPlane()->distance(linePoint + lineDirection)) > epsilonLen ||
       (rep->getMom(state).Unit() * state.getPlane()->getNormal()) > epsilonMom) {
 
-      if (verbose) {
-        origState.Print();
-        state.Print();
+    if (verbose) {
+      origState.Print();
+      state.Print();
 
-        std::cout << "distance of linePoint to plane = " << state.getPlane()->distance(linePoint) << "\n";
-        std::cout << "distance of linePoint+lineDirection to plane = "
-                  << state.getPlane()->distance(linePoint + lineDirection) << "\n";
-        std::cout << "direction * plane normal = " << rep->getMom(state).Unit() * state.getPlane()->getNormal() << "\n";
-      }
-      delete rep;
-      return kFailed;
+      std::cout << "distance of linePoint to plane = " << state.getPlane()->distance(linePoint) << "\n";
+      std::cout << "distance of linePoint+lineDirection to plane = "
+                << state.getPlane()->distance(linePoint + lineDirection) << "\n";
+      std::cout << "direction * plane normal = " << rep->getMom(state).Unit() * state.getPlane()->getNormal() << "\n";
     }
-
     delete rep;
-    return kPassed;
+    return kFailed;
+  }
+
+  delete rep;
+  return kPassed;
 
 }
 
 
-e_testStatus checkExtrapolateToPoint(bool writeHisto = false) {
+e_testStatus checkExtrapolateToPoint(bool writeHisto = false)
+{
 
   if (writeHisto)
     return kPassed;
@@ -822,8 +831,8 @@ e_testStatus checkExtrapolateToPoint(bool writeHisto = false) {
   rep = new genfit::RKTrackRep(pdg);
 
   //TVector3 pos(0,0,0);
-  TVector3 pos(gRandom->Gaus(0,0.1),gRandom->Gaus(0,0.1),gRandom->Gaus(0,0.1));
-  TVector3 mom(0,0.5,gRandom->Gaus(0,0.1));
+  TVector3 pos(gRandom->Gaus(0, 0.1), gRandom->Gaus(0, 0.1), gRandom->Gaus(0, 0.1));
+  TVector3 mom(0, 0.5, gRandom->Gaus(0, 0.1));
   mom *= randomSign();
 
 
@@ -833,13 +842,12 @@ e_testStatus checkExtrapolateToPoint(bool writeHisto = false) {
   genfit::SharedPlanePtr origPlane = state.getPlane();
   genfit::StateOnPlane origState(state);
 
-  TVector3 point(gRandom->Gaus(),randomSign()*10+gRandom->Gaus(),gRandom->Gaus());
+  TVector3 point(gRandom->Gaus(), randomSign() * 10 + gRandom->Gaus(), gRandom->Gaus());
 
   // forth
   try {
     rep->extrapolateToPoint(state, point, false);
-  }
-  catch (genfit::Exception& e) {
+  } catch (genfit::Exception& e) {
     std::cerr << e.what();
 
     delete rep;
@@ -850,24 +858,25 @@ e_testStatus checkExtrapolateToPoint(bool writeHisto = false) {
   // compare
   if (fabs(state.getPlane()->distance(point)) > epsilonLen ||
       fabs((rep->getMom(state).Unit() * state.getPlane()->getNormal())) - 1 > epsilonMom) {
-      if (verbose) {
-        origState.Print();
-        state.Print();
+    if (verbose) {
+      origState.Print();
+      state.Print();
 
-        std::cout << "distance of point to plane = " << state.getPlane()->distance(point) << "\n";
-        std::cout << "direction * plane normal = " << rep->getMom(state).Unit() * state.getPlane()->getNormal() << "\n";
-      }
-      delete rep;
-      return kFailed;
+      std::cout << "distance of point to plane = " << state.getPlane()->distance(point) << "\n";
+      std::cout << "direction * plane normal = " << rep->getMom(state).Unit() * state.getPlane()->getNormal() << "\n";
     }
-
     delete rep;
-    return kPassed;
+    return kFailed;
+  }
+
+  delete rep;
+  return kPassed;
 
 }
 
 
-e_testStatus checkExtrapolateToCylinder(bool writeHisto = false) {
+e_testStatus checkExtrapolateToCylinder(bool writeHisto = false)
+{
 
   if (writeHisto)
     return kPassed;
@@ -880,8 +889,8 @@ e_testStatus checkExtrapolateToCylinder(bool writeHisto = false) {
   rep = new genfit::RKTrackRep(pdg);
 
   //TVector3 pos(0,0,0);
-  TVector3 pos(0+gRandom->Gaus(0,0.1),0+gRandom->Gaus(0,0.1),0+gRandom->Gaus(0,0.1));
-  TVector3 mom(0,0.5,0.);
+  TVector3 pos(0 + gRandom->Gaus(0, 0.1), 0 + gRandom->Gaus(0, 0.1), 0 + gRandom->Gaus(0, 0.1));
+  TVector3 mom(0, 0.5, 0.);
   mom *= randomSign();
 
 
@@ -891,15 +900,14 @@ e_testStatus checkExtrapolateToCylinder(bool writeHisto = false) {
   genfit::SharedPlanePtr origPlane = state.getPlane();
   genfit::StateOnPlane origState(state);
 
-  const TVector3 linePoint(gRandom->Gaus(0,5), gRandom->Gaus(0,5), gRandom->Gaus(0,5));
-  const TVector3 lineDirection(gRandom->Gaus(),gRandom->Gaus(),2+gRandom->Gaus());
+  const TVector3 linePoint(gRandom->Gaus(0, 5), gRandom->Gaus(0, 5), gRandom->Gaus(0, 5));
+  const TVector3 lineDirection(gRandom->Gaus(), gRandom->Gaus(), 2 + gRandom->Gaus());
   const double radius = gRandom->Uniform(10);
 
   // forth
   try {
     rep->extrapolateToCylinder(state, radius, linePoint, lineDirection, false);
-  }
-  catch (genfit::Exception& e) {
+  } catch (genfit::Exception& e) {
     std::cerr << e.what();
 
     delete rep;
@@ -908,34 +916,35 @@ e_testStatus checkExtrapolateToCylinder(bool writeHisto = false) {
   }
 
   TVector3 pocaOnLine(lineDirection);
-  double t = 1./(pocaOnLine.Mag2()) * ((rep->getPos(state)*pocaOnLine) - (linePoint*pocaOnLine));
+  double t = 1. / (pocaOnLine.Mag2()) * ((rep->getPos(state) * pocaOnLine) - (linePoint * pocaOnLine));
   pocaOnLine *= t;
   pocaOnLine += linePoint;
 
   TVector3 radiusVec = rep->getPos(state) - pocaOnLine;
 
   // compare
-  if (fabs(state.getPlane()->getNormal()*radiusVec.Unit())-1 > epsilonLen ||
-      fabs(lineDirection*radiusVec) > epsilonLen ||
-      fabs(radiusVec.Mag()-radius) > epsilonLen) {
-      if (verbose) {
-        origState.Print();
-        state.Print();
+  if (fabs(state.getPlane()->getNormal()*radiusVec.Unit()) - 1 > epsilonLen ||
+      fabs(lineDirection * radiusVec) > epsilonLen ||
+      fabs(radiusVec.Mag() - radius) > epsilonLen) {
+    if (verbose) {
+      origState.Print();
+      state.Print();
 
-        std::cout << "lineDirection*radiusVec = " << lineDirection * radiusVec << "\n";
-        std::cout << "radiusVec.Mag()-radius = " << radiusVec.Mag() - radius << "\n";
-      }
-      delete rep;
-      return kFailed;
+      std::cout << "lineDirection*radiusVec = " << lineDirection* radiusVec << "\n";
+      std::cout << "radiusVec.Mag()-radius = " << radiusVec.Mag() - radius << "\n";
     }
-
     delete rep;
-    return kPassed;
+    return kFailed;
+  }
+
+  delete rep;
+  return kPassed;
 
 }
 
 
-e_testStatus checkExtrapolateToSphere(bool writeHisto = false) {
+e_testStatus checkExtrapolateToSphere(bool writeHisto = false)
+{
 
   if (writeHisto)
     return kPassed;
@@ -948,8 +957,8 @@ e_testStatus checkExtrapolateToSphere(bool writeHisto = false) {
   rep = new genfit::RKTrackRep(pdg);
 
   //TVector3 pos(0,0,0);
-  TVector3 pos(0+gRandom->Gaus(0,0.1),0+gRandom->Gaus(0,0.1),0+gRandom->Gaus(0,0.1));
-  TVector3 mom(0,0.5,0.);
+  TVector3 pos(0 + gRandom->Gaus(0, 0.1), 0 + gRandom->Gaus(0, 0.1), 0 + gRandom->Gaus(0, 0.1));
+  TVector3 mom(0, 0.5, 0.);
   mom *= randomSign();
 
 
@@ -959,14 +968,13 @@ e_testStatus checkExtrapolateToSphere(bool writeHisto = false) {
   genfit::SharedPlanePtr origPlane = state.getPlane();
   genfit::StateOnPlane origState(state);
 
-  const TVector3 centerPoint(gRandom->Gaus(0,10), gRandom->Gaus(0,10), gRandom->Gaus(0,10));
+  const TVector3 centerPoint(gRandom->Gaus(0, 10), gRandom->Gaus(0, 10), gRandom->Gaus(0, 10));
   const double radius = gRandom->Uniform(10);
 
   // forth
   try {
     rep->extrapolateToSphere(state, radius, centerPoint, false);
-  }
-  catch (genfit::Exception& e) {
+  } catch (genfit::Exception& e) {
     std::cerr << e.what();
 
     delete rep;
@@ -978,26 +986,27 @@ e_testStatus checkExtrapolateToSphere(bool writeHisto = false) {
   TVector3 radiusVec = rep->getPos(state) - centerPoint;
 
   // compare
-  if (fabs(state.getPlane()->getNormal()*radiusVec.Unit())-1 > epsilonLen ||
-      fabs(radiusVec.Mag()-radius) > epsilonLen) {
-      if (verbose) {
-        origState.Print();
-        state.Print();
+  if (fabs(state.getPlane()->getNormal()*radiusVec.Unit()) - 1 > epsilonLen ||
+      fabs(radiusVec.Mag() - radius) > epsilonLen) {
+    if (verbose) {
+      origState.Print();
+      state.Print();
 
-        std::cout << "state.getPlane()->getNormal()*radiusVec = " << state.getPlane()->getNormal() * radiusVec << "\n";
-        std::cout << "radiusVec.Mag()-radius = " << radiusVec.Mag() - radius << "\n";
-      }
-      delete rep;
-      return kFailed;
+      std::cout << "state.getPlane()->getNormal()*radiusVec = " << state.getPlane()->getNormal() * radiusVec << "\n";
+      std::cout << "radiusVec.Mag()-radius = " << radiusVec.Mag() - radius << "\n";
     }
-
     delete rep;
-    return kPassed;
+    return kFailed;
+  }
+
+  delete rep;
+  return kPassed;
 
 }
 
 
-e_testStatus checkExtrapolateBy(bool writeHisto = false) {
+e_testStatus checkExtrapolateBy(bool writeHisto = false)
+{
 
   if (writeHisto)
     return kPassed;
@@ -1009,8 +1018,8 @@ e_testStatus checkExtrapolateBy(bool writeHisto = false) {
   rep = new genfit::RKTrackRep(pdg);
 
   //TVector3 pos(0,0,0);
-  TVector3 pos(0+gRandom->Gaus(0,0.1),0+gRandom->Gaus(0,0.1),0+gRandom->Gaus(0,0.1));
-  TVector3 mom(0,0.5,0.);
+  TVector3 pos(0 + gRandom->Gaus(0, 0.1), 0 + gRandom->Gaus(0, 0.1), 0 + gRandom->Gaus(0, 0.1));
+  TVector3 mom(0, 0.5, 0.);
   mom *= randomSign();
 
 
@@ -1022,14 +1031,13 @@ e_testStatus checkExtrapolateBy(bool writeHisto = false) {
   genfit::SharedPlanePtr origPlane = state.getPlane();
   genfit::StateOnPlane origState(state);
 
-  double step = gRandom->Uniform(-15.,15.);
+  double step = gRandom->Uniform(-15., 15.);
   double extrapolatedLen(0);
 
   // forth
   try {
     extrapolatedLen = rep->extrapolateBy(state, step, false);
-  }
-  catch (genfit::Exception& e) {
+  } catch (genfit::Exception& e) {
     return kException;
   }
 
@@ -1039,26 +1047,26 @@ e_testStatus checkExtrapolateBy(bool writeHisto = false) {
 
 
   // compare
-  if (fabs(extrapolatedLen-step) > epsilonLen ||
+  if (fabs(extrapolatedLen - step) > epsilonLen ||
       (posOrig - posExt).Mag() > fabs(step)) {
-      if (verbose) {
-        origState.Print();
-        state.Print();
+    if (verbose) {
+      origState.Print();
+      state.Print();
 
-        std::cout << "extrapolatedLen-step = " << extrapolatedLen - step << "\n";
-        std::cout << "started extrapolation from: ";
-        posOrig.Print();
-        std::cout << "extrapolated to ";
-        posExt.Print();
-        std::cout << "difference = " << (posOrig - posExt).Mag() << "; step = " << step << "; delta = "
-                  << (posOrig - posExt).Mag() - fabs(step) << "\n";
-      }
-      delete rep;
-      return kFailed;
+      std::cout << "extrapolatedLen-step = " << extrapolatedLen - step << "\n";
+      std::cout << "started extrapolation from: ";
+      posOrig.Print();
+      std::cout << "extrapolated to ";
+      posExt.Print();
+      std::cout << "difference = " << (posOrig - posExt).Mag() << "; step = " << step << "; delta = "
+                << (posOrig - posExt).Mag() - fabs(step) << "\n";
     }
-
     delete rep;
-    return kPassed;
+    return kFailed;
+  }
+
+  delete rep;
+  return kPassed;
 
 }
 //=====================================================================================================================
@@ -1067,7 +1075,8 @@ e_testStatus checkExtrapolateBy(bool writeHisto = false) {
 //=====================================================================================================================
 
 struct TestCase {
-  TestCase(const std::string &name, e_testStatus(*function)(bool)) : name_(name), function_(function), nPassed_(0), nFailed_(0), nException_(0) {;}
+  TestCase(const std::string& name, e_testStatus(*function)(bool)) : name_(name), function_(function), nPassed_(0), nFailed_(0),
+    nException_(0) {;}
   void Print() {std::cout << name_ << " \t" << nPassed_ << " \t" << nFailed_ << " \t" << nException_ << "\n";}
 
   std::string name_;
@@ -1078,7 +1087,8 @@ struct TestCase {
 };
 
 
-int main() {
+int main()
+{
 
   const double BField = 15.;       // kGauss
   //const bool debug = true;
@@ -1089,7 +1099,7 @@ int main() {
   // init geometry and mag. field
   new TGeoManager("Geometry", "Geane geometry");
   TGeoManager::Import("genfitGeom.root");
-  genfit::FieldManager::getInstance()->init(new genfit::ConstField(0.,0.,BField));
+  genfit::FieldManager::getInstance()->init(new genfit::ConstField(0., 0., BField));
   genfit::MaterialEffects::getInstance()->init(new genfit::TGeoMaterialInterface());
 
   /*genfit::MaterialEffects::getInstance()->drawdEdx(2212);
@@ -1115,21 +1125,21 @@ int main() {
   testCases.push_back(TestCase(std::string("compareForthBackJacNoise()     "), &compareForthBackJacNoise));
 
 
-  for (unsigned int i=0; i<nTests; ++i) {
+  for (unsigned int i = 0; i < nTests; ++i) {
 
-    for (unsigned int j=0; j<testCases.size(); ++j) {
+    for (unsigned int j = 0; j < testCases.size(); ++j) {
       e_testStatus status = testCases[j].function_(false);
       switch (status) {
-      case kPassed:
-        testCases[j].nPassed_++;
-        break;
-      case kFailed:
-        testCases[j].nFailed_++;
-        std::cout << "failed " << testCases[j].name_ << " nr " << i << "\n";
-        break;
-      case kException:
-        testCases[j].nException_++;
-        std::cout << "exception at " << testCases[j].name_ << " nr " << i << "\n";
+        case kPassed:
+          testCases[j].nPassed_++;
+          break;
+        case kFailed:
+          testCases[j].nFailed_++;
+          std::cout << "failed " << testCases[j].name_ << " nr " << i << "\n";
+          break;
+        case kException:
+          testCases[j].nException_++;
+          std::cout << "exception at " << testCases[j].name_ << " nr " << i << "\n";
       }
     }
 
@@ -1137,11 +1147,11 @@ int main() {
 
   //CALLGRIND_STOP_INSTRUMENTATION;
   std::cout << "name                           " << " \t" << "pass" << " \t" << "fail" << " \t" << "exception" << "\n";
-  for (unsigned int j=0; j<testCases.size(); ++j) {
+  for (unsigned int j = 0; j < testCases.size(); ++j) {
     testCases[j].Print();
   }
 
-  for (unsigned int j=0; j<testCases.size(); ++j) {
+  for (unsigned int j = 0; j < testCases.size(); ++j) {
     testCases[j].function_(true);
   }
 

--- a/test/vertexingTest/main.cc
+++ b/test/vertexingTest/main.cc
@@ -34,7 +34,8 @@
 
 
 
-int main() {
+int main()
+{
 
   gRandom->SetSeed(14);
 
@@ -45,7 +46,7 @@ int main() {
   // init geometry and mag. field
   new TGeoManager("Geometry", "Geane geometry");
   TGeoManager::Import("genfitGeom.root");
-  genfit::FieldManager::getInstance()->init(new genfit::ConstField(0.,0., 15.)); // 15 kGauss
+  genfit::FieldManager::getInstance()->init(new genfit::ConstField(0., 0., 15.)); // 15 kGauss
   genfit::MaterialEffects::getInstance()->init(new genfit::TGeoMaterialInterface());
 
 
@@ -76,7 +77,7 @@ int main() {
   std::vector<genfit::GFRaveVertex*> vertices;
 
   // main loop
-  for (unsigned int iEvent=0; iEvent<10; ++iEvent){
+  for (unsigned int iEvent = 0; iEvent < 10; ++iEvent) {
 
     // clean up
     trackArray.Delete();
@@ -87,19 +88,19 @@ int main() {
 
     unsigned int nTracks = gRandom->Uniform(2, 10);
 
-    for (unsigned int iTrack=0; iTrack<nTracks; ++iTrack){
+    for (unsigned int iTrack = 0; iTrack < nTracks; ++iTrack) {
 
       // true start values
       TVector3 pos(0, 0, 0);
-      TVector3 mom(1.,0,0);
-      mom.SetPhi(gRandom->Uniform(0.,2*TMath::Pi()));
-      mom.SetTheta(gRandom->Uniform(0.4*TMath::Pi(),0.6*TMath::Pi()));
+      TVector3 mom(1., 0, 0);
+      mom.SetPhi(gRandom->Uniform(0., 2 * TMath::Pi()));
+      mom.SetTheta(gRandom->Uniform(0.4 * TMath::Pi(), 0.6 * TMath::Pi()));
       mom.SetMag(gRandom->Uniform(0.2, 1.));
 
 
       // helix track model
       const int pdg = 13;               // particle pdg code
-      const double charge = TDatabasePDG::Instance()->GetParticle(pdg)->Charge()/(3.);
+      const double charge = TDatabasePDG::Instance()->GetParticle(pdg)->Charge() / (3.);
       genfit::HelixTrackModel* helix = new genfit::HelixTrackModel(pos, mom, charge);
       measurementCreator.setTrackModel(helix);
 
@@ -110,27 +111,27 @@ int main() {
       // smeared start values
       const bool smearPosMom = true;     // init the Reps with smeared pos and mom
       const double posSmear = 0.1;     // cm
-      const double momSmear = 3. /180.*TMath::Pi();     // rad
+      const double momSmear = 3. / 180.*TMath::Pi();    // rad
       const double momMagSmear = 0.1;   // relative
 
       TVector3 posM(pos);
       TVector3 momM(mom);
       if (smearPosMom) {
-        posM.SetX(gRandom->Gaus(posM.X(),posSmear));
-        posM.SetY(gRandom->Gaus(posM.Y(),posSmear));
-        posM.SetZ(gRandom->Gaus(posM.Z(),posSmear));
+        posM.SetX(gRandom->Gaus(posM.X(), posSmear));
+        posM.SetY(gRandom->Gaus(posM.Y(), posSmear));
+        posM.SetZ(gRandom->Gaus(posM.Z(), posSmear));
 
-        momM.SetPhi(gRandom->Gaus(mom.Phi(),momSmear));
-        momM.SetTheta(gRandom->Gaus(mom.Theta(),momSmear));
-        momM.SetMag(gRandom->Gaus(mom.Mag(), momMagSmear*mom.Mag()));
+        momM.SetPhi(gRandom->Gaus(mom.Phi(), momSmear));
+        momM.SetTheta(gRandom->Gaus(mom.Theta(), momSmear));
+        momM.SetMag(gRandom->Gaus(mom.Mag(), momMagSmear * mom.Mag()));
       }
       // approximate covariance
       TMatrixDSym covM(6);
       double resolution = 0.01;
       for (int i = 0; i < 3; ++i)
-        covM(i,i) = resolution*resolution;
+        covM(i, i) = resolution * resolution;
       for (int i = 3; i < 6; ++i)
-        covM(i,i) = pow(resolution / nMeasurements / sqrt(3), 2);
+        covM(i, i) = pow(resolution / nMeasurements / sqrt(3), 2);
 
 
       // trackrep
@@ -146,7 +147,7 @@ int main() {
       TMatrixDSym seedCov(6);
       rep->get6DStateCov(stateSmeared, seedState, seedCov);
 
-      new(trackArray[iTrack]) genfit::Track(rep, seedState, seedCov);
+      new (trackArray[iTrack]) genfit::Track(rep, seedState, seedCov);
       genfit::Track* trackPtr(static_cast<genfit::Track*>(trackArray.At(iTrack)));
       tracks.push_back(trackPtr);
 
@@ -157,14 +158,13 @@ int main() {
 
 
       // create smeared measurements and add to track
-      try{
-        for (unsigned int i=1; i<measurementTypes.size(); ++i){
-          std::vector<genfit::AbsMeasurement*> measurements = measurementCreator.create(measurementTypes[i], i*5.);
+      try {
+        for (unsigned int i = 1; i < measurementTypes.size(); ++i) {
+          std::vector<genfit::AbsMeasurement*> measurements = measurementCreator.create(measurementTypes[i], i * 5.);
           trackPtr->insertPoint(new genfit::TrackPoint(measurements, trackPtr));
         }
-      }
-      catch(genfit::Exception& e){
-        std::cerr<<"Exception, next track"<<std::endl;
+      } catch (genfit::Exception& e) {
+        std::cerr << "Exception, next track" << std::endl;
         std::cerr << e.what();
         continue; // here is a memleak!
       }
@@ -173,10 +173,9 @@ int main() {
       assert(trackPtr->checkConsistency());
 
       // do the fit
-      try{
+      try {
         fitter->processTrack(trackPtr);
-      }
-      catch(genfit::Exception& e){
+      } catch (genfit::Exception& e) {
         std::cerr << e.what();
         std::cerr << "Exception, next track" << std::endl;
         continue;
@@ -192,17 +191,17 @@ int main() {
     // vertexing
     vertexFactory.findVertices(&vertices, tracks);
 
-    for (unsigned int i=0; i<vertices.size(); ++i) {
-      new(vertexArray[i]) genfit::GFRaveVertex(*(vertices[i]));
+    for (unsigned int i = 0; i < vertices.size(); ++i) {
+      new (vertexArray[i]) genfit::GFRaveVertex(*(vertices[i]));
 
       genfit::GFRaveVertex* vtx = static_cast<genfit::GFRaveVertex*>(vertices[i]);
-      for (unsigned int j=0; j<vtx->getNTracks(); ++j) {
+      for (unsigned int j = 0; j < vtx->getNTracks(); ++j) {
         std::cout << "track parameters uniqueID: " << vtx->getParameters(j)->GetUniqueID() << "\n";
       }
     }
 
 
-    for (unsigned int i=0; i<tracks.size(); ++i) {
+    for (unsigned int i = 0; i < tracks.size(); ++i) {
       genfit::Track* trk = static_cast<genfit::Track*>(tracks[i]);
       std::cout << "track uniqueID: " << trk->GetUniqueID() << "\n";
     }

--- a/test/vertexingTest/read.cc
+++ b/test/vertexingTest/read.cc
@@ -16,7 +16,8 @@
 #include <iostream>
 
 
-int main() {
+int main()
+{
 
   genfit::Track tr; // pull in genfit libraries
 
@@ -49,7 +50,7 @@ int main() {
 
     for (Long_t j = 0; j < trackArray->GetEntriesFast(); ++j) {
       std::cout << "track uniqueID: " << static_cast<genfit::Track*>(trackArray->At(j))->GetUniqueID() <<
-          " (" << static_cast<genfit::Track*>(trackArray->At(j))->GetUniqueID() - 16777216 << ")\n";
+                " (" << static_cast<genfit::Track*>(trackArray->At(j))->GetUniqueID() - 16777216 << ")\n";
     }
 
     for (Long_t j = 0; j < vertexArray->GetEntriesFast(); ++j) {
@@ -57,17 +58,16 @@ int main() {
       aVertexPtr = (genfit::GFRaveVertex*)(vertexArray->At(j));
       //aVertexPtr->Print();
 
-      for (unsigned int k=0; k<aVertexPtr->getNTracks(); ++k) {
+      for (unsigned int k = 0; k < aVertexPtr->getNTracks(); ++k) {
         std::cout << "track parameters uniqueID: " << aVertexPtr->getParameters(k)->GetUniqueID() << "\n";
       }
 
       // when the track branch from the tracks.root file is loaded, the TRefs to the tracks
       // in the GFRaveTrackParameters are again pointing to them.
-      for (unsigned int k = 0; k<aVertexPtr->getNTracks(); ++k) {
+      for (unsigned int k = 0; k < aVertexPtr->getNTracks(); ++k) {
         if (aVertexPtr->getParameters(k)->hasTrack()) {
           std::cout << "track parameters have track \n";
-        }
-        else {
+        } else {
           std::cout << "track parameters have NO track <--------------------------------- \n";
         }
       }

--- a/trackReps/include/AbsMaterialInterface.h
+++ b/trackReps/include/AbsMaterialInterface.h
@@ -33,46 +33,46 @@
 
 namespace genfit {
 
-/**
- * @brief Abstract base class for geometry interfacing
- */
-class AbsMaterialInterface : public TObject {
-
- public:
-
-  AbsMaterialInterface() : debugLvl_(0) {;};
-  virtual ~AbsMaterialInterface(){;};
-
-  /** @brief Initialize the navigator at given position and with given direction.  Return true if volume changed.
+  /**
+   * @brief Abstract base class for geometry interfacing
    */
-  virtual bool initTrack(double posX, double posY, double posZ,
-                         double dirX, double dirY, double dirZ) = 0;
+  class AbsMaterialInterface : public TObject {
 
-  /***
-   * Get the material paramaters in the current material.
-   * @return
-   */
-  virtual Material getMaterialParameters() = 0;
+  public:
 
-  /** @brief Make a step until maxStep or the next boundary is reached.
-   *
-   * After making a step to a boundary, the position has to be beyond the boundary,
-   * i.e. in the current material has to be that beyond the boundary.
-   * The actual step made is returned.
-   */
-  virtual double findNextBoundary(const RKTrackRep* rep,
-                                  const M1x7& state7,
-                                  double sMax,
-                                  bool varField = true) = 0;
+    AbsMaterialInterface() : debugLvl_(0) {;};
+    virtual ~AbsMaterialInterface() {;};
 
-  virtual void setDebugLvl(unsigned int lvl = 1) {debugLvl_ = lvl;}
+    /** @brief Initialize the navigator at given position and with given direction.  Return true if volume changed.
+     */
+    virtual bool initTrack(double posX, double posY, double posZ,
+                           double dirX, double dirY, double dirZ) = 0;
 
- protected:
-  unsigned int debugLvl_;
+    /***
+     * Get the material paramaters in the current material.
+     * @return
+     */
+    virtual Material getMaterialParameters() = 0;
 
-  //ClassDef(AbsMaterialInterface, 1);
+    /** @brief Make a step until maxStep or the next boundary is reached.
+     *
+     * After making a step to a boundary, the position has to be beyond the boundary,
+     * i.e. in the current material has to be that beyond the boundary.
+     * The actual step made is returned.
+     */
+    virtual double findNextBoundary(const RKTrackRep* rep,
+                                    const M1x7& state7,
+                                    double sMax,
+                                    bool varField = true) = 0;
 
-};
+    virtual void setDebugLvl(unsigned int lvl = 1) {debugLvl_ = lvl;}
+
+  protected:
+    unsigned int debugLvl_;
+
+    //ClassDef(AbsMaterialInterface, 1);
+
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/trackReps/include/MaterialEffects.h
+++ b/trackReps/include/MaterialEffects.h
@@ -35,176 +35,176 @@
 
 namespace genfit {
 
-/** @brief Stepper and energy loss/noise matrix calculation
- *
- *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
- *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
- *  @author Johannes Rauch  (Technische Universit&auml;t M&uuml;nchen, author)
- *
- *  It provides functionality to limit the stepsize of an extrapolation in order not to
- *  exceed a specified maximum momentum loss. After propagation, the energy loss
- *  for the given length and (optionally) the noise matrix can be calculated.
- *  You have to set which energy-loss and noise mechanisms you want to use.
- *  At the moment, per default all energy loss and noise options are ON.
- */
-class MaterialEffects {
-
- private:
-
-  MaterialEffects();
-  virtual ~MaterialEffects();
-
-  static MaterialEffects* instance_;
-
-
-public:
-
-  static MaterialEffects* getInstance();
-  static void destruct();
-
-  //! set the material interface here. Material interface classes must be derived from AbsMaterialInterface.
-  void init(AbsMaterialInterface* matIfc);
-  bool isInitialized() { return materialInterface_ != nullptr; }
-
-  void setNoEffects(bool opt = true) {noEffects_ = opt;}
-
-  void setEnergyLossBetheBloch(bool opt = true) {energyLossBetheBloch_ = opt; noEffects_ = false;}
-  void setNoiseBetheBloch(bool opt = true) {noiseBetheBloch_ = opt; noEffects_ = false;}
-  void setNoiseCoulomb(bool opt = true) {noiseCoulomb_ = opt; noEffects_ = false;}
-  void setEnergyLossBrems(bool opt = true) {energyLossBrems_ = opt; noEffects_ = false;}
-  void setNoiseBrems(bool opt = true) {noiseBrems_ = opt; noEffects_ = false;}
-  void ignoreBoundariesBetweenEqualMaterials(bool opt = true) {ignoreBoundariesBetweenEqualMaterials_ = opt;}
-  void setMagCharge(double magCharge) {mag_charge_ = magCharge;} 
-
-  /** @brief Select the multiple scattering model that will be used during track fit.
+  /** @brief Stepper and energy loss/noise matrix calculation
    *
-   *  At the moment two model are available GEANE and Highland. GEANE is the model was was present in Genfit first.
-   *  Note that using this function has no effect if setNoiseCoulomb(false) is set.
+   *  @author Christian H&ouml;ppner (Technische Universit&auml;t M&uuml;nchen, original author)
+   *  @author Sebastian Neubert  (Technische Universit&auml;t M&uuml;nchen, original author)
+   *  @author Johannes Rauch  (Technische Universit&auml;t M&uuml;nchen, author)
+   *
+   *  It provides functionality to limit the stepsize of an extrapolation in order not to
+   *  exceed a specified maximum momentum loss. After propagation, the energy loss
+   *  for the given length and (optionally) the noise matrix can be calculated.
+   *  You have to set which energy-loss and noise mechanisms you want to use.
+   *  At the moment, per default all energy loss and noise options are ON.
    */
-  void setMscModel(const std::string& modelName);
+  class MaterialEffects {
+
+  private:
+
+    MaterialEffects();
+    virtual ~MaterialEffects();
+
+    static MaterialEffects* instance_;
 
 
-  //! Calculates energy loss in the traveled path, optional calculation of noise matrix
-  double effects(const std::vector<RKStep>& steps,
-                 int materialsFXStart,
-                 int materialsFXStop,
-                 const double& mom,
+  public:
+
+    static MaterialEffects* getInstance();
+    static void destruct();
+
+    //! set the material interface here. Material interface classes must be derived from AbsMaterialInterface.
+    void init(AbsMaterialInterface* matIfc);
+    bool isInitialized() { return materialInterface_ != nullptr; }
+
+    void setNoEffects(bool opt = true) {noEffects_ = opt;}
+
+    void setEnergyLossBetheBloch(bool opt = true) {energyLossBetheBloch_ = opt; noEffects_ = false;}
+    void setNoiseBetheBloch(bool opt = true) {noiseBetheBloch_ = opt; noEffects_ = false;}
+    void setNoiseCoulomb(bool opt = true) {noiseCoulomb_ = opt; noEffects_ = false;}
+    void setEnergyLossBrems(bool opt = true) {energyLossBrems_ = opt; noEffects_ = false;}
+    void setNoiseBrems(bool opt = true) {noiseBrems_ = opt; noEffects_ = false;}
+    void ignoreBoundariesBetweenEqualMaterials(bool opt = true) {ignoreBoundariesBetweenEqualMaterials_ = opt;}
+    void setMagCharge(double magCharge) {mag_charge_ = magCharge;}
+
+    /** @brief Select the multiple scattering model that will be used during track fit.
+     *
+     *  At the moment two model are available GEANE and Highland. GEANE is the model was was present in Genfit first.
+     *  Note that using this function has no effect if setNoiseCoulomb(false) is set.
+     */
+    void setMscModel(const std::string& modelName);
+
+
+    //! Calculates energy loss in the traveled path, optional calculation of noise matrix
+    double effects(const std::vector<RKStep>& steps,
+                   int materialsFXStart,
+                   int materialsFXStop,
+                   const double& mom,
+                   const int& pdg,
+                   M7x7* noise = nullptr);
+
+    /**  @brief Returns maximum length so that a specified momentum loss will not be exceeded.
+     *
+     * The stepper returns the maximum length that the particle may travel, so that a specified relative momentum loss will not be exceeded,
+     * or the next material boundary is reached. The material crossed are stored together with their stepsizes.
+    */
+    void stepper(const RKTrackRep* rep,
+                 M1x7& state7,
+                 const double& mom, // momentum
+                 double& relMomLoss, // relative momloss for the step will be added
                  const int& pdg,
-                 M7x7* noise = nullptr);
+                 Material& currentMaterial,
+                 StepLimits& limits,
+                 bool varField = true);
 
-  /**  @brief Returns maximum length so that a specified momentum loss will not be exceeded.
-   *
-   * The stepper returns the maximum length that the particle may travel, so that a specified relative momentum loss will not be exceeded,
-   * or the next material boundary is reached. The material crossed are stored together with their stepsizes.
-  */
-  void stepper(const RKTrackRep* rep,
-               M1x7& state7,
-               const double& mom, // momentum
-               double& relMomLoss, // relative momloss for the step will be added
-               const int& pdg,
-               Material& currentMaterial,
-               StepLimits& limits,
-               bool varField = true);
-
-  void setDebugLvl(unsigned int lvl = 1);
+    void setDebugLvl(unsigned int lvl = 1);
 
 
-  void drawdEdx(int pdg = 11);
+    void drawdEdx(int pdg = 11);
 
- private:
+  private:
 
-  //! sets charge_, mass_
-  void getParticleParameters();
+    //! sets charge_, mass_
+    void getParticleParameters();
 
-  void getMomGammaBeta(double Energy,
-                       double& mom, double& gammaSquare, double& gamma, double& betaSquare) const;
+    void getMomGammaBeta(double Energy,
+                         double& mom, double& gammaSquare, double& gamma, double& betaSquare) const;
 
-  //! Returns momentum loss
-  /**
-   * Also sets dEdx_ and E_.
-   */
-  double momentumLoss(double stepSign, double mom, bool linear);
+    //! Returns momentum loss
+    /**
+     * Also sets dEdx_ and E_.
+     */
+    double momentumLoss(double stepSign, double mom, bool linear);
 
-  //! Calculate dEdx for a given energy
-  double dEdx(double Energy);
+    //! Calculate dEdx for a given energy
+    double dEdx(double Energy);
 
 
-  //! Uses Bethe Bloch formula to calculate dEdx.
-  double dEdxBetheBloch(double betaSquare, double gamma, double gammasquare) const;
+    //! Uses Bethe Bloch formula to calculate dEdx.
+    double dEdxBetheBloch(double betaSquare, double gamma, double gammasquare) const;
 
-  //! calculation of energy loss straggeling
-  /**  For the energy loss straggeling, different formulas are used for different regions:
-    *  - Vavilov-Gaussian regime
-    *  - Urban/Landau approximation
-    *  - truncated Landau distribution
-    *  - Urban model
-    *
-    *  Needs dEdx_, which is calculated in momentumLoss, so it has to be called afterwards!
+    //! calculation of energy loss straggeling
+    /**  For the energy loss straggeling, different formulas are used for different regions:
+      *  - Vavilov-Gaussian regime
+      *  - Urban/Landau approximation
+      *  - truncated Landau distribution
+      *  - Urban model
+      *
+      *  Needs dEdx_, which is calculated in momentumLoss, so it has to be called afterwards!
+      */
+    void noiseBetheBloch(M7x7& noise, double mom, double betaSquare, double gamma, double gammaSquare) const;
+
+    //! calculation of multiple scattering
+    /**  This function first calcuates a MSC variance based on the current material and step length
+     * 2 different formulas for the MSC variance are implemeted. One can select the formula via "setMscModel".
+     * With the MSC variance and the current direction of the track a full 7D noise matrix is calculated.
+     * This noise matrix is the additional noise at the end of fStep in the 7D globa cooridnate system
+     * taking even the (co)variances of the position coordinates into account.
+     *
+      */
+    void noiseCoulomb(M7x7& noise,
+                      const M1x3& direction, double momSquare, double betaSquare) const;
+
+    //! Returns dEdx
+    /** Can be called with any pdg, but only calculates dEdx for electrons and positrons (otherwise returns 0).
+      * Uses a gaussian approximation (Bethe-Heitler formula with Migdal corrections).
+      * For positrons, dEdx is weighed with a correction factor.
     */
-  void noiseBetheBloch(M7x7& noise, double mom, double betaSquare, double gamma, double gammaSquare) const;
+    double dEdxBrems(double mom) const;
 
-  //! calculation of multiple scattering
-  /**  This function first calcuates a MSC variance based on the current material and step length
-   * 2 different formulas for the MSC variance are implemeted. One can select the formula via "setMscModel".
-   * With the MSC variance and the current direction of the track a full 7D noise matrix is calculated.
-   * This noise matrix is the additional noise at the end of fStep in the 7D globa cooridnate system
-   * taking even the (co)variances of the position coordinates into account.
-   * 
-    */
-  void noiseCoulomb(M7x7& noise,
-                    const M1x3& direction, double momSquare, double betaSquare) const;
-
-  //! Returns dEdx
-  /** Can be called with any pdg, but only calculates dEdx for electrons and positrons (otherwise returns 0).
-    * Uses a gaussian approximation (Bethe-Heitler formula with Migdal corrections).
-    * For positrons, dEdx is weighed with a correction factor.
-  */
-  double dEdxBrems(double mom) const;
-
-  //! calculation of energy loss straggeling
-  /** Can be called with any pdg, but only calculates straggeling for electrons and positrons.
-   */
-  void noiseBrems(M7x7& noise, double momSquare, double betaSquare) const;
+    //! calculation of energy loss straggeling
+    /** Can be called with any pdg, but only calculates straggeling for electrons and positrons.
+     */
+    void noiseBrems(M7x7& noise, double momSquare, double betaSquare) const;
 
 
 
-  bool noEffects_;
+    bool noEffects_;
 
-  bool energyLossBetheBloch_;
-  bool noiseBetheBloch_;
-  bool noiseCoulomb_;
-  bool energyLossBrems_;
-  bool noiseBrems_;
+    bool energyLossBetheBloch_;
+    bool noiseBetheBloch_;
+    bool noiseCoulomb_;
+    bool energyLossBrems_;
+    bool noiseBrems_;
 
-  bool ignoreBoundariesBetweenEqualMaterials_;
+    bool ignoreBoundariesBetweenEqualMaterials_;
 
-  const double me_; // electron mass (GeV)
+    const double me_; // electron mass (GeV)
 
-  double stepSize_; // stepsize
+    double stepSize_; // stepsize
 
-  // cached values for energy loss and noise calculations
-  double dEdx_; // Runkge Kutta dEdx
-  double E_; // Runge Kutta Energy
-  double matDensity_;
-  double matZ_;
-  double matA_;
-  double radiationLength_;
-  double mEE_; // mean excitation energy
+    // cached values for energy loss and noise calculations
+    double dEdx_; // Runkge Kutta dEdx
+    double E_; // Runge Kutta Energy
+    double matDensity_;
+    double matZ_;
+    double matA_;
+    double radiationLength_;
+    double mEE_; // mean excitation energy
 
-  int pdg_;
-  double charge_;
-  double mag_charge_; // in units of e+
-  double mass_;
+    int pdg_;
+    double charge_;
+    double mag_charge_; // in units of e+
+    double mass_;
 
-  int mscModelCode_; /// depending on this number a specific msc model is chosen in the noiseCoulomb function.
+    int mscModelCode_; /// depending on this number a specific msc model is chosen in the noiseCoulomb function.
 
-  AbsMaterialInterface* materialInterface_;
+    AbsMaterialInterface* materialInterface_;
 
-  unsigned int debugLvl_;
+    unsigned int debugLvl_;
 
-  // ClassDef(MaterialEffects, 1);
+    // ClassDef(MaterialEffects, 1);
 
-};
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/trackReps/include/MplTrackRep.h
+++ b/trackReps/include/MplTrackRep.h
@@ -47,7 +47,7 @@ namespace genfit {
                        bool calcOnlyLastRowOfJ = false) const override;
 
     // Returns the magnetic charge instead of electric as in the base class.
-    double getCharge(const StateOnPlane& state) const override; 
+    double getCharge(const StateOnPlane& state) const override;
 
   private:
 

--- a/trackReps/include/RKTools.h
+++ b/trackReps/include/RKTools.h
@@ -30,74 +30,80 @@
 
 namespace genfit {
 
-template <size_t nRows, size_t nCols>
-struct RKMatrix {
-  double vals[nRows * nCols];
+  template <size_t nRows, size_t nCols>
+  struct RKMatrix {
+    double vals[nRows * nCols];
 
-  RKMatrix() = default;
-  RKMatrix(const RKMatrix&) = default;
-  RKMatrix(std::initializer_list<double> initList) {
-    std::copy(initList.begin(), initList.end(), vals);
+    RKMatrix() = default;
+    RKMatrix(const RKMatrix&) = default;
+    RKMatrix(std::initializer_list<double> initList)
+    {
+      std::copy(initList.begin(), initList.end(), vals);
+    };
+
+    double& operator()(size_t iRow, size_t iCol)
+    {
+      return vals[nCols * iRow + iCol];
+    }
+    double& operator[](size_t n)
+    {
+      return vals[n];
+    }
+    const double& operator[](size_t n) const
+    {
+      return vals[n];
+    }
+
+    double* begin() { return vals; }
+    double* end() { return vals + nRows * nCols; }
+    const double* begin() const { return vals; }
+    const double* end() const { return vals + nRows * nCols; }
+
+    RKMatrix<nRows, nCols>& operator=(const RKMatrix<nRows, nCols>& o)
+    {
+      std::copy(o.begin(), o.end(), this->begin());
+      return *this;
+    }
+
+    void print();
   };
 
-  double& operator()(size_t iRow, size_t iCol) {
-    return vals[nCols*iRow + iCol];
+  typedef RKMatrix<1, 3> M1x3;
+  typedef RKMatrix<1, 4> M1x4;
+  typedef RKMatrix<1, 7> M1x7;
+  typedef RKMatrix<5, 5> M5x5;
+  typedef RKMatrix<6, 6> M6x6;
+  typedef RKMatrix<7, 7> M7x7;
+  typedef RKMatrix<6, 5> M6x5;
+  typedef RKMatrix<7, 5> M7x5;
+  typedef RKMatrix<5, 6> M5x6;
+  typedef RKMatrix<5, 7> M5x7;
+
+  /**
+   * @brief Array matrix multiplications used in RKTrackRep
+   */
+  namespace RKTools {
+
+    void J_pMTxcov5xJ_pM(const M5x7& J_pM, const M5x5& cov5, M7x7& out7);
+    void J_pMTxcov5xJ_pM(const M5x6& J_pM, const M5x5& cov5, M6x6& out6);
+
+    void J_MpTxcov7xJ_Mp(const M7x5& J_Mp, const M7x7& cov7, M5x5& out5);
+    void J_MpTxcov6xJ_Mp(const M6x5& J_Mp, const M6x6& cov6, M5x5& out5);
+
+    void J_pMTTxJ_MMTTxJ_MpTT(const M7x5& J_pMT, const M7x7& J_MMT, const M5x7& J_MpT, M5x5& J_pp);
+
+    void Np_N_NpT(const M7x7& Np, M7x7& N);
+
+    void printDim(const double* mat, unsigned int dimX, unsigned int dimY);
+
   }
-  double& operator[](size_t n) {
-    return vals[n];
+
+  template<size_t nRows, size_t nCols>
+  inline void
+  RKMatrix<nRows, nCols>::print()
+  {
+    RKTools::printDim(this->vals, nRows, nCols);
   }
-  const double& operator[](size_t n) const {
-    return vals[n];
-  }
-
-  double* begin() { return vals; }
-  double* end() { return vals + nRows * nCols; }
-  const double* begin() const { return vals; }
-  const double* end() const { return vals + nRows * nCols; }
-
-  RKMatrix<nRows, nCols>& operator=(const RKMatrix<nRows, nCols>& o) {
-    std::copy(o.begin(), o.end(), this->begin());
-    return *this;
-  }
-
-  void print();
-};
-
-typedef RKMatrix<1, 3> M1x3;
-typedef RKMatrix<1, 4> M1x4;
-typedef RKMatrix<1, 7> M1x7;
-typedef RKMatrix<5, 5> M5x5;
-typedef RKMatrix<6, 6> M6x6;
-typedef RKMatrix<7, 7> M7x7;
-typedef RKMatrix<6, 5> M6x5;
-typedef RKMatrix<7, 5> M7x5;
-typedef RKMatrix<5, 6> M5x6;
-typedef RKMatrix<5, 7> M5x7;
-
-/**
- * @brief Array matrix multiplications used in RKTrackRep
- */
-namespace RKTools {
-
-  void J_pMTxcov5xJ_pM(const M5x7& J_pM, const M5x5& cov5, M7x7& out7);
-  void J_pMTxcov5xJ_pM(const M5x6& J_pM, const M5x5& cov5, M6x6& out6);
-
-  void J_MpTxcov7xJ_Mp(const M7x5& J_Mp, const M7x7& cov7, M5x5& out5);
-  void J_MpTxcov6xJ_Mp(const M6x5& J_Mp, const M6x6& cov6, M5x5& out5);
-
-  void J_pMTTxJ_MMTTxJ_MpTT(const M7x5& J_pMT, const M7x7& J_MMT, const M5x7& J_MpT, M5x5& J_pp);
-
-  void Np_N_NpT(const M7x7& Np, M7x7& N);
-
-  void printDim(const double* mat, unsigned int dimX, unsigned int dimY);
-
-}
-
-template<size_t nRows, size_t nCols>
-inline void
-RKMatrix<nRows, nCols>::print() {
-  RKTools::printDim(this->vals, nRows, nCols);
-}
 
 } /* End of namespace genfit */
 /** @} */

--- a/trackReps/include/StepLimits.h
+++ b/trackReps/include/StepLimits.h
@@ -30,81 +30,83 @@
 
 namespace genfit {
 
-enum StepLimitType {
-  // soft limits (only rough estimation, can go beyond safely)
-  stp_noLimit = 0,    // only for internal use
+  enum StepLimitType {
+    // soft limits (only rough estimation, can go beyond safely)
+    stp_noLimit = 0,    // only for internal use
 
-  // medium limits (can go a bit further if e.g. plane or boundary will be reached)
-  stp_fieldCurv,  // stepsize limited by curvature and magnetic field inhomogenities
-  stp_momLoss,    // stepsize limited by stepper because maximum momLoss is reached
-  stp_sMax,       // stepsize limited by SMax defined in #estimateStep()
+    // medium limits (can go a bit further if e.g. plane or boundary will be reached)
+    stp_fieldCurv,  // stepsize limited by curvature and magnetic field inhomogenities
+    stp_momLoss,    // stepsize limited by stepper because maximum momLoss is reached
+    stp_sMax,       // stepsize limited by SMax defined in #estimateStep()
 
-  // hard limits (must stop there at any case!)
-  stp_sMaxArg,    // stepsize limited by argument maxStepArg passed to #estimateStep()
-  stp_boundary,   // stepsize limited by stepper because material boundary is encountered
-  stp_plane,      // stepsize limited because destination plane is reached
+    // hard limits (must stop there at any case!)
+    stp_sMaxArg,    // stepsize limited by argument maxStepArg passed to #estimateStep()
+    stp_boundary,   // stepsize limited by stepper because material boundary is encountered
+    stp_plane,      // stepsize limited because destination plane is reached
 
-  ENUM_NR_ITEMS   // only for internal use
-};
+    ENUM_NR_ITEMS   // only for internal use
+  };
 
-
-/**
- * @brief Helper to store different limits on the stepsize for the RKTRackRep.
- */
-class StepLimits {
-
- public:
-  StepLimits()
-  : limits_(ENUM_NR_ITEMS, maxLimit_), stepSign_(1) {;}
-
-  StepLimits(const StepLimits&) = default;
-
-  StepLimits& operator=(const StepLimits& other);
-
-  //! Get limit of type. If that limit has not yet been set, return max double value.
-  double getLimit(StepLimitType type) const {return limits_[type];}
-  double getLimitSigned(StepLimitType type) const {
-    return stepSign_*getLimit(type);
-  }
 
   /**
-   * @brief Get the lowest limit.
-   *
-   * If hard limits are there, medium limits can be exceeded by up to margin
-   * (default margin is 0.1, i.e. medium limits can be exceeded by up to 10%).
-   * If no limit has been set yet, return std::pair<stp_noLimit, std::numeric_limits<double>::max>.
+   * @brief Helper to store different limits on the stepsize for the RKTRackRep.
    */
-  std::pair<StepLimitType, double> getLowestLimit(double margin = 1.E-3) const;
+  class StepLimits {
 
-  //! Get the unsigned numerical value of the lowest limit.
-  double getLowestLimitVal(double margin = 1.E-3) const;
-  //! Get the numerical value of the lowest limit, signed with #stepSign_.
-  double getLowestLimitSignedVal(double margin = 1.E-3) const {
-    return getLowestLimitVal(margin) * stepSign_;
-  }
+  public:
+    StepLimits()
+      : limits_(ENUM_NR_ITEMS, maxLimit_), stepSign_(1) {;}
 
-  char getStepSign() const {return stepSign_;} // +- 1
+    StepLimits(const StepLimits&) = default;
 
-  //! absolute of value will be taken! If limit is already lower, it will stay.
-  void reduceLimit(StepLimitType type, double value);
-  //! absolute of value will be taken! If limit is already lower, it will be set to value anyway.
-  void setLimit(StepLimitType type, double value) {limits_[type] = fabs(value);}
-  //! sets #stepSign_ to sign of signedVal
-  void setStepSign(char signedVal);
-  //! sets #stepSign_ to sign of signedVal
-  void setStepSign(double signedVal);
+    StepLimits& operator=(const StepLimits& other);
 
-  void removeLimit(StepLimitType type) {limits_[type] = maxLimit_;}
+    //! Get limit of type. If that limit has not yet been set, return max double value.
+    double getLimit(StepLimitType type) const {return limits_[type];}
+    double getLimitSigned(StepLimitType type) const
+    {
+      return stepSign_ * getLimit(type);
+    }
 
-  void reset();
-  void Print();
+    /**
+     * @brief Get the lowest limit.
+     *
+     * If hard limits are there, medium limits can be exceeded by up to margin
+     * (default margin is 0.1, i.e. medium limits can be exceeded by up to 10%).
+     * If no limit has been set yet, return std::pair<stp_noLimit, std::numeric_limits<double>::max>.
+     */
+    std::pair<StepLimitType, double> getLowestLimit(double margin = 1.E-3) const;
 
- private:
-  std::vector<double> limits_; // limits are unsigned (i.e. non-negative)
-  signed char stepSign_;
-  static const double maxLimit_;
+    //! Get the unsigned numerical value of the lowest limit.
+    double getLowestLimitVal(double margin = 1.E-3) const;
+    //! Get the numerical value of the lowest limit, signed with #stepSign_.
+    double getLowestLimitSignedVal(double margin = 1.E-3) const
+    {
+      return getLowestLimitVal(margin) * stepSign_;
+    }
 
-};
+    char getStepSign() const {return stepSign_;} // +- 1
+
+    //! absolute of value will be taken! If limit is already lower, it will stay.
+    void reduceLimit(StepLimitType type, double value);
+    //! absolute of value will be taken! If limit is already lower, it will be set to value anyway.
+    void setLimit(StepLimitType type, double value) {limits_[type] = fabs(value);}
+    //! sets #stepSign_ to sign of signedVal
+    void setStepSign(char signedVal);
+    //! sets #stepSign_ to sign of signedVal
+    void setStepSign(double signedVal);
+
+    void removeLimit(StepLimitType type) {limits_[type] = maxLimit_;}
+
+    void reset();
+    void Print();
+
+  private:
+    std::vector<double> limits_; // limits are unsigned (i.e. non-negative)
+    signed char stepSign_;
+    static const double maxLimit_;
+
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/trackReps/include/TGeoMaterialInterface.h
+++ b/trackReps/include/TGeoMaterialInterface.h
@@ -29,39 +29,39 @@
 
 namespace genfit {
 
-/**
- * @brief AbsMaterialInterface implementation for use with ROOT's TGeoManager.
- */
-class TGeoMaterialInterface : public AbsMaterialInterface {
-
- public:
-
-  TGeoMaterialInterface() {};
-  ~TGeoMaterialInterface(){;};
-
-  /** @brief Initialize the navigator at given position and with given
-      direction.  Returns true if the volume changed.
+  /**
+   * @brief AbsMaterialInterface implementation for use with ROOT's TGeoManager.
    */
-  bool initTrack(double posX, double posY, double posZ,
-                 double dirX, double dirY, double dirZ) override;
+  class TGeoMaterialInterface : public AbsMaterialInterface {
 
-  Material getMaterialParameters() override;
+  public:
 
-  /** @brief Make a step (following the curvature) until step length
-   * sMax or the next boundary is reached.  After making a step to a
-   * boundary, the position has to be beyond the boundary, i.e. the
-   * current material has to be that beyond the boundary.  The actual
-   * step made is returned.
-   */
-  double findNextBoundary(const RKTrackRep* rep,
-                          const M1x7& state7,
-                          double sMax,
-                          bool varField = true) override;
+    TGeoMaterialInterface() {};
+    ~TGeoMaterialInterface() {;};
 
-  // ClassDefOverride(TGeoMaterialInterface, 1);
+    /** @brief Initialize the navigator at given position and with given
+        direction.  Returns true if the volume changed.
+     */
+    bool initTrack(double posX, double posY, double posZ,
+                   double dirX, double dirY, double dirZ) override;
 
- private:
-};
+    Material getMaterialParameters() override;
+
+    /** @brief Make a step (following the curvature) until step length
+     * sMax or the next boundary is reached.  After making a step to a
+     * boundary, the position has to be beyond the boundary, i.e. the
+     * current material has to be that beyond the boundary.  The actual
+     * step made is returned.
+     */
+    double findNextBoundary(const RKTrackRep* rep,
+                            const M1x7& state7,
+                            double sMax,
+                            bool varField = true) override;
+
+    // ClassDefOverride(TGeoMaterialInterface, 1);
+
+  private:
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/trackReps/src/MaterialEffects.cc
+++ b/trackReps/src/MaterialEffects.cc
@@ -37,308 +37,238 @@
 
 namespace genfit {
 
-MaterialEffects* MaterialEffects::instance_ = nullptr;
+  MaterialEffects* MaterialEffects::instance_ = nullptr;
 
 
-MaterialEffects::MaterialEffects():
-  noEffects_(false),
-  energyLossBetheBloch_(true), noiseBetheBloch_(true),
-  noiseCoulomb_(true),
-  energyLossBrems_(true), noiseBrems_(true),
-  ignoreBoundariesBetweenEqualMaterials_(true),
-  me_(0.510998910E-3),
-  stepSize_(0),
-  dEdx_(0),
-  E_(0),
-  matDensity_(0),
-  matZ_(0),
-  matA_(0),
-  radiationLength_(0),
-  mEE_(0),
-  pdg_(0),
-  charge_(0),
-  mag_charge_(0),
-  mass_(0),
-  mscModelCode_(0),
-  materialInterface_(nullptr),
-  debugLvl_(0)
-{
-}
-
-MaterialEffects::~MaterialEffects()
-{
-  if (materialInterface_ != nullptr) delete materialInterface_;
-}
-
-MaterialEffects* MaterialEffects::getInstance()
-{
-  if (instance_ == nullptr) instance_ = new MaterialEffects();
-  return instance_;
-}
-
-void MaterialEffects::destruct()
-{
-  if (instance_ != nullptr) {
-    delete instance_;
-    instance_ = nullptr;
-  }
-}
-
-void MaterialEffects::init(AbsMaterialInterface* matIfc)
-{
-  if (materialInterface_ != nullptr) {
-    std::string msg("MaterialEffects::initMaterialInterface(): Already initialized! ");
-    std::runtime_error err(msg);
-  }
-  materialInterface_ = matIfc;
-}
-
-
-
-void MaterialEffects::setMscModel(const std::string& modelName)
-{
-  if (modelName == std::string("GEANE")) {
-    mscModelCode_ = 0;
-  } else if (modelName == std::string("Highland")) {
-    mscModelCode_ = 1;
-  } else {// throw exception
-    std::string errorMsg = std::string("There is no MSC model called \"") + modelName + "\". Maybe it is not implemented or you misspelled the model name";
-    Exception exc(errorMsg, __LINE__, __FILE__);
-    exc.setFatal();
-    errorOut << exc.what();
-    throw exc;
-  }
-}
-
-
-double MaterialEffects::effects(const std::vector<RKStep>& steps,
-                                int materialsFXStart,
-                                int materialsFXStop,
-                                const double& mom,
-                                const int& pdg,
-                                M7x7* noise)
-{
-
-  if (debugLvl_ > 0) {
-    debugOut << "     MaterialEffects::effects \n";
+  MaterialEffects::MaterialEffects():
+    noEffects_(false),
+    energyLossBetheBloch_(true), noiseBetheBloch_(true),
+    noiseCoulomb_(true),
+    energyLossBrems_(true), noiseBrems_(true),
+    ignoreBoundariesBetweenEqualMaterials_(true),
+    me_(0.510998910E-3),
+    stepSize_(0),
+    dEdx_(0),
+    E_(0),
+    matDensity_(0),
+    matZ_(0),
+    matA_(0),
+    radiationLength_(0),
+    mEE_(0),
+    pdg_(0),
+    charge_(0),
+    mag_charge_(0),
+    mass_(0),
+    mscModelCode_(0),
+    materialInterface_(nullptr),
+    debugLvl_(0)
+  {
   }
 
-  /*debugOut << "noEffects_ " << noEffects_ << "\n";
-  debugOut << "energyLossBetheBloch_ " << energyLossBetheBloch_ << "\n";
-  debugOut << "noiseBetheBloch_ " << noiseBetheBloch_ << "\n";
-  debugOut << "noiseCoulomb_ " << noiseCoulomb_ << "\n";
-  debugOut << "energyLossBrems_ " << energyLossBrems_ << "\n";
-  debugOut << "noiseBrems_ " << noiseBrems_ << "\n";*/
-
-
-  if (noEffects_) return 0.;
-
-  if (materialInterface_ == nullptr) {
-    std::string msg("MaterialEffects hasn't been initialized with a correct AbsMaterialInterface pointer!");
-    std::runtime_error err(msg);
-    throw err;
+  MaterialEffects::~MaterialEffects()
+  {
+    if (materialInterface_ != nullptr) delete materialInterface_;
   }
 
-  bool doNoise(noise != nullptr);
+  MaterialEffects* MaterialEffects::getInstance()
+  {
+    if (instance_ == nullptr) instance_ = new MaterialEffects();
+    return instance_;
+  }
 
-  pdg_ = pdg;
-  getParticleParameters();
-
-  double momLoss = 0.;
-
-  for ( std::vector<RKStep>::const_iterator it = steps.begin() + materialsFXStart; it !=  steps.begin() + materialsFXStop; ++it) { // loop over steps
-
-    double realPath = it->matStep_.stepSize_;
-    if (fabs(realPath) < 1.E-8) {
-      // do material effects only if distance is not too small
-      continue;
+  void MaterialEffects::destruct()
+  {
+    if (instance_ != nullptr) {
+      delete instance_;
+      instance_ = nullptr;
     }
+  }
+
+  void MaterialEffects::init(AbsMaterialInterface* matIfc)
+  {
+    if (materialInterface_ != nullptr) {
+      std::string msg("MaterialEffects::initMaterialInterface(): Already initialized! ");
+      std::runtime_error err(msg);
+    }
+    materialInterface_ = matIfc;
+  }
+
+
+
+  void MaterialEffects::setMscModel(const std::string& modelName)
+  {
+    if (modelName == std::string("GEANE")) {
+      mscModelCode_ = 0;
+    } else if (modelName == std::string("Highland")) {
+      mscModelCode_ = 1;
+    } else {// throw exception
+      std::string errorMsg = std::string("There is no MSC model called \"") + modelName +
+                             "\". Maybe it is not implemented or you misspelled the model name";
+      Exception exc(errorMsg, __LINE__, __FILE__);
+      exc.setFatal();
+      errorOut << exc.what();
+      throw exc;
+    }
+  }
+
+
+  double MaterialEffects::effects(const std::vector<RKStep>& steps,
+                                  int materialsFXStart,
+                                  int materialsFXStop,
+                                  const double& mom,
+                                  const int& pdg,
+                                  M7x7* noise)
+  {
 
     if (debugLvl_ > 0) {
-      debugOut << "     calculate matFX ";
-      if (doNoise) 
-        debugOut << "and noise";
-      debugOut << " for ";
-      debugOut << "stepSize = " << it->matStep_.stepSize_ << "\t";
-      it->matStep_.material_.Print();
+      debugOut << "     MaterialEffects::effects \n";
     }
 
-    double stepSign(1.);
-    if (realPath < 0)
-      stepSign = -1.;
-    realPath = fabs(realPath);
-    stepSize_ = realPath;
+    /*debugOut << "noEffects_ " << noEffects_ << "\n";
+    debugOut << "energyLossBetheBloch_ " << energyLossBetheBloch_ << "\n";
+    debugOut << "noiseBetheBloch_ " << noiseBetheBloch_ << "\n";
+    debugOut << "noiseCoulomb_ " << noiseCoulomb_ << "\n";
+    debugOut << "energyLossBrems_ " << energyLossBrems_ << "\n";
+    debugOut << "noiseBrems_ " << noiseBrems_ << "\n";*/
 
 
-    const Material& currentMaterial = it->matStep_.material_;
-    matDensity_ = currentMaterial.density;
-    matZ_ = currentMaterial.Z;
-    matA_ = currentMaterial.A;
-    radiationLength_ = currentMaterial.radiationLength;
-    mEE_ = currentMaterial.mEE;
+    if (noEffects_) return 0.;
 
-
-    if (matZ_ > 1.E-3) { // don't calculate energy loss for vacuum
-
-      momLoss += momentumLoss(stepSign, mom - momLoss, false);
-
-      if (doNoise){
-        // get values for the "effective" energy of the RK step E_
-        double p(0), gammaSquare(0), gamma(0), betaSquare(0);
-        this->getMomGammaBeta(E_, p, gammaSquare, gamma, betaSquare);
-        double pSquare = p*p;
-
-        if (pdg_ == c_monopolePDGCode) {
-          charge_ = mag_charge_ * mom / hypot(mom, mass_); //effective charge for monopoles
-        }
-
-        if (energyLossBetheBloch_ && noiseBetheBloch_)
-          this->noiseBetheBloch(*noise, p, betaSquare, gamma, gammaSquare);
-
-        if (noiseCoulomb_)
-          this->noiseCoulomb(*noise, *((M1x3*) &it->state7_[3]), pSquare, betaSquare);
-
-        if (energyLossBrems_ && noiseBrems_)
-          this->noiseBrems(*noise, pSquare, betaSquare);
-      } // end doNoise
-
+    if (materialInterface_ == nullptr) {
+      std::string msg("MaterialEffects hasn't been initialized with a correct AbsMaterialInterface pointer!");
+      std::runtime_error err(msg);
+      throw err;
     }
 
-  } // end loop over steps
+    bool doNoise(noise != nullptr);
 
-  if (momLoss >= mom) {
-    Exception exc("MaterialEffects::effects ==> momLoss >= momentum, aborting extrapolation!",__LINE__,__FILE__);
-    exc.setFatal();
-    throw exc;
-  }
+    pdg_ = pdg;
+    getParticleParameters();
 
-  return momLoss;
-}
+    double momLoss = 0.;
 
+    for (std::vector<RKStep>::const_iterator it = steps.begin() + materialsFXStart; it !=  steps.begin() + materialsFXStop;
+         ++it) {  // loop over steps
 
-void MaterialEffects::stepper(const RKTrackRep* rep,
-                              M1x7& state7,
-                              const double& mom, // momentum
-                              double& relMomLoss, // relative momloss for the step will be added
-                              const int& pdg,
-                              Material& currentMaterial,
-                              StepLimits& limits,
-                              bool varField)
-{
-
-  static const double maxRelMomLoss = .01; // maximum relative momentum loss allowed
-  static const double Pmin   = 4.E-3;           // minimum momentum for propagation [GeV]
-  static const double minStep = 1.E-4; // 1 µm
-
-  // check momentum
-  if(mom < Pmin){
-    std::ostringstream sstream;
-    sstream << "MaterialEffects::stepper ==> momentum too low: " << mom*1000. << " MeV";
-    Exception exc(sstream.str(),__LINE__,__FILE__);
-    exc.setFatal();
-    throw exc;
-  }
-
-  // Trivial cases
-  if (noEffects_)
-    return;
-
-  if (materialInterface_ == nullptr) {
-    std::string msg("MaterialEffects hasn't been initialized with a correct AbsMaterialInterface pointer!");
-    std::runtime_error err(msg);
-    throw err;
-  }
-
-  if (relMomLoss > maxRelMomLoss) {
-    limits.setLimit(stp_momLoss, 0);
-    return;
-  }
-
-
-  double sMax = limits.getLowestLimitSignedVal(); // signed
-
-  if (fabs(sMax) < minStep)
-    return;
-
-
-
-  pdg_ = pdg;
-  getParticleParameters();
-
-
-  // make minStep
-  state7[0] += limits.getStepSign() * minStep * state7[3];
-  state7[1] += limits.getStepSign() * minStep * state7[4];
-  state7[2] += limits.getStepSign() * minStep * state7[5];
-
-  materialInterface_->initTrack(state7[0], state7[1], state7[2],
-                                limits.getStepSign() * state7[3], limits.getStepSign() * state7[4], limits.getStepSign() * state7[5]);
-
-
-  currentMaterial = materialInterface_->getMaterialParameters();
-  matDensity_ = currentMaterial.density;
-  matZ_ = currentMaterial.Z;
-  matA_ = currentMaterial.A;
-  radiationLength_ = currentMaterial.radiationLength;
-  mEE_ = currentMaterial.mEE;
-
-  if (debugLvl_ > 0) {
-    debugOut << "     currentMaterial "; currentMaterial.Print();
-  }
-
-  // limit due to momloss
-  double relMomLossPer_cm(0);
-  stepSize_ = 1.; // set stepsize for momLoss calculation
-
-  if (matZ_ > 1.E-3) { // don't calculate energy loss for vacuum
-    relMomLossPer_cm = this->momentumLoss(limits.getStepSign(), mom, true) / mom;
-  }
-
-  double maxStepMomLoss = fabs((maxRelMomLoss - fabs(relMomLoss)) / relMomLossPer_cm); // >= 0
-  limits.setLimit(stp_momLoss, maxStepMomLoss);
-
-  if (debugLvl_ > 0) {
-    debugOut << "     momLoss exceeded after a step of " <<  maxStepMomLoss
-        << "; relMomLoss up to now = " << relMomLoss << "\n";
-  }
-
-
-  // now look for boundaries
-  sMax = limits.getLowestLimitSignedVal();
-
-  stepSize_ = limits.getStepSign() * minStep;
-  M1x3 SA;
-  double boundaryStep(sMax);
-
-  for (unsigned int i=0; i<100; ++i) {
-    if (debugLvl_ > 0) {
-      debugOut << "     find next boundary\n";
-    }
-    double step =  materialInterface_->findNextBoundary(rep, state7, boundaryStep, varField);
-
-    if (debugLvl_ > 0) {
-      if (step == 0) {
-        debugOut << "     materialInterface_ returned a step of 0 \n";
+      double realPath = it->matStep_.stepSize_;
+      if (fabs(realPath) < 1.E-8) {
+        // do material effects only if distance is not too small
+        continue;
       }
+
+      if (debugLvl_ > 0) {
+        debugOut << "     calculate matFX ";
+        if (doNoise)
+          debugOut << "and noise";
+        debugOut << " for ";
+        debugOut << "stepSize = " << it->matStep_.stepSize_ << "\t";
+        it->matStep_.material_.Print();
+      }
+
+      double stepSign(1.);
+      if (realPath < 0)
+        stepSign = -1.;
+      realPath = fabs(realPath);
+      stepSize_ = realPath;
+
+
+      const Material& currentMaterial = it->matStep_.material_;
+      matDensity_ = currentMaterial.density;
+      matZ_ = currentMaterial.Z;
+      matA_ = currentMaterial.A;
+      radiationLength_ = currentMaterial.radiationLength;
+      mEE_ = currentMaterial.mEE;
+
+
+      if (matZ_ > 1.E-3) { // don't calculate energy loss for vacuum
+
+        momLoss += momentumLoss(stepSign, mom - momLoss, false);
+
+        if (doNoise) {
+          // get values for the "effective" energy of the RK step E_
+          double p(0), gammaSquare(0), gamma(0), betaSquare(0);
+          this->getMomGammaBeta(E_, p, gammaSquare, gamma, betaSquare);
+          double pSquare = p * p;
+
+          if (pdg_ == c_monopolePDGCode) {
+            charge_ = mag_charge_ * mom / hypot(mom, mass_); //effective charge for monopoles
+          }
+
+          if (energyLossBetheBloch_ && noiseBetheBloch_)
+            this->noiseBetheBloch(*noise, p, betaSquare, gamma, gammaSquare);
+
+          if (noiseCoulomb_)
+            this->noiseCoulomb(*noise, *((M1x3*) &it->state7_[3]), pSquare, betaSquare);
+
+          if (energyLossBrems_ && noiseBrems_)
+            this->noiseBrems(*noise, pSquare, betaSquare);
+        } // end doNoise
+
+      }
+
+    } // end loop over steps
+
+    if (momLoss >= mom) {
+      Exception exc("MaterialEffects::effects ==> momLoss >= momentum, aborting extrapolation!", __LINE__, __FILE__);
+      exc.setFatal();
+      throw exc;
     }
 
-    stepSize_ += step;
-    boundaryStep -= step;
+    return momLoss;
+  }
 
-    if (debugLvl_ > 0) {
-      debugOut << "     made a step of " << step << "\n";
+
+  void MaterialEffects::stepper(const RKTrackRep* rep,
+                                M1x7& state7,
+                                const double& mom, // momentum
+                                double& relMomLoss, // relative momloss for the step will be added
+                                const int& pdg,
+                                Material& currentMaterial,
+                                StepLimits& limits,
+                                bool varField)
+  {
+
+    static const double maxRelMomLoss = .01; // maximum relative momentum loss allowed
+    static const double Pmin   = 4.E-3;           // minimum momentum for propagation [GeV]
+    static const double minStep = 1.E-4; // 1 µm
+
+    // check momentum
+    if (mom < Pmin) {
+      std::ostringstream sstream;
+      sstream << "MaterialEffects::stepper ==> momentum too low: " << mom * 1000. << " MeV";
+      Exception exc(sstream.str(), __LINE__, __FILE__);
+      exc.setFatal();
+      throw exc;
     }
 
-    if (! ignoreBoundariesBetweenEqualMaterials_)
-      break;
+    // Trivial cases
+    if (noEffects_)
+      return;
 
-    if (fabs(stepSize_) >= fabs(sMax))
-      break;
+    if (materialInterface_ == nullptr) {
+      std::string msg("MaterialEffects hasn't been initialized with a correct AbsMaterialInterface pointer!");
+      std::runtime_error err(msg);
+      throw err;
+    }
 
-    // propagate with found step to boundary
-    rep->RKPropagate(state7, nullptr, SA, step, varField);
+    if (relMomLoss > maxRelMomLoss) {
+      limits.setLimit(stp_momLoss, 0);
+      return;
+    }
 
-    // make minStep to cross boundary
+
+    double sMax = limits.getLowestLimitSignedVal(); // signed
+
+    if (fabs(sMax) < minStep)
+      return;
+
+
+
+    pdg_ = pdg;
+    getParticleParameters();
+
+
+    // make minStep
     state7[0] += limits.getStepSign() * minStep * state7[3];
     state7[1] += limits.getStepSign() * minStep * state7[4];
     state7[2] += limits.getStepSign() * minStep * state7[5];
@@ -346,553 +276,628 @@ void MaterialEffects::stepper(const RKTrackRep* rep,
     materialInterface_->initTrack(state7[0], state7[1], state7[2],
                                   limits.getStepSign() * state7[3], limits.getStepSign() * state7[4], limits.getStepSign() * state7[5]);
 
-    Material materialAfter = materialInterface_->getMaterialParameters();
+
+    currentMaterial = materialInterface_->getMaterialParameters();
+    matDensity_ = currentMaterial.density;
+    matZ_ = currentMaterial.Z;
+    matA_ = currentMaterial.A;
+    radiationLength_ = currentMaterial.radiationLength;
+    mEE_ = currentMaterial.mEE;
 
     if (debugLvl_ > 0) {
-      debugOut << "     material after step: "; materialAfter.Print();
+      debugOut << "     currentMaterial "; currentMaterial.Print();
     }
 
-    if (materialAfter != currentMaterial)
-      break;
+    // limit due to momloss
+    double relMomLossPer_cm(0);
+    stepSize_ = 1.; // set stepsize for momLoss calculation
+
+    if (matZ_ > 1.E-3) { // don't calculate energy loss for vacuum
+      relMomLossPer_cm = this->momentumLoss(limits.getStepSign(), mom, true) / mom;
+    }
+
+    double maxStepMomLoss = fabs((maxRelMomLoss - fabs(relMomLoss)) / relMomLossPer_cm); // >= 0
+    limits.setLimit(stp_momLoss, maxStepMomLoss);
+
+    if (debugLvl_ > 0) {
+      debugOut << "     momLoss exceeded after a step of " <<  maxStepMomLoss
+               << "; relMomLoss up to now = " << relMomLoss << "\n";
+    }
+
+
+    // now look for boundaries
+    sMax = limits.getLowestLimitSignedVal();
+
+    stepSize_ = limits.getStepSign() * minStep;
+    M1x3 SA;
+    double boundaryStep(sMax);
+
+    for (unsigned int i = 0; i < 100; ++i) {
+      if (debugLvl_ > 0) {
+        debugOut << "     find next boundary\n";
+      }
+      double step =  materialInterface_->findNextBoundary(rep, state7, boundaryStep, varField);
+
+      if (debugLvl_ > 0) {
+        if (step == 0) {
+          debugOut << "     materialInterface_ returned a step of 0 \n";
+        }
+      }
+
+      stepSize_ += step;
+      boundaryStep -= step;
+
+      if (debugLvl_ > 0) {
+        debugOut << "     made a step of " << step << "\n";
+      }
+
+      if (! ignoreBoundariesBetweenEqualMaterials_)
+        break;
+
+      if (fabs(stepSize_) >= fabs(sMax))
+        break;
+
+      // propagate with found step to boundary
+      rep->RKPropagate(state7, nullptr, SA, step, varField);
+
+      // make minStep to cross boundary
+      state7[0] += limits.getStepSign() * minStep * state7[3];
+      state7[1] += limits.getStepSign() * minStep * state7[4];
+      state7[2] += limits.getStepSign() * minStep * state7[5];
+
+      materialInterface_->initTrack(state7[0], state7[1], state7[2],
+                                    limits.getStepSign() * state7[3], limits.getStepSign() * state7[4], limits.getStepSign() * state7[5]);
+
+      Material materialAfter = materialInterface_->getMaterialParameters();
+
+      if (debugLvl_ > 0) {
+        debugOut << "     material after step: "; materialAfter.Print();
+      }
+
+      if (materialAfter != currentMaterial)
+        break;
+    }
+
+    limits.setLimit(stp_boundary, stepSize_);
+
+
+    relMomLoss += relMomLossPer_cm * limits.getLowestLimitVal();
   }
 
-  limits.setLimit(stp_boundary, stepSize_);
 
-
-  relMomLoss += relMomLossPer_cm * limits.getLowestLimitVal();
-}
-
-
-void MaterialEffects::getParticleParameters()
-{
-  TParticlePDG* part = TDatabasePDG::Instance()->GetParticle(pdg_);
-  charge_ = part->Charge() / 3.;  // We only ever use the square
-  mass_ = part->Mass(); // GeV
-}
-
-
-void MaterialEffects::getMomGammaBeta(double Energy,
-                     double& mom, double& gammaSquare, double& gamma, double& betaSquare) const {
-
-  if (Energy <= mass_) {
-    Exception exc("MaterialEffects::getMomGammaBeta - Energy <= mass",__LINE__,__FILE__);
-    exc.setFatal();
-    throw exc;
+  void MaterialEffects::getParticleParameters()
+  {
+    TParticlePDG* part = TDatabasePDG::Instance()->GetParticle(pdg_);
+    charge_ = part->Charge() / 3.;  // We only ever use the square
+    mass_ = part->Mass(); // GeV
   }
-  gamma = Energy/mass_;
-  gammaSquare = gamma*gamma;
-  betaSquare = 1.-1./gammaSquare;
-  mom = Energy*sqrt(betaSquare);
-}
+
+
+  void MaterialEffects::getMomGammaBeta(double Energy,
+                                        double& mom, double& gammaSquare, double& gamma, double& betaSquare) const
+  {
+
+    if (Energy <= mass_) {
+      Exception exc("MaterialEffects::getMomGammaBeta - Energy <= mass", __LINE__, __FILE__);
+      exc.setFatal();
+      throw exc;
+    }
+    gamma = Energy / mass_;
+    gammaSquare = gamma * gamma;
+    betaSquare = 1. - 1. / gammaSquare;
+    mom = Energy * sqrt(betaSquare);
+  }
 
 
 
 //---- Energy-loss and Noise calculations -----------------------------------------
 
-double MaterialEffects::momentumLoss(double stepSign, double mom, bool linear)
-{
-  double E0 = hypot(mom, mass_);
-  double step = stepSize_*stepSign; // signed
+  double MaterialEffects::momentumLoss(double stepSign, double mom, bool linear)
+  {
+    double E0 = hypot(mom, mass_);
+    double step = stepSize_ * stepSign; // signed
 
 
-  // calc dEdx_, also needed in noiseBetheBloch!
-  // using fourth order Runge Kutta
-  //k1 = f(t0,y0)
-  //k2 = f(t0 + h/2, y0 + h/2 * k1)
-  //k3 = f(t0 + h/2, y0 + h/2 * k2)
-  //k4 = f(t0 + h,   y0 + h   * k3)
+    // calc dEdx_, also needed in noiseBetheBloch!
+    // using fourth order Runge Kutta
+    //k1 = f(t0,y0)
+    //k2 = f(t0 + h/2, y0 + h/2 * k1)
+    //k3 = f(t0 + h/2, y0 + h/2 * k2)
+    //k4 = f(t0 + h,   y0 + h   * k3)
 
-  // This means in our case:
-  //dEdx1 = dEdx(x0,       E0)
-  //dEdx2 = dEdx(x0 + h/2, E1); E1 = E0 + h/2 * dEdx1
-  //dEdx3 = dEdx(x0 + h/2, E2); E2 = E0 + h/2 * dEdx2
-  //dEdx4 = dEdx(x0 + h,   E3); E3 = E0 + h   * dEdx3
+    // This means in our case:
+    //dEdx1 = dEdx(x0,       E0)
+    //dEdx2 = dEdx(x0 + h/2, E1); E1 = E0 + h/2 * dEdx1
+    //dEdx3 = dEdx(x0 + h/2, E2); E2 = E0 + h/2 * dEdx2
+    //dEdx4 = dEdx(x0 + h,   E3); E3 = E0 + h   * dEdx3
 
-  double dEdx1 = dEdx(E0); // dEdx(x0,p0)
+    double dEdx1 = dEdx(E0); // dEdx(x0,p0)
 
-  if (linear) {
-    dEdx_ = dEdx1;
-  }
-  else { // RK4
-    double E1 = E0 - dEdx1*step/2.;
-    double dEdx2 = dEdx(E1); // dEdx(x0 + h/2, E0 + h/2 * dEdx1)
+    if (linear) {
+      dEdx_ = dEdx1;
+    } else { // RK4
+      double E1 = E0 - dEdx1 * step / 2.;
+      double dEdx2 = dEdx(E1); // dEdx(x0 + h/2, E0 + h/2 * dEdx1)
 
-    double E2 = E0 - dEdx2*step/2.;
-    double dEdx3 = dEdx(E2); // dEdx(x0 + h/2, E0 + h/2 * dEdx2)
+      double E2 = E0 - dEdx2 * step / 2.;
+      double dEdx3 = dEdx(E2); // dEdx(x0 + h/2, E0 + h/2 * dEdx2)
 
-    double E3 = E0 - dEdx3*step;
-    double dEdx4 = dEdx(E3); // dEdx(x0 + h, E0 + h * dEdx3)
+      double E3 = E0 - dEdx3 * step;
+      double dEdx4 = dEdx(E3); // dEdx(x0 + h, E0 + h * dEdx3)
 
-    dEdx_ = (dEdx1 + 2.*dEdx2 + 2.*dEdx3 + dEdx4)/6.;
-  }
-
-  E_ = E0 - dEdx_*step*0.5;
-
-  double dE = step*dEdx_; // positive for positive stepSign
-
-  double momLoss(0);
-
-  if (E0 - dE <= mass_) {
-    // Step would stop particle (E_kin <= 0).
-    return momLoss = mom;
-  }
-  else momLoss = mom - sqrt(pow(E0 - dE, 2) - mass_*mass_); // momLoss; positive for positive stepSign
-
-  if (debugLvl_ > 0) {
-    debugOut << "      MaterialEffects::momentumLoss: mom = " << mom << "; E0 = " << E0
-        << "; dEdx = " << dEdx_
-        << "; dE = " << dE << "; mass = " << mass_ << "\n";
-  }
-
-  //assert(momLoss * stepSign >= 0);
-
-  return momLoss;
-}
-
-
-double MaterialEffects::dEdx(double Energy) {
-
-  double mom(0), gammaSquare(0), gamma(0), betaSquare(0);
-  this->getMomGammaBeta(Energy, mom, gammaSquare, gamma, betaSquare);
-  if (pdg_ == c_monopolePDGCode) { // if TParticlePDG also had magnetic charge, life would have been easier.
-    charge_ = mag_charge_ * sqrt(betaSquare); //effective charge for monopoles
-  }
-
-  double result(0);
-
-  if (energyLossBetheBloch_)
-    result += dEdxBetheBloch(betaSquare, gamma, gammaSquare);
-
-  if (energyLossBrems_)
-    result += dEdxBrems(mom);
-
-  return result;
-}
-
-
-double MaterialEffects::dEdxBetheBloch(double betaSquare, double gamma, double gammaSquare) const
-{
-  static const double betaGammaMin(0.05);
-  if (betaSquare*gammaSquare < betaGammaMin*betaGammaMin) {
-    Exception exc("MaterialEffects::dEdxBetheBloch ==> beta*gamma < 0.05, Bethe-Bloch implementation not valid anymore!",__LINE__,__FILE__);
-    exc.setFatal();
-    throw exc;
-  }
-
-  // calc dEdx_, also needed in noiseBetheBloch!
-  double result( 0.307075 * matZ_ / matA_ * matDensity_ / betaSquare * charge_ * charge_ );
-  double massRatio( me_ / mass_ );
-  double argument( gammaSquare * betaSquare * me_ * 1.E3 * 2. / ((1.E-6 * mEE_) *
-      sqrt(1. + 2. * gamma * massRatio + massRatio * massRatio)) );
-  result *= log(argument) - betaSquare; // Bethe-Bloch [MeV/cm]
-  result *= 1.E-3;  // in GeV/cm, hence 1.e-3
-  if (result < 0.) {
-    result = 0;
-  }
-
-  return result;
-}
-
-
-void MaterialEffects::noiseBetheBloch(M7x7& noise, double mom, double betaSquare, double gamma, double gammaSquare) const
-{
-  // Code ported from GEANT 3 (erland.F)
-
-  // ENERGY LOSS FLUCTUATIONS; calculate sigma^2(E);
-  double sigma2E ( 0. );
-  double zeta  ( 153.4E3 * charge_ * charge_ / betaSquare * matZ_ / matA_ * matDensity_ * fabs(stepSize_) ); // eV
-  double Emax  ( 2.E9 * me_ * betaSquare * gammaSquare / (1. + 2.*gamma * me_ / mass_ + (me_ / mass_) * (me_ / mass_)) ); // eV
-  double kappa ( zeta / Emax );
-
-  if (kappa > 0.01) { // Vavilov-Gaussian regime
-    sigma2E += zeta * Emax * (1. - betaSquare / 2.); // eV^2
-  } else { // Urban/Landau approximation
-    // calculate number of collisions Nc
-    double I = 16. * pow(matZ_, 0.9); // eV
-    double f2 = 0.;
-    if (matZ_ > 2.) f2 = 2. / matZ_;
-    double f1 = 1. - f2;
-    double e2 = 10.*matZ_ * matZ_; // eV
-    double e1 = pow((I / pow(e2, f2)), 1. / f1); // eV
-
-    double mbbgg2 = 2.E9 * mass_ * betaSquare * gammaSquare; // eV
-    double Sigma1 = dEdx_ * 1.0E9 * f1 / e1 * (log(mbbgg2 / e1) - betaSquare) / (log(mbbgg2 / I) - betaSquare) * 0.6; // 1/cm
-    double Sigma2 = dEdx_ * 1.0E9 * f2 / e2 * (log(mbbgg2 / e2) - betaSquare) / (log(mbbgg2 / I) - betaSquare) * 0.6; // 1/cm
-    double Sigma3 = dEdx_ * 1.0E9 * Emax / (I * (Emax + I) * log((Emax + I) / I)) * 0.4; // 1/cm
-
-    double Nc = (Sigma1 + Sigma2 + Sigma3) * fabs(stepSize_);
-
-    if (Nc > 50.) { // truncated Landau distribution
-      double sigmaalpha = 15.76;
-      // calculate sigmaalpha  (see GEANT3 manual W5013)
-      double RLAMED = -0.422784 - betaSquare - log(zeta / Emax);
-      double RLAMAX =  0.60715 + 1.1934 * RLAMED + (0.67794 + 0.052382 * RLAMED) * exp(0.94753 + 0.74442 * RLAMED);
-      // from lambda max to sigmaalpha=sigma (empirical polynomial)
-      if (RLAMAX <= 1010.) {
-        sigmaalpha =  1.975560
-                      + 9.898841e-02 * RLAMAX
-                      - 2.828670e-04 * RLAMAX * RLAMAX
-                      + 5.345406e-07 * pow(RLAMAX, 3.)
-                      - 4.942035e-10 * pow(RLAMAX, 4.)
-                      + 1.729807e-13 * pow(RLAMAX, 5.);
-      } else { sigmaalpha = 1.871887E+01 + 1.296254E-02 * RLAMAX; }
-      // alpha=54.6  corresponds to a 0.9996 maximum cut
-      if (sigmaalpha > 54.6) sigmaalpha = 54.6;
-      sigma2E += sigmaalpha * sigmaalpha * zeta * zeta; // eV^2
-    } else { // Urban model
-      static const double alpha = 0.996;
-      double Ealpha  = I / (1. - (alpha * Emax / (Emax + I))); // eV
-      double meanE32 = I * (Emax + I) / Emax * (Ealpha - I); // eV^2
-      sigma2E += fabs(stepSize_) * (Sigma1 * e1 * e1 + Sigma2 * e2 * e2 + Sigma3 * meanE32); // eV^2
+      dEdx_ = (dEdx1 + 2.*dEdx2 + 2.*dEdx3 + dEdx4) / 6.;
     }
+
+    E_ = E0 - dEdx_ * step * 0.5;
+
+    double dE = step * dEdx_; // positive for positive stepSign
+
+    double momLoss(0);
+
+    if (E0 - dE <= mass_) {
+      // Step would stop particle (E_kin <= 0).
+      return momLoss = mom;
+    } else momLoss = mom - sqrt(pow(E0 - dE, 2) - mass_ * mass_); // momLoss; positive for positive stepSign
+
+    if (debugLvl_ > 0) {
+      debugOut << "      MaterialEffects::momentumLoss: mom = " << mom << "; E0 = " << E0
+               << "; dEdx = " << dEdx_
+               << "; dE = " << dE << "; mass = " << mass_ << "\n";
+    }
+
+    //assert(momLoss * stepSign >= 0);
+
+    return momLoss;
   }
 
-  sigma2E *= 1.E-18; // eV -> GeV
 
-  // update noise matrix, using linear error propagation from E to q/p
-  noise[6 * 7 + 6] += charge_*charge_/betaSquare / pow(mom, 4) * sigma2E;
-}
+  double MaterialEffects::dEdx(double Energy)
+  {
 
+    double mom(0), gammaSquare(0), gamma(0), betaSquare(0);
+    this->getMomGammaBeta(Energy, mom, gammaSquare, gamma, betaSquare);
+    if (pdg_ == c_monopolePDGCode) { // if TParticlePDG also had magnetic charge, life would have been easier.
+      charge_ = mag_charge_ * sqrt(betaSquare); //effective charge for monopoles
+    }
 
-void MaterialEffects::noiseCoulomb(M7x7& noise,
-                                   const M1x3& direction, double momSquare, double betaSquare) const
-{
+    double result(0);
 
-  // MULTIPLE SCATTERING; calculate sigma^2
-  double sigma2 = 0;
-  assert(mscModelCode_ == 0 || mscModelCode_ == 1);
-  const double step = fabs(stepSize_);
-  const double step2 = step * step;
-  if (mscModelCode_ == 0) {// PANDA report PV/01-07 eq(43); linear in step length
-    sigma2 = 225.E-6 * charge_ * charge_ / (betaSquare * momSquare) * step / radiationLength_ * matZ_ / (matZ_ + 1) * log(159.*pow(matZ_, -1. / 3.)) / log(287.*pow(matZ_, -0.5)); // sigma^2 = 225E-6*z^2/mom^2 * XX0/beta_^2 * Z/(Z+1) * ln(159*Z^(-1/3))/ln(287*Z^(-1/2)
+    if (energyLossBetheBloch_)
+      result += dEdxBetheBloch(betaSquare, gamma, gammaSquare);
 
-  } else if (mscModelCode_ == 1) { //Highland not linear in step length formula taken from PDG book 2011 edition
-    double stepOverRadLength = step / radiationLength_;
-    double logCor = (1 + 0.038 * log(stepOverRadLength));
-    sigma2 = 0.0136 * 0.0136 * charge_ * charge_ / (betaSquare * momSquare) * stepOverRadLength * logCor * logCor;
+    if (energyLossBrems_)
+      result += dEdxBrems(mom);
+
+    return result;
   }
-  //assert(sigma2 >= 0.0);
-  sigma2 = (sigma2 > 0.0 ? sigma2 : 0.0);
-  //XXX debugOut << "MaterialEffects::noiseCoulomb the MSC variance is " << sigma2 << std::endl;
 
-  M7x7 noiseAfter; // will hold the new MSC noise to cause by the current stepSize_ length
-  std::fill(noiseAfter.begin(), noiseAfter.end(), 0);
 
-  const M1x3& a = direction; // as an abbreviation
-  // This calculates the MSC angular spread in the 7D global
-  // coordinate system.  See PDG 2010, Sec. 27.3 for formulae.
-  noiseAfter[0 * 7 + 0] =  sigma2 * step2 / 3.0 * (1 - a[0]*a[0]);
-  noiseAfter[1 * 7 + 0] = -sigma2 * step2 / 3.0 * a[0]*a[1];
-  noiseAfter[2 * 7 + 0] = -sigma2 * step2 / 3.0 * a[0]*a[2];
-  noiseAfter[3 * 7 + 0] =  sigma2 * step * 0.5 * (1 - a[0]*a[0]);
-  noiseAfter[4 * 7 + 0] = -sigma2 * step * 0.5 * a[0]*a[1];
-  noiseAfter[5 * 7 + 0] = -sigma2 * step * 0.5 * a[0]*a[1];
-  noiseAfter[0 * 7 + 1] = noiseAfter[1 * 7 + 0];
-  noiseAfter[1 * 7 + 1] =  sigma2 * step2 / 3.0 * (1 - a[1]*a[1]);
-  noiseAfter[2 * 7 + 1] = -sigma2 * step2 / 3.0 * a[1]*a[2];
-  noiseAfter[3 * 7 + 1] = noiseAfter[4 * 7 + 0]; // Cov(x,a_y) = Cov(y,a_x)
-  noiseAfter[4 * 7 + 1] =  sigma2 * step * 0.5 * (1 - a[1] * a[1]);
-  noiseAfter[5 * 7 + 1] = -sigma2 * step * 0.5 * a[1]*a[2];
-  noiseAfter[0 * 7 + 2] = noiseAfter[2 * 7 + 0];
-  noiseAfter[1 * 7 + 2] = noiseAfter[2 * 7 + 1];
-  noiseAfter[2 * 7 + 2] =  sigma2 * step2 / 3.0 * (1 - a[2]*a[2]);
-  noiseAfter[3 * 7 + 2] = noiseAfter[5 * 7 + 0]; // Cov(z,a_x) = Cov(x,a_z)
-  noiseAfter[4 * 7 + 2] = noiseAfter[5 * 7 + 1]; // Cov(y,a_z) = Cov(z,a_y)
-  noiseAfter[5 * 7 + 2] =  sigma2 * step * 0.5 * (1 - a[2]*a[2]);
-  noiseAfter[0 * 7 + 3] = noiseAfter[3 * 7 + 0];
-  noiseAfter[1 * 7 + 3] = noiseAfter[3 * 7 + 1];
-  noiseAfter[2 * 7 + 3] = noiseAfter[3 * 7 + 2];
-  noiseAfter[3 * 7 + 3] =  sigma2 * (1 - a[0]*a[0]);
-  noiseAfter[4 * 7 + 3] = -sigma2 * a[0]*a[1];
-  noiseAfter[5 * 7 + 3] = -sigma2 * a[0]*a[2];
-  noiseAfter[0 * 7 + 4] = noiseAfter[4 * 7 + 0];
-  noiseAfter[1 * 7 + 4] = noiseAfter[4 * 7 + 1];
-  noiseAfter[2 * 7 + 4] = noiseAfter[4 * 7 + 2];
-  noiseAfter[3 * 7 + 4] = noiseAfter[4 * 7 + 3];
-  noiseAfter[4 * 7 + 4] =  sigma2 * (1 - a[1]*a[1]);
-  noiseAfter[5 * 7 + 4] = -sigma2 * a[1]*a[2];
-  noiseAfter[0 * 7 + 5] = noiseAfter[5 * 7 + 0];
-  noiseAfter[1 * 7 + 5] = noiseAfter[5 * 7 + 1];
-  noiseAfter[2 * 7 + 5] = noiseAfter[5 * 7 + 2];
-  noiseAfter[3 * 7 + 5] = noiseAfter[5 * 7 + 3];
-  noiseAfter[4 * 7 + 5] = noiseAfter[5 * 7 + 4];
-  noiseAfter[5 * 7 + 5] = sigma2 * (1 - a[2]*a[2]);
+  double MaterialEffects::dEdxBetheBloch(double betaSquare, double gamma, double gammaSquare) const
+  {
+    static const double betaGammaMin(0.05);
+    if (betaSquare * gammaSquare < betaGammaMin * betaGammaMin) {
+      Exception exc("MaterialEffects::dEdxBetheBloch ==> beta*gamma < 0.05, Bethe-Bloch implementation not valid anymore!", __LINE__,
+                    __FILE__);
+      exc.setFatal();
+      throw exc;
+    }
+
+    // calc dEdx_, also needed in noiseBetheBloch!
+    double result(0.307075 * matZ_ / matA_ * matDensity_ / betaSquare * charge_ * charge_);
+    double massRatio(me_ / mass_);
+    double argument(gammaSquare * betaSquare * me_ * 1.E3 * 2. / ((1.E-6 * mEE_) *
+                    sqrt(1. + 2. * gamma * massRatio + massRatio * massRatio)));
+    result *= log(argument) - betaSquare; // Bethe-Bloch [MeV/cm]
+    result *= 1.E-3;  // in GeV/cm, hence 1.e-3
+    if (result < 0.) {
+      result = 0;
+    }
+
+    return result;
+  }
+
+
+  void MaterialEffects::noiseBetheBloch(M7x7& noise, double mom, double betaSquare, double gamma, double gammaSquare) const
+  {
+    // Code ported from GEANT 3 (erland.F)
+
+    // ENERGY LOSS FLUCTUATIONS; calculate sigma^2(E);
+    double sigma2E(0.);
+    double zeta(153.4E3 * charge_ * charge_ / betaSquare * matZ_ / matA_ * matDensity_ * fabs(stepSize_));     // eV
+    double Emax(2.E9 * me_ * betaSquare * gammaSquare / (1. + 2.*gamma * me_ / mass_ + (me_ / mass_) * (me_ / mass_)));     // eV
+    double kappa(zeta / Emax);
+
+    if (kappa > 0.01) { // Vavilov-Gaussian regime
+      sigma2E += zeta * Emax * (1. - betaSquare / 2.); // eV^2
+    } else { // Urban/Landau approximation
+      // calculate number of collisions Nc
+      double I = 16. * pow(matZ_, 0.9); // eV
+      double f2 = 0.;
+      if (matZ_ > 2.) f2 = 2. / matZ_;
+      double f1 = 1. - f2;
+      double e2 = 10.*matZ_ * matZ_; // eV
+      double e1 = pow((I / pow(e2, f2)), 1. / f1); // eV
+
+      double mbbgg2 = 2.E9 * mass_ * betaSquare * gammaSquare; // eV
+      double Sigma1 = dEdx_ * 1.0E9 * f1 / e1 * (log(mbbgg2 / e1) - betaSquare) / (log(mbbgg2 / I) - betaSquare) * 0.6; // 1/cm
+      double Sigma2 = dEdx_ * 1.0E9 * f2 / e2 * (log(mbbgg2 / e2) - betaSquare) / (log(mbbgg2 / I) - betaSquare) * 0.6; // 1/cm
+      double Sigma3 = dEdx_ * 1.0E9 * Emax / (I * (Emax + I) * log((Emax + I) / I)) * 0.4; // 1/cm
+
+      double Nc = (Sigma1 + Sigma2 + Sigma3) * fabs(stepSize_);
+
+      if (Nc > 50.) { // truncated Landau distribution
+        double sigmaalpha = 15.76;
+        // calculate sigmaalpha  (see GEANT3 manual W5013)
+        double RLAMED = -0.422784 - betaSquare - log(zeta / Emax);
+        double RLAMAX =  0.60715 + 1.1934 * RLAMED + (0.67794 + 0.052382 * RLAMED) * exp(0.94753 + 0.74442 * RLAMED);
+        // from lambda max to sigmaalpha=sigma (empirical polynomial)
+        if (RLAMAX <= 1010.) {
+          sigmaalpha =  1.975560
+                        + 9.898841e-02 * RLAMAX
+                        - 2.828670e-04 * RLAMAX * RLAMAX
+                        + 5.345406e-07 * pow(RLAMAX, 3.)
+                        - 4.942035e-10 * pow(RLAMAX, 4.)
+                        + 1.729807e-13 * pow(RLAMAX, 5.);
+        } else { sigmaalpha = 1.871887E+01 + 1.296254E-02 * RLAMAX; }
+        // alpha=54.6  corresponds to a 0.9996 maximum cut
+        if (sigmaalpha > 54.6) sigmaalpha = 54.6;
+        sigma2E += sigmaalpha * sigmaalpha * zeta * zeta; // eV^2
+      } else { // Urban model
+        static const double alpha = 0.996;
+        double Ealpha  = I / (1. - (alpha * Emax / (Emax + I))); // eV
+        double meanE32 = I * (Emax + I) / Emax * (Ealpha - I); // eV^2
+        sigma2E += fabs(stepSize_) * (Sigma1 * e1 * e1 + Sigma2 * e2 * e2 + Sigma3 * meanE32); // eV^2
+      }
+    }
+
+    sigma2E *= 1.E-18; // eV -> GeV
+
+    // update noise matrix, using linear error propagation from E to q/p
+    noise[6 * 7 + 6] += charge_ * charge_ / betaSquare / pow(mom, 4) * sigma2E;
+  }
+
+
+  void MaterialEffects::noiseCoulomb(M7x7& noise,
+                                     const M1x3& direction, double momSquare, double betaSquare) const
+  {
+
+    // MULTIPLE SCATTERING; calculate sigma^2
+    double sigma2 = 0;
+    assert(mscModelCode_ == 0 || mscModelCode_ == 1);
+    const double step = fabs(stepSize_);
+    const double step2 = step * step;
+    if (mscModelCode_ == 0) {// PANDA report PV/01-07 eq(43); linear in step length
+      sigma2 = 225.E-6 * charge_ * charge_ / (betaSquare * momSquare) * step / radiationLength_ * matZ_ / (matZ_ + 1) * log(159.*pow(
+                 matZ_, -1. / 3.)) / log(287.*pow(matZ_,
+                                                  -0.5)); // sigma^2 = 225E-6*z^2/mom^2 * XX0/beta_^2 * Z/(Z+1) * ln(159*Z^(-1/3))/ln(287*Z^(-1/2)
+
+    } else if (mscModelCode_ == 1) { //Highland not linear in step length formula taken from PDG book 2011 edition
+      double stepOverRadLength = step / radiationLength_;
+      double logCor = (1 + 0.038 * log(stepOverRadLength));
+      sigma2 = 0.0136 * 0.0136 * charge_ * charge_ / (betaSquare * momSquare) * stepOverRadLength * logCor * logCor;
+    }
+    //assert(sigma2 >= 0.0);
+    sigma2 = (sigma2 > 0.0 ? sigma2 : 0.0);
+    //XXX debugOut << "MaterialEffects::noiseCoulomb the MSC variance is " << sigma2 << std::endl;
+
+    M7x7 noiseAfter; // will hold the new MSC noise to cause by the current stepSize_ length
+    std::fill(noiseAfter.begin(), noiseAfter.end(), 0);
+
+    const M1x3& a = direction; // as an abbreviation
+    // This calculates the MSC angular spread in the 7D global
+    // coordinate system.  See PDG 2010, Sec. 27.3 for formulae.
+    noiseAfter[0 * 7 + 0] =  sigma2 * step2 / 3.0 * (1 - a[0] * a[0]);
+    noiseAfter[1 * 7 + 0] = -sigma2 * step2 / 3.0 * a[0] * a[1];
+    noiseAfter[2 * 7 + 0] = -sigma2 * step2 / 3.0 * a[0] * a[2];
+    noiseAfter[3 * 7 + 0] =  sigma2 * step * 0.5 * (1 - a[0] * a[0]);
+    noiseAfter[4 * 7 + 0] = -sigma2 * step * 0.5 * a[0] * a[1];
+    noiseAfter[5 * 7 + 0] = -sigma2 * step * 0.5 * a[0] * a[1];
+    noiseAfter[0 * 7 + 1] = noiseAfter[1 * 7 + 0];
+    noiseAfter[1 * 7 + 1] =  sigma2 * step2 / 3.0 * (1 - a[1] * a[1]);
+    noiseAfter[2 * 7 + 1] = -sigma2 * step2 / 3.0 * a[1] * a[2];
+    noiseAfter[3 * 7 + 1] = noiseAfter[4 * 7 + 0]; // Cov(x,a_y) = Cov(y,a_x)
+    noiseAfter[4 * 7 + 1] =  sigma2 * step * 0.5 * (1 - a[1] * a[1]);
+    noiseAfter[5 * 7 + 1] = -sigma2 * step * 0.5 * a[1] * a[2];
+    noiseAfter[0 * 7 + 2] = noiseAfter[2 * 7 + 0];
+    noiseAfter[1 * 7 + 2] = noiseAfter[2 * 7 + 1];
+    noiseAfter[2 * 7 + 2] =  sigma2 * step2 / 3.0 * (1 - a[2] * a[2]);
+    noiseAfter[3 * 7 + 2] = noiseAfter[5 * 7 + 0]; // Cov(z,a_x) = Cov(x,a_z)
+    noiseAfter[4 * 7 + 2] = noiseAfter[5 * 7 + 1]; // Cov(y,a_z) = Cov(z,a_y)
+    noiseAfter[5 * 7 + 2] =  sigma2 * step * 0.5 * (1 - a[2] * a[2]);
+    noiseAfter[0 * 7 + 3] = noiseAfter[3 * 7 + 0];
+    noiseAfter[1 * 7 + 3] = noiseAfter[3 * 7 + 1];
+    noiseAfter[2 * 7 + 3] = noiseAfter[3 * 7 + 2];
+    noiseAfter[3 * 7 + 3] =  sigma2 * (1 - a[0] * a[0]);
+    noiseAfter[4 * 7 + 3] = -sigma2 * a[0] * a[1];
+    noiseAfter[5 * 7 + 3] = -sigma2 * a[0] * a[2];
+    noiseAfter[0 * 7 + 4] = noiseAfter[4 * 7 + 0];
+    noiseAfter[1 * 7 + 4] = noiseAfter[4 * 7 + 1];
+    noiseAfter[2 * 7 + 4] = noiseAfter[4 * 7 + 2];
+    noiseAfter[3 * 7 + 4] = noiseAfter[4 * 7 + 3];
+    noiseAfter[4 * 7 + 4] =  sigma2 * (1 - a[1] * a[1]);
+    noiseAfter[5 * 7 + 4] = -sigma2 * a[1] * a[2];
+    noiseAfter[0 * 7 + 5] = noiseAfter[5 * 7 + 0];
+    noiseAfter[1 * 7 + 5] = noiseAfter[5 * 7 + 1];
+    noiseAfter[2 * 7 + 5] = noiseAfter[5 * 7 + 2];
+    noiseAfter[3 * 7 + 5] = noiseAfter[5 * 7 + 3];
+    noiseAfter[4 * 7 + 5] = noiseAfter[5 * 7 + 4];
+    noiseAfter[5 * 7 + 5] = sigma2 * (1 - a[2] * a[2]);
 //    debugOut << "new noise\n";
 //    RKTools::printDim(noiseAfter, 7,7);
-  for (unsigned int i = 0; i < 7 * 7; ++i) {
-    noise[i] += noiseAfter[i];
+    for (unsigned int i = 0; i < 7 * 7; ++i) {
+      noise[i] += noiseAfter[i];
+    }
   }
-}
 
 
-double MaterialEffects::dEdxBrems(double mom) const
-{
+  double MaterialEffects::dEdxBrems(double mom) const
+  {
 
-  // Code ported from GEANT 3 (gbrele.F)
+    // Code ported from GEANT 3 (gbrele.F)
 
-  if (abs(pdg_) != 11) return 0; // only for electrons and positrons
+    if (abs(pdg_) != 11) return 0; // only for electrons and positrons
 
 #if !defined(BETHE)
-  static const double C[101] = { 0.0, -0.960613E-01, 0.631029E-01, -0.142819E-01, 0.150437E-02, -0.733286E-04, 0.131404E-05, 0.859343E-01, -0.529023E-01, 0.131899E-01, -0.159201E-02, 0.926958E-04, -0.208439E-05, -0.684096E+01, 0.370364E+01, -0.786752E+00, 0.822670E-01, -0.424710E-02, 0.867980E-04, -0.200856E+01, 0.129573E+01, -0.306533E+00, 0.343682E-01, -0.185931E-02, 0.392432E-04, 0.127538E+01, -0.515705E+00, 0.820644E-01, -0.641997E-02, 0.245913E-03, -0.365789E-05, 0.115792E+00, -0.463143E-01, 0.725442E-02, -0.556266E-03, 0.208049E-04, -0.300895E-06, -0.271082E-01, 0.173949E-01, -0.452531E-02, 0.569405E-03, -0.344856E-04, 0.803964E-06, 0.419855E-02, -0.277188E-02, 0.737658E-03, -0.939463E-04, 0.569748E-05, -0.131737E-06, -0.318752E-03, 0.215144E-03, -0.579787E-04, 0.737972E-05, -0.441485E-06, 0.994726E-08, 0.938233E-05, -0.651642E-05, 0.177303E-05, -0.224680E-06, 0.132080E-07, -0.288593E-09, -0.245667E-03, 0.833406E-04, -0.129217E-04, 0.915099E-06, -0.247179E-07, 0.147696E-03, -0.498793E-04, 0.402375E-05, 0.989281E-07, -0.133378E-07, -0.737702E-02, 0.333057E-02, -0.553141E-03, 0.402464E-04, -0.107977E-05, -0.641533E-02, 0.290113E-02, -0.477641E-03, 0.342008E-04, -0.900582E-06, 0.574303E-05, 0.908521E-04, -0.256900E-04, 0.239921E-05, -0.741271E-07, -0.341260E-04, 0.971711E-05, -0.172031E-06, -0.119455E-06, 0.704166E-08, 0.341740E-05, -0.775867E-06, -0.653231E-07, 0.225605E-07, -0.114860E-08, -0.119391E-06, 0.194885E-07, 0.588959E-08, -0.127589E-08, 0.608247E-10};
-  static const double xi = 2.51, beta = 0.99, vl = 0.00004;
+    static const double C[101] = { 0.0, -0.960613E-01, 0.631029E-01, -0.142819E-01, 0.150437E-02, -0.733286E-04, 0.131404E-05, 0.859343E-01, -0.529023E-01, 0.131899E-01, -0.159201E-02, 0.926958E-04, -0.208439E-05, -0.684096E+01, 0.370364E+01, -0.786752E+00, 0.822670E-01, -0.424710E-02, 0.867980E-04, -0.200856E+01, 0.129573E+01, -0.306533E+00, 0.343682E-01, -0.185931E-02, 0.392432E-04, 0.127538E+01, -0.515705E+00, 0.820644E-01, -0.641997E-02, 0.245913E-03, -0.365789E-05, 0.115792E+00, -0.463143E-01, 0.725442E-02, -0.556266E-03, 0.208049E-04, -0.300895E-06, -0.271082E-01, 0.173949E-01, -0.452531E-02, 0.569405E-03, -0.344856E-04, 0.803964E-06, 0.419855E-02, -0.277188E-02, 0.737658E-03, -0.939463E-04, 0.569748E-05, -0.131737E-06, -0.318752E-03, 0.215144E-03, -0.579787E-04, 0.737972E-05, -0.441485E-06, 0.994726E-08, 0.938233E-05, -0.651642E-05, 0.177303E-05, -0.224680E-06, 0.132080E-07, -0.288593E-09, -0.245667E-03, 0.833406E-04, -0.129217E-04, 0.915099E-06, -0.247179E-07, 0.147696E-03, -0.498793E-04, 0.402375E-05, 0.989281E-07, -0.133378E-07, -0.737702E-02, 0.333057E-02, -0.553141E-03, 0.402464E-04, -0.107977E-05, -0.641533E-02, 0.290113E-02, -0.477641E-03, 0.342008E-04, -0.900582E-06, 0.574303E-05, 0.908521E-04, -0.256900E-04, 0.239921E-05, -0.741271E-07, -0.341260E-04, 0.971711E-05, -0.172031E-06, -0.119455E-06, 0.704166E-08, 0.341740E-05, -0.775867E-06, -0.653231E-07, 0.225605E-07, -0.114860E-08, -0.119391E-06, 0.194885E-07, 0.588959E-08, -0.127589E-08, 0.608247E-10};
+    static const double xi = 2.51, beta = 0.99, vl = 0.00004;
 #endif
 #if defined(BETHE) // no MIGDAL corrections
-  static const double C[101] = { 0.0, 0.834459E-02, 0.443979E-02, -0.101420E-02, 0.963240E-04, -0.409769E-05, 0.642589E-07, 0.464473E-02, -0.290378E-02, 0.547457E-03, -0.426949E-04, 0.137760E-05, -0.131050E-07, -0.547866E-02, 0.156218E-02, -0.167352E-03, 0.101026E-04, -0.427518E-06, 0.949555E-08, -0.406862E-02, 0.208317E-02, -0.374766E-03, 0.317610E-04, -0.130533E-05, 0.211051E-07, 0.158941E-02, -0.385362E-03, 0.315564E-04, -0.734968E-06, -0.230387E-07, 0.971174E-09, 0.467219E-03, -0.154047E-03, 0.202400E-04, -0.132438E-05, 0.431474E-07, -0.559750E-09, -0.220958E-02, 0.100698E-02, -0.596464E-04, -0.124653E-04, 0.142999E-05, -0.394378E-07, 0.477447E-03, -0.184952E-03, -0.152614E-04, 0.848418E-05, -0.736136E-06, 0.190192E-07, -0.552930E-04, 0.209858E-04, 0.290001E-05, -0.133254E-05, 0.116971E-06, -0.309716E-08, 0.212117E-05, -0.103884E-05, -0.110912E-06, 0.655143E-07, -0.613013E-08, 0.169207E-09, 0.301125E-04, -0.461920E-04, 0.871485E-05, -0.622331E-06, 0.151800E-07, -0.478023E-04, 0.247530E-04, -0.381763E-05, 0.232819E-06, -0.494487E-08, -0.336230E-04, 0.223822E-04, -0.384583E-05, 0.252867E-06, -0.572599E-08, 0.105335E-04, -0.567074E-06, -0.216564E-06, 0.237268E-07, -0.658131E-09, 0.282025E-05, -0.671965E-06, 0.565858E-07, -0.193843E-08, 0.211839E-10, 0.157544E-04, -0.304104E-05, -0.624410E-06, 0.120124E-06, -0.457445E-08, -0.188222E-05, -0.407118E-06, 0.375106E-06, -0.466881E-07, 0.158312E-08, 0.945037E-07, 0.564718E-07, -0.319231E-07, 0.371926E-08, -0.123111E-09};
-  static const double xi = 2.10, beta = 1.00, vl = 0.001;
+    static const double C[101] = { 0.0, 0.834459E-02, 0.443979E-02, -0.101420E-02, 0.963240E-04, -0.409769E-05, 0.642589E-07, 0.464473E-02, -0.290378E-02, 0.547457E-03, -0.426949E-04, 0.137760E-05, -0.131050E-07, -0.547866E-02, 0.156218E-02, -0.167352E-03, 0.101026E-04, -0.427518E-06, 0.949555E-08, -0.406862E-02, 0.208317E-02, -0.374766E-03, 0.317610E-04, -0.130533E-05, 0.211051E-07, 0.158941E-02, -0.385362E-03, 0.315564E-04, -0.734968E-06, -0.230387E-07, 0.971174E-09, 0.467219E-03, -0.154047E-03, 0.202400E-04, -0.132438E-05, 0.431474E-07, -0.559750E-09, -0.220958E-02, 0.100698E-02, -0.596464E-04, -0.124653E-04, 0.142999E-05, -0.394378E-07, 0.477447E-03, -0.184952E-03, -0.152614E-04, 0.848418E-05, -0.736136E-06, 0.190192E-07, -0.552930E-04, 0.209858E-04, 0.290001E-05, -0.133254E-05, 0.116971E-06, -0.309716E-08, 0.212117E-05, -0.103884E-05, -0.110912E-06, 0.655143E-07, -0.613013E-08, 0.169207E-09, 0.301125E-04, -0.461920E-04, 0.871485E-05, -0.622331E-06, 0.151800E-07, -0.478023E-04, 0.247530E-04, -0.381763E-05, 0.232819E-06, -0.494487E-08, -0.336230E-04, 0.223822E-04, -0.384583E-05, 0.252867E-06, -0.572599E-08, 0.105335E-04, -0.567074E-06, -0.216564E-06, 0.237268E-07, -0.658131E-09, 0.282025E-05, -0.671965E-06, 0.565858E-07, -0.193843E-08, 0.211839E-10, 0.157544E-04, -0.304104E-05, -0.624410E-06, 0.120124E-06, -0.457445E-08, -0.188222E-05, -0.407118E-06, 0.375106E-06, -0.466881E-07, 0.158312E-08, 0.945037E-07, 0.564718E-07, -0.319231E-07, 0.371926E-08, -0.123111E-09};
+    static const double xi = 2.10, beta = 1.00, vl = 0.001;
 #endif
 
-  double BCUT = 10000.; // energy up to which soft bremsstrahlung energy loss is calculated
+    double BCUT = 10000.; // energy up to which soft bremsstrahlung energy loss is calculated
 
-  static const double THIGH = 100., CHIGH = 50.;
-  double dedxBrems = 0.;
+    static const double THIGH = 100., CHIGH = 50.;
+    double dedxBrems = 0.;
 
-  if (BCUT > 0.) {
-    double T, kc;
+    if (BCUT > 0.) {
+      double T, kc;
 
-    if (BCUT > mom) BCUT = mom; // confine BCUT to mom_
+      if (BCUT > mom) BCUT = mom; // confine BCUT to mom_
 
-    // T=mom_,  confined to THIGH
-    // kc=BCUT, confined to CHIGH ??
-    if (mom > THIGH) {
-      T = THIGH;
-      if (BCUT >= THIGH)
-        kc = CHIGH;
-      else
+      // T=mom_,  confined to THIGH
+      // kc=BCUT, confined to CHIGH ??
+      if (mom > THIGH) {
+        T = THIGH;
+        if (BCUT >= THIGH)
+          kc = CHIGH;
+        else
+          kc = BCUT;
+      } else {
+        T = mom;
         kc = BCUT;
-    } else {
-      T = mom;
-      kc = BCUT;
-    }
-
-    double E = T + me_; // total electron energy
-    if (BCUT > T)
-      kc = T;
-
-    double X = log(T / me_);
-    double Y = log(kc / (E * vl));
-
-    double XX;
-    int    K;
-    double S = 0., YY = 1.;
-
-    for (unsigned int I = 1; I <= 2; ++I) {
-      XX = 1.;
-      for (unsigned int J = 1; J <= 6; ++J) {
-        K = 6 * I + J - 6;
-        S += C[K] * XX * YY;
-        XX *= X;
       }
-      YY *= Y;
-    }
 
-    for (unsigned int I = 3; I <= 6; ++I) {
-      XX = 1.;
-      for (unsigned int J = 1; J <= 6; ++J) {
-        K = 6 * I + J - 6;
-        if (Y > 0.)
-          K += 24;
-        S += C[K] * XX * YY;
-        XX *= X;
+      double E = T + me_; // total electron energy
+      if (BCUT > T)
+        kc = T;
+
+      double X = log(T / me_);
+      double Y = log(kc / (E * vl));
+
+      double XX;
+      int    K;
+      double S = 0., YY = 1.;
+
+      for (unsigned int I = 1; I <= 2; ++I) {
+        XX = 1.;
+        for (unsigned int J = 1; J <= 6; ++J) {
+          K = 6 * I + J - 6;
+          S += C[K] * XX * YY;
+          XX *= X;
+        }
+        YY *= Y;
       }
-      YY *= Y;
-    }
 
-    double SS = 0.;
-    YY = 1.;
-
-    for (unsigned int I = 1; I <= 2; ++I) {
-      XX = 1.;
-      for (unsigned int J = 1; J <= 5; ++J) {
-        K = 5 * I + J + 55;
-        SS += C[K] * XX * YY;
-        XX *= X;
+      for (unsigned int I = 3; I <= 6; ++I) {
+        XX = 1.;
+        for (unsigned int J = 1; J <= 6; ++J) {
+          K = 6 * I + J - 6;
+          if (Y > 0.)
+            K += 24;
+          S += C[K] * XX * YY;
+          XX *= X;
+        }
+        YY *= Y;
       }
-      YY *= Y;
-    }
 
-    for (unsigned int I = 3; I <= 5; ++I) {
-      XX = 1.;
-      for (unsigned int J = 1; J <= 5; ++J) {
-        K = 5 * I + J + 55;
-        if (Y > 0.)
-          K += 15;
-        SS += C[K] * XX * YY;
-        XX *= X;
+      double SS = 0.;
+      YY = 1.;
+
+      for (unsigned int I = 1; I <= 2; ++I) {
+        XX = 1.;
+        for (unsigned int J = 1; J <= 5; ++J) {
+          K = 5 * I + J + 55;
+          SS += C[K] * XX * YY;
+          XX *= X;
+        }
+        YY *= Y;
       }
-      YY *= Y;
-    }
 
-    S += matZ_ * SS;
+      for (unsigned int I = 3; I <= 5; ++I) {
+        XX = 1.;
+        for (unsigned int J = 1; J <= 5; ++J) {
+          K = 5 * I + J + 55;
+          if (Y > 0.)
+            K += 15;
+          SS += C[K] * XX * YY;
+          XX *= X;
+        }
+        YY *= Y;
+      }
 
-    if (S > 0.) {
-      double CORR = 1.;
+      S += matZ_ * SS;
+
+      if (S > 0.) {
+        double CORR = 1.;
 #if !defined(BETHE)
-      CORR = 1. / (1. + 0.805485E-10 * matDensity_ * matZ_ * E * E / (matA_ * kc * kc)); // MIGDAL correction factor
+        CORR = 1. / (1. + 0.805485E-10 * matDensity_ * matZ_ * E * E / (matA_ * kc * kc)); // MIGDAL correction factor
 #endif
 
-      // We use exp(beta * log(...) here because pow(..., beta) is
-      // REALLY slow and we don't need ultimate numerical precision
-      // for this approximation.
-      double FAC = matZ_ * (matZ_ + xi) * E * E / (E + me_);
-      if (beta == 1.)  // That is the #ifdef BETHE case
-        FAC *= kc * CORR / T;
-      else
-        FAC *= exp(beta * log(kc * CORR / T));
-      if (FAC <= 0.)
-        return 0.;
-      dedxBrems = FAC * S;
+        // We use exp(beta * log(...) here because pow(..., beta) is
+        // REALLY slow and we don't need ultimate numerical precision
+        // for this approximation.
+        double FAC = matZ_ * (matZ_ + xi) * E * E / (E + me_);
+        if (beta == 1.)  // That is the #ifdef BETHE case
+          FAC *= kc * CORR / T;
+        else
+          FAC *= exp(beta * log(kc * CORR / T));
+        if (FAC <= 0.)
+          return 0.;
+        dedxBrems = FAC * S;
 
 
-      if (mom >= THIGH) {
-        double RAT;
-        if (BCUT < THIGH) {
-          RAT = BCUT / mom;
-          S = (1. - 0.5 * RAT + 2.*RAT * RAT / 9.);
-          RAT = BCUT / T;
-          S /= 1. - 0.5 * RAT + 2.*RAT * RAT / 9.;
-        } else {
-          RAT = BCUT / mom;
-          S = BCUT * (1. - 0.5 * RAT + 2.*RAT * RAT / 9.);
-          RAT = kc / T;
-          S /= kc * (1. - 0.5 * RAT + 2.*RAT * RAT / 9.);
+        if (mom >= THIGH) {
+          double RAT;
+          if (BCUT < THIGH) {
+            RAT = BCUT / mom;
+            S = (1. - 0.5 * RAT + 2.*RAT * RAT / 9.);
+            RAT = BCUT / T;
+            S /= 1. - 0.5 * RAT + 2.*RAT * RAT / 9.;
+          } else {
+            RAT = BCUT / mom;
+            S = BCUT * (1. - 0.5 * RAT + 2.*RAT * RAT / 9.);
+            RAT = kc / T;
+            S /= kc * (1. - 0.5 * RAT + 2.*RAT * RAT / 9.);
+          }
+          dedxBrems *= S; // GeV barn
         }
-        dedxBrems *= S; // GeV barn
-      }
 
-      dedxBrems *= 0.60221367 * matDensity_ / matA_; // energy loss dE/dx [GeV/cm]
-    }
-  }
-
-  if (dedxBrems < 0.)
-    dedxBrems = 0;
-
-  double factor = 1.; // positron correction factor
-
-  if (pdg_ == -11) {
-    static const double AA = 7522100., A1 = 0.415, A3 = 0.0021, A5 = 0.00054;
-
-    double ETA = 0.;
-    if (matZ_ > 0.) {
-      double X = log(AA * mom / (matZ_ * matZ_));
-      if (X > -8.) {
-        if (X >= +9.) ETA = 1.;
-        else {
-          double W = A1 * X + A3 * pow(X, 3.) + A5 * pow(X, 5.);
-          ETA = 0.5 + atan(W) / M_PI;
-        }
+        dedxBrems *= 0.60221367 * matDensity_ / matA_; // energy loss dE/dx [GeV/cm]
       }
     }
 
-    if (ETA < 0.0001)
-      factor = 1.E-10;
-    else if (ETA > 0.9999)
-      factor = 1.;
-    else {
-      double E0 = BCUT / mom;
-      if (E0 > 1.)
-        E0 = 1.;
-      if (E0 < 1.E-8)
+    if (dedxBrems < 0.)
+      dedxBrems = 0;
+
+    double factor = 1.; // positron correction factor
+
+    if (pdg_ == -11) {
+      static const double AA = 7522100., A1 = 0.415, A3 = 0.0021, A5 = 0.00054;
+
+      double ETA = 0.;
+      if (matZ_ > 0.) {
+        double X = log(AA * mom / (matZ_ * matZ_));
+        if (X > -8.) {
+          if (X >= +9.) ETA = 1.;
+          else {
+            double W = A1 * X + A3 * pow(X, 3.) + A5 * pow(X, 5.);
+            ETA = 0.5 + atan(W) / M_PI;
+          }
+        }
+      }
+
+      if (ETA < 0.0001)
+        factor = 1.E-10;
+      else if (ETA > 0.9999)
         factor = 1.;
-      else
-        factor = ETA * (1. - pow(1. - E0, 1. / ETA)) / E0;
+      else {
+        double E0 = BCUT / mom;
+        if (E0 > 1.)
+          E0 = 1.;
+        if (E0 < 1.E-8)
+          factor = 1.;
+        else
+          factor = ETA * (1. - pow(1. - E0, 1. / ETA)) / E0;
+      }
     }
+
+    return factor * dedxBrems; //always positive
   }
 
-  return factor * dedxBrems; //always positive
-}
+
+  void MaterialEffects::noiseBrems(M7x7& noise, double momSquare, double betaSquare) const
+  {
+    // Code ported from GEANT 3 (erland.F) and simplified
+    // E \approx p is assumed.
+    // the factor  1.44 is not in the original Bethe-Heitler model.
+    // It seems to be some empirical correction copied over from some other project.
+
+    if (abs(pdg_) != 11) return; // only for electrons and positrons
+
+    double minusXOverLn2  = -1.442695 * fabs(stepSize_) / radiationLength_;
+    double sigma2E = 1.44 * (pow(3., minusXOverLn2) - pow(4., minusXOverLn2)) * momSquare;
+    sigma2E = std::max(sigma2E, 0.0); // must be positive
+
+    // update noise matrix, using linear error propagation from E to q/p
+    noise[6 * 7 + 6] += charge_ * charge_ / betaSquare / pow(momSquare, 2) * sigma2E;
+  }
 
 
-void MaterialEffects::noiseBrems(M7x7& noise, double momSquare, double betaSquare) const
-{
-  // Code ported from GEANT 3 (erland.F) and simplified
-  // E \approx p is assumed.
-  // the factor  1.44 is not in the original Bethe-Heitler model.
-  // It seems to be some empirical correction copied over from some other project.
-
-  if (abs(pdg_) != 11) return; // only for electrons and positrons
-
-  double minusXOverLn2  = -1.442695 * fabs(stepSize_) / radiationLength_;
-  double sigma2E = 1.44*(pow(3., minusXOverLn2) - pow(4., minusXOverLn2)) * momSquare;
-  sigma2E = std::max(sigma2E, 0.0); // must be positive
-  
-  // update noise matrix, using linear error propagation from E to q/p
-  noise[6 * 7 + 6] += charge_*charge_/betaSquare / pow(momSquare, 2) * sigma2E;
-}
+  void MaterialEffects::setDebugLvl(unsigned int lvl)
+  {
+    debugLvl_ = lvl;
+    if (materialInterface_ and debugLvl_ > 1)
+      materialInterface_->setDebugLvl(debugLvl_ - 1);
+  }
 
 
-void MaterialEffects::setDebugLvl(unsigned int lvl) {
-  debugLvl_ = lvl;
-  if (materialInterface_ and debugLvl_ > 1)
-    materialInterface_->setDebugLvl(debugLvl_-1);
-}
+  void MaterialEffects::drawdEdx(int pdg)
+  {
+    pdg_ = pdg;
+    this->getParticleParameters();
+
+    stepSize_ = 1;
+
+    materialInterface_->initTrack(0, 0, 0, 1, 1, 1);
+    auto currentMaterial = materialInterface_->getMaterialParameters();
+    matDensity_ = currentMaterial.density;
+    matZ_ = currentMaterial.Z;
+    matA_ = currentMaterial.A;
+    radiationLength_ = currentMaterial.radiationLength;
+    mEE_ = currentMaterial.mEE;
+
+    double minMom = 0.00001;
+    double maxMom = 10000;
+    int nSteps(10000);
+    double logStepSize = (log10(maxMom) - log10(minMom)) / (nSteps - 1);
+
+    TH1D hdEdxBethe("dEdxBethe", "dEdxBethe; log10(mom)", nSteps, log10(minMom), log10(maxMom));
+    TH1D hdEdxBrems("dEdxBrems", "dEdxBrems; log10(mom)", nSteps, log10(minMom), log10(maxMom));
+
+    for (int i = 0; i < nSteps; ++i) {
+      double mom = pow(10., log10(minMom) + i * logStepSize);
+      double E = hypot(mom, mass_);
+      if (pdg_ == c_monopolePDGCode) {
+        charge_ = mag_charge_ * mom / E; //effective charge for monopoles
+      }
+
+      energyLossBrems_ = false;
+      energyLossBetheBloch_ = true;
+
+      try {
+        hdEdxBethe.Fill(log10(mom), dEdx(E));
+      } catch (...) {
+
+      }
 
 
-void MaterialEffects::drawdEdx(int pdg) {
-  pdg_ = pdg;
-  this->getParticleParameters();
+      //debugOut<< "E = " << E << "; dEdx = " << dEdx(E) <<"\n";
 
-  stepSize_ = 1;
+      energyLossBrems_ = true;
+      energyLossBetheBloch_ = false;
+      try {
+        hdEdxBrems.Fill(log10(mom), dEdx(E));
+      } catch (...) {
 
-  materialInterface_->initTrack(0, 0, 0, 1, 1, 1);
-  auto currentMaterial = materialInterface_->getMaterialParameters();
-  matDensity_ = currentMaterial.density;
-  matZ_ = currentMaterial.Z;
-  matA_ = currentMaterial.A;
-  radiationLength_ = currentMaterial.radiationLength;
-  mEE_ = currentMaterial.mEE;
-
-  double minMom = 0.00001;
-  double maxMom = 10000;
-  int nSteps(10000);
-  double logStepSize = (log10(maxMom) - log10(minMom)) / (nSteps-1);
-
-  TH1D hdEdxBethe("dEdxBethe", "dEdxBethe; log10(mom)", nSteps, log10(minMom), log10(maxMom));
-  TH1D hdEdxBrems("dEdxBrems", "dEdxBrems; log10(mom)", nSteps, log10(minMom), log10(maxMom));
-
-  for (int i=0; i<nSteps; ++i) {
-    double mom = pow(10., log10(minMom) + i*logStepSize);
-    double E = hypot(mom, mass_);
-    if (pdg_ == c_monopolePDGCode) {
-      charge_ = mag_charge_ * mom / E; //effective charge for monopoles
+      }
     }
-
-    energyLossBrems_ = false;
-    energyLossBetheBloch_ = true;
-
-    try {
-      hdEdxBethe.Fill(log10(mom), dEdx(E));
-    }
-    catch (...) {
-
-    }
-
-
-    //debugOut<< "E = " << E << "; dEdx = " << dEdx(E) <<"\n";
 
     energyLossBrems_ = true;
-    energyLossBetheBloch_ = false;
-    try {
-      hdEdxBrems.Fill(log10(mom), dEdx(E));
-    }
-    catch (...) {
+    energyLossBetheBloch_ = true;
 
-    }
+    std::string Result;//string which will contain the result
+    std::stringstream convert; // stringstream used for the conversion
+    convert << pdg;//add the value of Number to the characters in the stream
+    Result = convert.str();//set Result to the content of the stream
+
+    TFile outfile("dEdx_" + TString(Result) + ".root", "recreate");
+    outfile.cd();
+    hdEdxBethe.Write();
+    hdEdxBrems.Write();
+    outfile.Close();
   }
-
-  energyLossBrems_ = true;
-  energyLossBetheBloch_ = true;
-
-  std::string Result;//string which will contain the result
-  std::stringstream convert; // stringstream used for the conversion
-  convert << pdg;//add the value of Number to the characters in the stream
-  Result = convert.str();//set Result to the content of the stream
-
-  TFile outfile("dEdx_" + TString(Result) + ".root", "recreate");
-  outfile.cd();
-  hdEdxBethe.Write();
-  hdEdxBrems.Write();
-  outfile.Close();
-}
 
 } /* End of namespace genfit */
 

--- a/trackReps/src/MplTrackRep.cc
+++ b/trackReps/src/MplTrackRep.cc
@@ -33,7 +33,8 @@ using namespace genfit;
 MplTrackRep::MplTrackRep(int pdgCode, float magCharge, char propDir) :
   RKTrackRep(pdgCode, propDir),
   m_magCharge(magCharge),
-  m_mass(TDatabasePDG::Instance()->GetParticle(pdgCode)->Mass()) // We could ofc use AbsTrackRep::getMass(state) but we have no state here to call on
+  m_mass(TDatabasePDG::Instance()->GetParticle(
+           pdgCode)->Mass()) // We could ofc use AbsTrackRep::getMass(state) but we have no state here to call on
 {
 }
 
@@ -41,15 +42,16 @@ MplTrackRep::~MplTrackRep()
 {
 }
 
-double MplTrackRep::getCharge(const StateOnPlane& state) const {
+double MplTrackRep::getCharge(const StateOnPlane& state) const
+{
 
   if (dynamic_cast<const MeasurementOnPlane*>(&state) != nullptr) {
-    Exception exc("RKTrackRep::getCharge - cannot get charge from MeasurementOnPlane",__LINE__,__FILE__);
+    Exception exc("RKTrackRep::getCharge - cannot get charge from MeasurementOnPlane", __LINE__, __FILE__);
     exc.setFatal();
     throw exc;
   }
 
-  double pdgCharge( m_magCharge * (this->getPDGCharge() > 0 ? 1.0 : -1.0));
+  double pdgCharge(m_magCharge * (this->getPDGCharge() > 0 ? 1.0 : -1.0));
 
   // return pdgCharge with sign of q/p
   if (state.getState()(0) * pdgCharge < 0)
@@ -79,16 +81,16 @@ double MplTrackRep::RKPropagate(M1x7& state7,
   //   http://inspirehep.net/record/160548
 
   // important fixed numbers
-  static const double EC  ( 0.000149896229 );  // c/(2*10^12) resp. c/2Tera FIXME this 1/2 here is super sneaky
-  static const double P3  ( 1./3. );           // 1/3
-  static const double DLT ( .0002 );           // max. deviation for approximation-quality test
+  static const double EC(0.000149896229);      // c/(2*10^12) resp. c/2Tera FIXME this 1/2 here is super sneaky
+  static const double P3(1. / 3.);             // 1/3
+  static const double DLT(.0002);              // max. deviation for approximation-quality test
   double sign = state7[6] > 0 ? 1.0 : -1.0;
   // Aux parameters
   M1x3&   R           = *((M1x3*) &state7[0]);       // Start coordinates  [cm]  (x,  y,  z)
   M1x3&   A           = *((M1x3*) &state7[3]);       // Start directions         (ax, ay, az);   ax^2+ay^2+az^2=1
   double  S3(0), S4(0), PS2(0);
-  M1x3     H0 = {{0.,0.,0.}}, H1 = {{0.,0.,0.}}, H2 = {{0.,0.,0.}};
-  M1x3     r = {{0.,0.,0.}};
+  M1x3     H0 = {{0., 0., 0.}}, H1 = {{0., 0., 0.}}, H2 = {{0., 0., 0.}};
+  M1x3     r = {{0., 0., 0.}};
   // Variables for Runge Kutta solver
   double   A0(0), A1(0), A2(0), A3(0), A4(0), A5(0), A6(0);
   double   B0(0), B1(0), B2(0), B3(0), B4(0), B5(0), B6(0);
@@ -101,59 +103,57 @@ double MplTrackRep::RKPropagate(M1x7& state7,
   //
   // Runge Kutta Extrapolation
   //
-  S3 = P3*S;
-  S4 = 0.25*S;
+  S3 = P3 * S;
+  S4 = 0.25 * S;
   PS2 = m_magCharge * EC * S * sign;
 
- // First point
-  r[0] = R[0];           r[1] = R[1];           r[2]=R[2];
+// First point
+  r[0] = R[0];           r[1] = R[1];           r[2] = R[2];
   FieldManager::getInstance()->getFieldVal(r[0], r[1], r[2], H0[0], H0[1], H0[2]);       // magnetic field in 10^-1 T = kGauss
   H0[0] *= PS2; H0[1] *= PS2; H0[2] *= PS2;     // H0 is PS2*(Hx, Hy, Hz) @ R0; effectively this is h/2 * Force
-  D0 = fabs(m_magCharge/state7[6]); // p_n
+  D0 = fabs(m_magCharge / state7[6]); // p_n
   F0 = std::sqrt(m_mass * m_mass + D0 * D0) / (D0 * D0); // E / p^2
-  AH0 = A[0]*H0[0] + A[1]*H0[1] + A[2]*H0[2]; // A dot Force
+  AH0 = A[0] * H0[0] + A[1] * H0[1] + A[2] * H0[2]; // A dot Force
 
   A0 = F0 * (H0[0] - A[0] * AH0); B0 = F0 * (H0[1] - A[1] * AH0); C0 = F0 * (H0[2] - A[2] * AH0); // h/2 * k_1
-  A2 = A[0]+A0              ; B2 = A[1]+B0              ; C2 = A[2]+C0              ; // r'_n + h/2 * k_1
-  A1 = A2+A[0]              ; B1 = B2+A[1]              ; C1 = C2+A[2]              ; // 2*r'_n + h/2 * k_1
+  A2 = A[0] + A0              ; B2 = A[1] + B0              ; C2 = A[2] + C0              ; // r'_n + h/2 * k_1
+  A1 = A2 + A[0]              ; B1 = B2 + A[1]              ; C1 = C2 + A[2]              ; // 2*r'_n + h/2 * k_1
 
   // Second point
   if (varField) {
-    r[0] += A1*S4;         r[1] += B1*S4;         r[2] += C1*S4;
+    r[0] += A1 * S4;         r[1] += B1 * S4;         r[2] += C1 * S4;
     FieldManager::getInstance()->getFieldVal(r[0], r[1], r[2], H1[0], H1[1], H1[2]);
     H1[0] *= PS2; H1[1] *= PS2; H1[2] *= PS2; // H1 is PS2*(Hx, Hy, Hz) @ (x, y, z) + 0.25*S * [(A0, B0, C0) + 2*(ax, ay, az)]
-  }
-  else { H1 = H0; };
+  } else { H1 = H0; };
   D1 = D0 + F0 * D0 * AH0; // p_n + h/2 * l_1
   F1 = std::sqrt(m_mass * m_mass + D1 * D1) / (D1 * D1); // E / p^2
-  AH1 = A2*H1[0] + B2*H1[1] + C2*H1[2]; // A dot Force
+  AH1 = A2 * H1[0] + B2 * H1[1] + C2 * H1[2]; // A dot Force
 
-  A3 = A[0] + F1*(H1[0] - A2*AH1); B3 = A[1] + F1*(H1[1] - B2*AH1); C3 = A[2] + F1*(H1[2] - C2*AH1); // r'_n + h/2 * k_2
+  A3 = A[0] + F1 * (H1[0] - A2 * AH1); B3 = A[1] + F1 * (H1[1] - B2 * AH1); C3 = A[2] + F1 * (H1[2] - C2 * AH1); // r'_n + h/2 * k_2
   D2 = D0 + F1 * D1 * AH1; // p_n + h/2 * l_2
   F2 = std::sqrt(m_mass * m_mass + D2 * D2) / (D2 * D2); // E / p^2
-  AH2 = A3*H1[0] + B3*H1[1] + C3*H1[2]; // A dot Force
+  AH2 = A3 * H1[0] + B3 * H1[1] + C3 * H1[2]; // A dot Force
 
-  A4 = A[0] + F2*(H1[0] - A3*AH2); B4 = A[1] + F2*(H1[1] - B3*AH2); C4 = A[2] + F2*(H1[2] - C3*AH2); // r'_n + h/2 * k_3
-  A5 = A4-A[0]+A4            ; B5 = B4-A[1]+B4            ; C5 = C4-A[2]+C4            ; //    r'_n + h * k_3
+  A4 = A[0] + F2 * (H1[0] - A3 * AH2); B4 = A[1] + F2 * (H1[1] - B3 * AH2); C4 = A[2] + F2 * (H1[2] - C3 * AH2); // r'_n + h/2 * k_3
+  A5 = A4 - A[0] + A4            ; B5 = B4 - A[1] + B4            ; C5 = C4 - A[2] + C4            ; //    r'_n + h * k_3
   D3 = D0 + 2.0 * F2 * D2 * AH2; // p_n + h * l_3
   F3 = std::sqrt(m_mass * m_mass + D3 * D3) / (D3 * D3); // E / p^2
-  AH3 = A4*H1[0] + B4*H1[1] + C4*H1[2]; // A dot Force
+  AH3 = A4 * H1[0] + B4 * H1[1] + C4 * H1[2]; // A dot Force
 
   // Last point
   if (varField) {
-    r[0]=R[0]+S*A4;         r[1]=R[1]+S*B4;         r[2]=R[2]+S*C4;  //setup.Field(r,H2);
+    r[0] = R[0] + S * A4;         r[1] = R[1] + S * B4;         r[2] = R[2] + S * C4; //setup.Field(r,H2);
     FieldManager::getInstance()->getFieldVal(r[0], r[1], r[2], H2[0], H2[1], H2[2]);
     H2[0] *= PS2; H2[1] *= PS2; H2[2] *= PS2; // H2 is PS2*(Hx, Hy, Hz) @ (x, y, z) + 0.25*S * (A4, B4, C4)
-  }
-  else { H2 = H0; };
-  A6 = F3 * (H2[0] - A5*AH3); B6 = F3 * (H2[1] - B5*AH3); C6 = F3 * (H2[2] - C5*AH3); // h/2 * k_4
+  } else { H2 = H0; };
+  A6 = F3 * (H2[0] - A5 * AH3); B6 = F3 * (H2[1] - B5 * AH3); C6 = F3 * (H2[2] - C5 * AH3); // h/2 * k_4
   D4 = F3 * D3 * AH3 - D0; // h/2 * l_4 - p_n
-  D5 = P3*(D1 + 2*D2 + D3 + D4); //p_n+1
+  D5 = P3 * (D1 + 2 * D2 + D3 + D4); //p_n+1
 
   //
   // Derivatives of track parameters
   //
-  if(jacobianT != nullptr){
+  if (jacobianT != nullptr) {
 
     // jacobianT         //FIXME seems in magnetic case there are no shortcuts?
     // 1 0 0 0 0 0 0  x
@@ -172,7 +172,7 @@ double MplTrackRep::RKPropagate(M1x7& state7,
     // cppcheck-suppress unreadVariable
     double   dC0(0), dC2(0), dC3(0), dC4(0), dC5(0), dC6(0);
     // cppcheck-suppress unreadVariable
-    double   dD0(0), dD1(0), dD2(0), dD3(0), dD4(0); 
+    double   dD0(0), dD1(0), dD2(0), dD3(0), dD4(0);
 
     int start(0);
 
@@ -186,46 +186,61 @@ double MplTrackRep::RKPropagate(M1x7& state7,
 //         start = 3;
 //       }
 
-      for(int i=start; i<7; ++i) { 
+    for (int i = start; i < 7; ++i) {
 
-        //first point
-        dD0 = -D0*D0/m_magCharge/sign*J(i,6);
-        dA0 = (1/(F0*F0*D0*D0*D0) - 2/D0)*A0*dD0 - (D1-D0)/D0*J(i,3) - F0*A[0]*(J(i,3)*H0[0] + J(i,4)*H0[1] + J(i,5)*H0[2]); // FIXME A true marvel of clarity
-        dB0 = (1/(F0*F0*D0*D0*D0) - 2/D0)*B0*dD0 - (D1-D0)/D0*J(i,4) - F0*A[1]*(J(i,3)*H0[0] + J(i,4)*H0[1] + J(i,5)*H0[2]);
-        dC0 = (1/(F0*F0*D0*D0*D0) - 2/D0)*C0*dD0 - (D1-D0)/D0*J(i,5) - F0*A[2]*(J(i,3)*H0[0] + J(i,4)*H0[1] + J(i,5)*H0[2]);
+      //first point
+      dD0 = -D0 * D0 / m_magCharge / sign * J(i, 6);
+      dA0 = (1 / (F0 * F0 * D0 * D0 * D0) - 2 / D0) * A0 * dD0 - (D1 - D0) / D0 * J(i, 3) - F0 * A[0] * (J(i, 3) * H0[0] + J(i,
+            4) * H0[1] + J(i, 5) * H0[2]); // FIXME A true marvel of clarity
+      dB0 = (1 / (F0 * F0 * D0 * D0 * D0) - 2 / D0) * B0 * dD0 - (D1 - D0) / D0 * J(i, 4) - F0 * A[1] * (J(i, 3) * H0[0] + J(i,
+            4) * H0[1] + J(i, 5) * H0[2]);
+      dC0 = (1 / (F0 * F0 * D0 * D0 * D0) - 2 / D0) * C0 * dD0 - (D1 - D0) / D0 * J(i, 5) - F0 * A[2] * (J(i, 3) * H0[0] + J(i,
+            4) * H0[1] + J(i, 5) * H0[2]);
 
-        dD1 = dD0 + (1/(F0*F0*D0*D0*D0) - 1/D0)*(D1-D0)*dD0 + F0*D0*(J(i,3)*H0[0] + J(i,4)*H0[1] + J(i,5)*H0[2]);
-        dA2 = dA0+J(i, 3);
-        dB2 = dB0+J(i, 4);
-        dC2 = dC0+J(i, 5);
+      dD1 = dD0 + (1 / (F0 * F0 * D0 * D0 * D0) - 1 / D0) * (D1 - D0) * dD0 + F0 * D0 * (J(i, 3) * H0[0] + J(i, 4) * H0[1] + J(i,
+            5) * H0[2]);
+      dA2 = dA0 + J(i, 3);
+      dB2 = dB0 + J(i, 4);
+      dC2 = dC0 + J(i, 5);
 
-        //second point
-        dD2 = dD0 + (1/(F1*F1*D1*D1*D1) - 1/D1)*(D2-D0)*dD1 + F1*D1*(dA2*H1[0] + dB2*H1[1] + dC2*H1[2]);
-        dA3 = J(i,3)+(1/(F1*F1*D1*D1*D1) - 2/D1)*(A2-A[0])*dD1 - (D2-D0)/D1*dA2 - F1*A2*(dA2*H1[0] + dB2*H1[1] + dC2*H1[2]); // FIXME it's only getting better
-        dB3 = J(i,4)+(1/(F1*F1*D1*D1*D1) - 2/D1)*(B2-A[1])*dD1 - (D2-D0)/D1*dB2 - F1*B2*(dA2*H1[0] + dB2*H1[1] + dC2*H1[2]);
-        dC3 = J(i,5)+(1/(F1*F1*D1*D1*D1) - 2/D1)*(C2-A[2])*dD1 - (D2-D0)/D1*dC2 - F1*C2*(dA2*H1[0] + dB2*H1[1] + dC2*H1[2]);
+      //second point
+      dD2 = dD0 + (1 / (F1 * F1 * D1 * D1 * D1) - 1 / D1) * (D2 - D0) * dD1 + F1 * D1 * (dA2 * H1[0] + dB2 * H1[1] + dC2 * H1[2]);
+      dA3 = J(i, 3) + (1 / (F1 * F1 * D1 * D1 * D1) - 2 / D1) * (A2 - A[0]) * dD1 - (D2 - D0) / D1 * dA2 - F1 * A2 *
+            (dA2 * H1[0] + dB2 * H1[1] + dC2 * H1[2]); // FIXME it's only getting better
+      dB3 = J(i, 4) + (1 / (F1 * F1 * D1 * D1 * D1) - 2 / D1) * (B2 - A[1]) * dD1 - (D2 - D0) / D1 * dB2 - F1 * B2 *
+            (dA2 * H1[0] + dB2 * H1[1] + dC2 * H1[2]);
+      dC3 = J(i, 5) + (1 / (F1 * F1 * D1 * D1 * D1) - 2 / D1) * (C2 - A[2]) * dD1 - (D2 - D0) / D1 * dC2 - F1 * C2 *
+            (dA2 * H1[0] + dB2 * H1[1] + dC2 * H1[2]);
 
-        dD3 = dD0 + 2*(1/(F2*F2*D2*D2*D2) - 1/D2)*(D3-D0)*dD2 + 2*F2*D2*(dA3*H1[0] + dB3*H1[1] + dC3*H1[2]);
-        dA4 = J(i, 3)+(1/(F2*F2*D2*D2*D2) - 2/D2)*(A3-A[0])*dD2 - (D3-D0)/D2*dA3 - F2*A3*(dA3*H1[0] + dB3*H1[1] + dC3*H1[2]);
-        dB4 = J(i, 4)+(1/(F2*F2*D2*D2*D2) - 2/D2)*(B3-A[1])*dD2 - (D3-D0)/D2*dB3 - F2*B3*(dA3*H1[0] + dB3*H1[1] + dC3*H1[2]);
-        dC4 = J(i, 5)+(1/(F2*F2*D2*D2*D2) - 2/D2)*(C3-A[2])*dD2 - (D3-D0)/D2*dC3 - F2*C3*(dA3*H1[0] + dB3*H1[1] + dC3*H1[2]);
+      dD3 = dD0 + 2 * (1 / (F2 * F2 * D2 * D2 * D2) - 1 / D2) * (D3 - D0) * dD2 + 2 * F2 * D2 * (dA3 * H1[0] + dB3 * H1[1] + dC3 * H1[2]);
+      dA4 = J(i, 3) + (1 / (F2 * F2 * D2 * D2 * D2) - 2 / D2) * (A3 - A[0]) * dD2 - (D3 - D0) / D2 * dA3 - F2 * A3 *
+            (dA3 * H1[0] + dB3 * H1[1] + dC3 * H1[2]);
+      dB4 = J(i, 4) + (1 / (F2 * F2 * D2 * D2 * D2) - 2 / D2) * (B3 - A[1]) * dD2 - (D3 - D0) / D2 * dB3 - F2 * B3 *
+            (dA3 * H1[0] + dB3 * H1[1] + dC3 * H1[2]);
+      dC4 = J(i, 5) + (1 / (F2 * F2 * D2 * D2 * D2) - 2 / D2) * (C3 - A[2]) * dD2 - (D3 - D0) / D2 * dC3 - F2 * C3 *
+            (dA3 * H1[0] + dB3 * H1[1] + dC3 * H1[2]);
 
-        //last point
-        dA5 = dA4+dA4-J(i, 3);      // }
-        dB5 = dB4+dB4-J(i, 4);      //  } =  2*(dA4, dB4, dC4) - dA
-        dC5 = dC4+dC4-J(i, 5);      // }
+      //last point
+      dA5 = dA4 + dA4 - J(i, 3);  // }
+      dB5 = dB4 + dB4 - J(i, 4);  //  } =  2*(dA4, dB4, dC4) - dA
+      dC5 = dC4 + dC4 - J(i, 5);  // }
 
-        dD4 = -dD0+(1/(F3*F3*D3*D3*D3) - 1/D3)*(D4+D0)*dD3 + F3*D3*(dA5*H2[0] + dB5*H2[1] + dC5*H2[2]);
-        dA6 = (1/(F3*F3*D3*D3*D3) - 2/D3)*(A4-A[0])*dD3 - (D4+D0)/D3*dA5 - F3*A5*(dA5*H2[0] + dB5*H2[1] + dC5*H2[2]);
-        dB6 = (1/(F3*F3*D3*D3*D3) - 2/D3)*(B4-A[1])*dD3 - (D4+D0)/D3*dB5 - F3*B5*(dA5*H2[0] + dB5*H2[1] + dC5*H2[2]);
-        dC6 = (1/(F3*F3*D3*D3*D3) - 2/D3)*(C4-A[2])*dD3 - (D4+D0)/D3*dC5 - F3*C5*(dA5*H2[0] + dB5*H2[1] + dC5*H2[2]);
+      dD4 = -dD0 + (1 / (F3 * F3 * D3 * D3 * D3) - 1 / D3) * (D4 + D0) * dD3 + F3 * D3 * (dA5 * H2[0] + dB5 * H2[1] + dC5 * H2[2]);
+      dA6 = (1 / (F3 * F3 * D3 * D3 * D3) - 2 / D3) * (A4 - A[0]) * dD3 - (D4 + D0) / D3 * dA5 - F3 * A5 *
+            (dA5 * H2[0] + dB5 * H2[1] + dC5 * H2[2]);
+      dB6 = (1 / (F3 * F3 * D3 * D3 * D3) - 2 / D3) * (B4 - A[1]) * dD3 - (D4 + D0) / D3 * dB5 - F3 * B5 *
+            (dA5 * H2[0] + dB5 * H2[1] + dC5 * H2[2]);
+      dC6 = (1 / (F3 * F3 * D3 * D3 * D3) - 2 / D3) * (C4 - A[2]) * dD3 - (D4 + D0) / D3 * dC5 - F3 * C5 *
+            (dA5 * H2[0] + dB5 * H2[1] + dC5 * H2[2]);
 
-        // this gives the same results as multiplying the old with the new Jacobian
-        J(i, 0) += (dA2+dA3+dA4)*S3;  J(i, 3) = ((dA0+2.*dA3)+(dA5+dA6))*P3; // dR := dR + S3*[(dA2, dB2, dC2) +   (dA3, dB3, dC3) + (dA4, dB4, dC4)]
-        J(i, 1) += (dB2+dB3+dB4)*S3;  J(i, 4) = ((dB0+2.*dB3)+(dB5+dB6))*P3; // dA :=     1/3*[(dA0, dB0, dC0) + 2*(dA3, dB3, dC3) + (dA5, dB5, dC5) + (dA6, dB6, dC6)]
-        J(i, 2) += (dC2+dC3+dC4)*S3;  J(i, 5) = ((dC0+2.*dC3)+(dC5+dC6))*P3;
-        J(i,6) = -m_magCharge*sign/D5/D5*P3*(dD1 + 2*dD2 + dD3 + dD4);
-      }
+      // this gives the same results as multiplying the old with the new Jacobian
+      J(i, 0) += (dA2 + dA3 + dA4) * S3;
+      J(i, 3) = ((dA0 + 2.*dA3) + (dA5 + dA6)) * P3; // dR := dR + S3*[(dA2, dB2, dC2) +   (dA3, dB3, dC3) + (dA4, dB4, dC4)]
+      J(i, 1) += (dB2 + dB3 + dB4) * S3;
+      J(i, 4) = ((dB0 + 2.*dB3) + (dB5 + dB6)) * P3; // dA :=     1/3*[(dA0, dB0, dC0) + 2*(dA3, dB3, dC3) + (dA5, dB5, dC5) + (dA6, dB6, dC6)]
+      J(i, 2) += (dC2 + dC3 + dC4) * S3;  J(i, 5) = ((dC0 + 2.*dC3) + (dC5 + dC6)) * P3;
+      J(i, 6) = -m_magCharge * sign / D5 / D5 * P3 * (dD1 + 2 * dD2 + dD3 + dD4);
+    }
 
 //     } // end if (!calcOnlyLastRowOfJ)
 
@@ -233,48 +248,51 @@ double MplTrackRep::RKPropagate(M1x7& state7,
   //
   // Track parameters in last point
   //
-  R[0] += (A2+A3+A4)*S3;   A[0] += (SA[0]=((A0+2.*A3)+(A5+A6))*P3-A[0]);  // R  = R0 + S3*[(A2, B2, C2) +   (A3, B3, C3) + (A4, B4, C4)]
-  R[1] += (B2+B3+B4)*S3;   A[1] += (SA[1]=((B0+2.*B3)+(B5+B6))*P3-A[1]);  // A  =     1/3*[(A0, B0, C0) + 2*(A3, B3, C3) + (A5, B5, C5) + (A6, B6, C6)]
-  R[2] += (C2+C3+C4)*S3;   A[2] += (SA[2]=((C0+2.*C3)+(C5+C6))*P3-A[2]);  // SA = A_new - A_old
+  R[0] += (A2 + A3 + A4) * S3;
+  A[0] += (SA[0] = ((A0 + 2.*A3) + (A5 + A6)) * P3 - A[0]); // R  = R0 + S3*[(A2, B2, C2) +   (A3, B3, C3) + (A4, B4, C4)]
+  R[1] += (B2 + B3 + B4) * S3;
+  A[1] += (SA[1] = ((B0 + 2.*B3) + (B5 + B6)) * P3 - A[1]); // A  =     1/3*[(A0, B0, C0) + 2*(A3, B3, C3) + (A5, B5, C5) + (A6, B6, C6)]
+  R[2] += (C2 + C3 + C4) * S3;   A[2] += (SA[2] = ((C0 + 2.*C3) + (C5 + C6)) * P3 - A[2]); // SA = A_new - A_old
   state7[6] = m_magCharge * sign / D5; // g / p_n+1
 
   // normalize A
-  double CBA ( 1./sqrt(A[0]*A[0]+A[1]*A[1]+A[2]*A[2]) ); // 1/|A|
+  double CBA(1. / sqrt(A[0]*A[0] + A[1]*A[1] + A[2]*A[2])); // 1/|A|
   A[0] *= CBA; A[1] *= CBA; A[2] *= CBA;
 
 
   // Test approximation quality on given step
-  double EST ( fabs((A1+A6)-(A3+A4)) +
-               fabs((B1+B6)-(B3+B4)) +
-               fabs((C1+C6)-(C3+C4))  );  // EST = ||(ABC1+ABC6)-(ABC3+ABC4)||_1  =  ||(axzy x H0 + ABC5 x H2) - (ABC2 x H1 + ABC3 x H1)||_1
+  double EST(fabs((A1 + A6) - (A3 + A4)) +
+             fabs((B1 + B6) - (B3 + B4)) +
+             fabs((C1 + C6) - (C3 + C4))); // EST = ||(ABC1+ABC6)-(ABC3+ABC4)||_1  =  ||(axzy x H0 + ABC5 x H2) - (ABC2 x H1 + ABC3 x H1)||_1
   if (debugLvl_ > 0) {
-    debugOut << "    RKTrackRep::RKPropagate. Step = "<< S << "; quality EST = " << EST  << " \n";
+    debugOut << "    RKTrackRep::RKPropagate. Step = " << S << "; quality EST = " << EST  << " \n";
   }
 
   // Prevent the step length increase from getting too large, this is
   // just the point where it becomes 10.
-  if (EST < DLT*1e-5)
+  if (EST < DLT * 1e-5)
     return 10;
 
   // Step length increase for a fifth order Runge-Kutta, see e.g. 17.2
   // in Numerical Recipes.  FIXME: move to caller.
-  return pow(DLT/EST, 1./5.);
+  return pow(DLT / EST, 1. / 5.);
 }
 
-void MplTrackRep::Streamer(TBuffer &R__b)
+void MplTrackRep::Streamer(TBuffer& R__b)
 {
-   // I guess I have to reimplement this since it can not be taken from RKTrackRep?
-   typedef ::genfit::MplTrackRep thisClass;
-   UInt_t R__s, R__c;
-   if (R__b.IsReading()) {
-      ::genfit::AbsTrackRep::Streamer(R__b);
-      Version_t R__v = R__b.ReadVersion(&R__s, &R__c); if (R__v) { }
-      R__b.CheckByteCount(R__s, R__c, thisClass::IsA());
-      lastStartState_.setRep(this);
-      lastEndState_.setRep(this);
-   } else {
-      ::genfit::AbsTrackRep::Streamer(R__b);
-      R__c = R__b.WriteVersion(thisClass::IsA(), kTRUE);
-      R__b.SetByteCount(R__c, kTRUE);
-   }
+  // I guess I have to reimplement this since it can not be taken from RKTrackRep?
+  typedef ::genfit::MplTrackRep thisClass;
+  UInt_t R__s, R__c;
+  if (R__b.IsReading()) {
+    ::genfit::AbsTrackRep::Streamer(R__b);
+    Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+    if (R__v) { }
+    R__b.CheckByteCount(R__s, R__c, thisClass::IsA());
+    lastStartState_.setRep(this);
+    lastEndState_.setRep(this);
+  } else {
+    ::genfit::AbsTrackRep::Streamer(R__b);
+    R__c = R__b.WriteVersion(thisClass::IsA(), kTRUE);
+    R__b.SetByteCount(R__c, kTRUE);
+  }
 }

--- a/trackReps/src/RKTools.cc
+++ b/trackReps/src/RKTools.cc
@@ -28,484 +28,596 @@
 namespace genfit {
 
 
-void RKTools::J_pMTxcov5xJ_pM(const M5x7& J_pM, const M5x5& cov5, M7x7& out7){
-  // 5D -> 7D
-
-  // J_pM
-  // 0 0 0 0 0 0 1
-  // 0 0 0 x x x 0
-  // 0 0 0 x x x 0
-  // x x x 0 0 0 0
-  // x x x 0 0 0 0
-
-  // it is assumed that J_pM is only non-zero here:
-  // [6] = 1
-
-  // [1*7+3]
-  // [1*7+4]
-  // [1*7+5]
-
-  // [2*7+3]
-  // [2*7+4]
-  // [2*7+5]
-
-  // [3*7+0]
-  // [3*7+1]
-  // [3*7+2]
-
-  // [4*7+0]
-  // [4*7+1]
-  // [4*7+2]
-
-  double JTC0  = J_pM[21] * cov5[18] + J_pM[28] * cov5[23];
-  double JTC1  = J_pM[21] * cov5[23] + J_pM[28] * cov5[24];
-  double JTC2  = J_pM[21] * cov5[16] + J_pM[28] * cov5[21];
-  double JTC3  = J_pM[21] * cov5[17] + J_pM[28] * cov5[22];
-  double JTC4  = J_pM[22] * cov5[18] + J_pM[29] * cov5[23];
-  double JTC5  = J_pM[22] * cov5[23] + J_pM[29] * cov5[24];
-  double JTC6  = J_pM[22] * cov5[16] + J_pM[29] * cov5[21];
-  double JTC7  = J_pM[22] * cov5[17] + J_pM[29] * cov5[22];
-  double JTC8  = J_pM[23] * cov5[18] + J_pM[30] * cov5[23];
-  double JTC9  = J_pM[23] * cov5[23] + J_pM[30] * cov5[24];
-  double JTC10 = J_pM[23] * cov5[16] + J_pM[30] * cov5[21];
-  double JTC11 = J_pM[23] * cov5[17] + J_pM[30] * cov5[22];
-  double JTC12 = J_pM[10] * cov5[6]  + J_pM[17] * cov5[11];
-  double JTC13 = J_pM[10] * cov5[11] + J_pM[17] * cov5[12];
-  double JTC14 = J_pM[11] * cov5[6]  + J_pM[18] * cov5[11];
-  double JTC15 = J_pM[11] * cov5[11] + J_pM[18] * cov5[12];
-
-  // loops are vectorizable by the compiler!
-  for (int i=0; i<3; ++i) out7[i]  = JTC0 * J_pM[21+i] + JTC1 * J_pM[28+i];
-  for (int i=0; i<3; ++i) out7[3+i]  = JTC2 * J_pM[10+i] + JTC3 * J_pM[17+i];
-  out7[6]  =  J_pM[21] * cov5[15] + J_pM[28] * cov5[20];
-
-  for (int i=0; i<2; ++i) out7[8+i]  = JTC4 * J_pM[22+i] + JTC5 * J_pM[29+i];
-  for (int i=0; i<3; ++i) out7[10+i] = JTC6 * J_pM[10+i] + JTC7 * J_pM[17+i];
-  out7[13] = J_pM[22] * cov5[15] + J_pM[29] * cov5[20];
-
-  out7[16] = JTC8 * J_pM[23] + JTC9 * J_pM[30];
-  for (int i=0; i<3; ++i) out7[17+i] = JTC10 * J_pM[10+i] + JTC11 * J_pM[17+i];
-  out7[20] = J_pM[23] * cov5[15] + J_pM[30] * cov5[20];
-
-  for (int i=0; i<3; ++i) out7[24+i] = JTC12 * J_pM[10+i] + JTC13 * J_pM[17+i];
-  out7[27] = J_pM[10] * cov5[5] + J_pM[17] * cov5[10];
-
-  for (int i=0; i<2; ++i) out7[32+i] = JTC14 * J_pM[11+i] + JTC15 * J_pM[18+i];
-  out7[34] = J_pM[11] * cov5[5] + J_pM[18] * cov5[10];
-
-  out7[40] = (J_pM[12] * cov5[6] + J_pM[19] * cov5[11]) * J_pM[12] + (J_pM[12] * cov5[11] + J_pM[19] * cov5[12]) * J_pM[19];
-  out7[41] = J_pM[12] * cov5[5] + J_pM[19] * cov5[10];
-
-  out7[48] = cov5[0];
-
-  // symmetric part
-  out7[7]  = out7[1];
-  out7[14] = out7[2];  out7[15] = out7[9];
-  out7[21] = out7[3];  out7[22] = out7[10];  out7[23] = out7[17];
-  out7[28] = out7[4];  out7[29] = out7[11];  out7[30] = out7[18];  out7[31] = out7[25];
-  out7[35] = out7[5];  out7[36] = out7[12];  out7[37] = out7[19];  out7[38] = out7[26];  out7[39] = out7[33];
-  out7[42] = out7[6];  out7[43] = out7[13];  out7[44] = out7[20];  out7[45] = out7[27];  out7[46] = out7[34];  out7[47] = out7[41];
-
-}
-
-
-void RKTools::J_pMTxcov5xJ_pM(const M5x6& J_pM, const M5x5& cov5, M6x6& out6){
-  // 5D -> 6D
-
-  // J_pM
-  // 0 0 0 x x x
-  // 0 0 0 x x x
-  // 0 0 0 x x x
-  // x x x 0 0 0
-  // x x x 0 0 0
-
-  // it is assumed that J_pM is only non-zero here:
-  // [3]
-  // [4]
-  // [5]
-
-  // [1*6+3]
-  // [1*6+4]
-  // [1*6+5]
-
-  // [2*6+3]
-  // [2*6+4]
-  // [2*6+5]
-
-  // [3*6+0]
-  // [3*6+1]
-  // [3*6+2]
-
-  // [4*6+0]
-  // [4*6+1]
-  // [4*6+2]
-
-  double JTC0  = J_pM[18] * cov5[15+3] + J_pM[24] * cov5[20+3];
-  double JTC1  = J_pM[18] * cov5[20+3] + J_pM[24] * cov5[20+4];
-  double JTC2  = J_pM[18] * cov5[15] + J_pM[24] * cov5[20];
-  double JTC3  = J_pM[18] * cov5[15+1] + J_pM[24] * cov5[20+1];
-  double JTC4  = J_pM[18] * cov5[15+2] + J_pM[24] * cov5[20+2];
-  double JTC5  = J_pM[18+1] * cov5[15+3] + J_pM[24+1] * cov5[20+3];
-  double JTC6  = J_pM[18+1] * cov5[20+3] + J_pM[24+1] * cov5[20+4];
-  double JTC7  = J_pM[18+1] * cov5[15] + J_pM[24+1] * cov5[20];
-  double JTC8  = J_pM[18+1] * cov5[15+1] + J_pM[24+1] * cov5[20+1];
-  double JTC9  = J_pM[18+1] * cov5[15+2] + J_pM[24+1] * cov5[20+2];
-  double JTC10 = J_pM[18+2] * cov5[15] + J_pM[24+2] * cov5[20];
-  double JTC11 = J_pM[18+2] * cov5[15+1] + J_pM[24+2] * cov5[20+1];
-  double JTC12 = J_pM[18+2] * cov5[15+2] + J_pM[24+2] * cov5[20+2];
-  double JTC13 = J_pM[3] * cov5[0*5] + J_pM[6+3] * cov5[5] + J_pM[12+3] * cov5[10];
-  double JTC14 = J_pM[3] * cov5[5] + J_pM[6+3] * cov5[5+1] + J_pM[12+3] * cov5[10+1];
-  double JTC15 = J_pM[3] * cov5[10] + J_pM[6+3] * cov5[10+1] + J_pM[12+3] * cov5[10+2];
-  double JTC16 = J_pM[4] * cov5[0*5] + J_pM[6+4] * cov5[5] + J_pM[12+4] * cov5[10];
-  double JTC17 = J_pM[4] * cov5[5] + J_pM[6+4] * cov5[5+1] + J_pM[12+4] * cov5[10+1];
-  double JTC18 = J_pM[4] * cov5[10] + J_pM[6+4] * cov5[10+1] + J_pM[12+4] * cov5[10+2];
-
-  // loops are vectorizable by the compiler!
-  for (int i=0; i<3; ++i) out6[i] = JTC0 * J_pM[18+i] + JTC1 * J_pM[24+i];
-  for (int i=0; i<3; ++i) out6[3+i] = JTC2 * J_pM[3+i] + JTC3 * J_pM[9+i] + JTC4 * J_pM[15+i];
-
-  for (int i=0; i<2; ++i) out6[7+i] = JTC5 * J_pM[19+i] + JTC6 * J_pM[25+i];
-  for (int i=0; i<3; ++i) out6[9+i] = JTC7 * J_pM[3+i] + JTC8 * J_pM[9+i] + JTC9 * J_pM[15+i];
-
-  out6[12+2] = (J_pM[18+2] * cov5[15+3] + J_pM[24+2] * cov5[20+3]) * J_pM[18+2] + (J_pM[18+2] * cov5[20+3] + J_pM[24+2] * cov5[20+4]) * J_pM[24+2];
-  for (int i=0; i<3; ++i) out6[15+i] = JTC10 * J_pM[3+i] + JTC11 * J_pM[9+i] + JTC12 * J_pM[15+i];
-
-  for (int i=0; i<3; ++i) out6[21+i] = JTC13 * J_pM[3+i] + JTC14 * J_pM[9+i] + JTC15 * J_pM[15+i];
-
-  for (int i=0; i<3; ++i) out6[28+i] = JTC16 * J_pM[4+i] + JTC17 * J_pM[10+i] + JTC18 * J_pM[16+i];
-
-  out6[30+5] = (J_pM[5] * cov5[0*5] + J_pM[6+5] * cov5[5] + J_pM[12+5] * cov5[10]) * J_pM[5] + (J_pM[5] * cov5[5] + J_pM[6+5] * cov5[5+1] + J_pM[12+5] * cov5[10+1]) * J_pM[6+5] + (J_pM[5] * cov5[10] + J_pM[6+5] * cov5[10+1] + J_pM[12+5] * cov5[10+2]) * J_pM[12+5];
-
-  // symmetric part
-  out6[6] = out6[1];
-  out6[12] = out6[2];  out6[12+1] = out6[6+2];
-  out6[18] = out6[3];  out6[18+1] = out6[6+3];  out6[18+2] = out6[12+3];
-  out6[24] = out6[4];  out6[24+1] = out6[6+4];  out6[24+2] = out6[12+4];  out6[24+3] = out6[18+4];
-  out6[30] = out6[5];  out6[30+1] = out6[6+5];  out6[30+2] = out6[12+5];  out6[30+3] = out6[18+5];  out6[30+4] = out6[24+5];
-
-}
-
-
-void RKTools::J_MpTxcov7xJ_Mp(const M7x5& J_Mp, const M7x7& cov7, M5x5& out5)
-{
-  // 7D -> 5D
-
-  // J_Mp
-  // 0 0 0 x x
-  // 0 0 0 x x
-  // 0 0 0 x x
-  // 0 x x 0 0
-  // 0 x x 0 0
-  // 0 x x 0 0
-  // 1 0 0 0 0
-
-  // it is assumed that J_Mp is only non-zero here:
-  // [3]
-  // [1*7+3]
-  // [2*7+3]
-
-  // [4]
-  // [1*7+4]
-  // [2*7+4]
-
-  // [3*7+1]
-  // [4*7+1]
-  // [5*7+1]
-
-  // [3*7+2]
-  // [4*7+2]
-  // [5*7+2]
-
-  // [6*7+0] = 1
-
-
-  double JTC0  = (J_Mp[16] * cov7[24] + J_Mp[21] * cov7[31] + J_Mp[26] * cov7[38]);
-  double JTC1  = (J_Mp[16] * cov7[31] + J_Mp[21] * cov7[32] + J_Mp[26] * cov7[39]);
-  double JTC2  = (J_Mp[16] * cov7[38] + J_Mp[21] * cov7[39] + J_Mp[26] * cov7[40]);
-  double JTC3  = (J_Mp[16] * cov7[21] + J_Mp[21] * cov7[28] + J_Mp[26] * cov7[35]);
-  double JTC4  = (J_Mp[16] * cov7[22] + J_Mp[21] * cov7[29] + J_Mp[26] * cov7[36]);
-  double JTC5  = (J_Mp[16] * cov7[23] + J_Mp[21] * cov7[30] + J_Mp[26] * cov7[37]);
-  double JTC6  = (J_Mp[17] * cov7[21] + J_Mp[22] * cov7[28] + J_Mp[27] * cov7[35]);
-  double JTC7  = (J_Mp[17] * cov7[22] + J_Mp[22] * cov7[29] + J_Mp[27] * cov7[36]);
-  double JTC8  = (J_Mp[17] * cov7[23] + J_Mp[22] * cov7[30] + J_Mp[27] * cov7[37]);
-  double JTC9  = (J_Mp[3] * cov7[0] + J_Mp[8] * cov7[7] + J_Mp[13] * cov7[14]);
-  double JTC10 = (J_Mp[3] * cov7[7] + J_Mp[8] * cov7[8] + J_Mp[13] * cov7[15]);
-  double JTC11 = (J_Mp[3] * cov7[14] + J_Mp[8] * cov7[15] + J_Mp[13] * cov7[16]);
-
-  out5[0] = cov7[48];
-  out5[1] = J_Mp[16] * cov7[45] + J_Mp[21] * cov7[46] + J_Mp[26] * cov7[47];
-  out5[2] = J_Mp[17] * cov7[45] + J_Mp[22] * cov7[46] + J_Mp[27] * cov7[47];
-  out5[3] = J_Mp[3] * cov7[42] + J_Mp[8] * cov7[43] + J_Mp[13] * cov7[44];
-  out5[4] = J_Mp[4] * cov7[42] + J_Mp[9] * cov7[43] + J_Mp[14] * cov7[44];
-
-  // loops are vectorizable by the compiler!
-  for (int i=0; i<2; ++i) out5[6+i] = JTC0 * J_Mp[16+i] + JTC1 * J_Mp[21+i] + JTC2 * J_Mp[26+i];
-  for (int i=0; i<2; ++i) out5[8+i] = JTC3 * J_Mp[3+i] + JTC4 * J_Mp[8+i] + JTC5 * J_Mp[13+i];
-
-  out5[12] = (J_Mp[17] * cov7[24] + J_Mp[22] * cov7[31] + J_Mp[27] * cov7[38]) * J_Mp[17] + (J_Mp[17] * cov7[31] + J_Mp[22] * cov7[32] + J_Mp[27] * cov7[39]) * J_Mp[22] + (J_Mp[17] * cov7[38] + J_Mp[22] * cov7[39] + J_Mp[27] * cov7[40]) * J_Mp[27];
-  for (int i=0; i<2; ++i) out5[13+i] = JTC6 * J_Mp[3+i] + JTC7 * J_Mp[8+i] + JTC8 * J_Mp[13+i];
-
-  for (int i=0; i<2; ++i) out5[18+i] = JTC9 * J_Mp[3+i] + JTC10 * J_Mp[8+i] + JTC11 * J_Mp[13+i];
-
-  out5[24] = (J_Mp[4] * cov7[0] + J_Mp[9] * cov7[7] + J_Mp[14] * cov7[14]) * J_Mp[4] + (J_Mp[4] * cov7[7] + J_Mp[9] * cov7[8] + J_Mp[14] * cov7[15]) * J_Mp[9] + (J_Mp[4] * cov7[14] + J_Mp[9] * cov7[15] + J_Mp[14] * cov7[16]) * J_Mp[14];
-
-  // symmetric part
-  out5[5] = out5[1];
-  out5[10] = out5[2];  out5[11] = out5[7];
-  out5[15] = out5[3];  out5[16] = out5[8];  out5[17] = out5[13];
-  out5[20] = out5[4];  out5[21] = out5[9];  out5[22] = out5[14];  out5[23] = out5[19];
-
-}
-
-
-void RKTools::J_MpTxcov6xJ_Mp(const M6x5& J_Mp, const M6x6& cov6, M5x5& out5)
-{
-  // 6D -> 5D
-
-  // J_Mp
-  // 0 0 0 x x
-  // 0 0 0 x x
-  // 0 0 0 x x
-  // x x x 0 0
-  // x x x 0 0
-  // x x x 0 0
-
-  // it is assumed that J_Mp is only non-zero here:
-  // [3]
-  // [1*6+3]
-  // [2*6+3]
-
-  // [4]
-  // [1*6+4]
-  // [2*6+4]
-
-  // [3*6+0]
-  // [4*6+0]
-  // [5*6+0]
-
-  // [3*6+1]
-  // [4*6+1]
-  // [5*6+1]
-
-  // [3*6+2]
-  // [4*6+2]
-  // [5*6+2]
-
-  double JTC0  = (J_Mp[15] * cov6[18+3] + J_Mp[20] * cov6[24+3] + J_Mp[25] * cov6[30+3]);
-  double JTC1  = (J_Mp[15] * cov6[24+3] + J_Mp[20] * cov6[24+4] + J_Mp[25] * cov6[30+4]);
-  double JTC2  = (J_Mp[15] * cov6[30+3] + J_Mp[20] * cov6[30+4] + J_Mp[25] * cov6[30+5]);
-  double JTC3  = (J_Mp[15] * cov6[18] + J_Mp[20] * cov6[24] + J_Mp[25] * cov6[30]);
-  double JTC4  = (J_Mp[15] * cov6[18+1] + J_Mp[20] * cov6[24+1] + J_Mp[25] * cov6[30+1]);
-  double JTC5  = (J_Mp[15] * cov6[18+2] + J_Mp[20] * cov6[24+2] + J_Mp[25] * cov6[30+2]);
-  double JTC6  = (J_Mp[15+1] * cov6[18+3] + J_Mp[20+1] * cov6[24+3] + J_Mp[25+1] * cov6[30+3]);
-  double JTC7  = (J_Mp[15+1] * cov6[24+3] + J_Mp[20+1] * cov6[24+4] + J_Mp[25+1] * cov6[30+4]);
-  double JTC8  = (J_Mp[15+1] * cov6[30+3] + J_Mp[20+1] * cov6[30+4] + J_Mp[25+1] * cov6[30+5]);
-  double JTC9  = (J_Mp[15+1] * cov6[18] + J_Mp[20+1] * cov6[24] + J_Mp[25+1] * cov6[30]);
-  double JTC10 = (J_Mp[15+1] * cov6[18+1] + J_Mp[20+1] * cov6[24+1] + J_Mp[25+1] * cov6[30+1]);
-  double JTC11 = (J_Mp[15+1] * cov6[18+2] + J_Mp[20+1] * cov6[24+2] + J_Mp[25+1] * cov6[30+2]);
-  double JTC12 = (J_Mp[15+2] * cov6[18] + J_Mp[20+2] * cov6[24] + J_Mp[25+2] * cov6[30]);
-  double JTC13 = (J_Mp[15+2] * cov6[18+1] + J_Mp[20+2] * cov6[24+1] + J_Mp[25+2] * cov6[30+1]);
-  double JTC14 = (J_Mp[15+2] * cov6[18+2] + J_Mp[20+2] * cov6[24+2] + J_Mp[25+2] * cov6[30+2]);
-  double JTC15 = (J_Mp[3] * cov6[0] + J_Mp[5+3] * cov6[6] + J_Mp[10+3] * cov6[12]);
-  double JTC16 = (J_Mp[3] * cov6[6] + J_Mp[5+3] * cov6[6+1] + J_Mp[10+3] * cov6[12+1]);
-  double JTC17 = (J_Mp[3] * cov6[12] + J_Mp[5+3] * cov6[12+1] + J_Mp[10+3] * cov6[12+2]);
-
-  // loops are vectorizable by the compiler!
-  for (int i=0; i<3; ++i) out5[i] = JTC0 * J_Mp[15+i] + JTC1 * J_Mp[20+i] + JTC2 * J_Mp[25+i];
-  for (int i=0; i<2; ++i) out5[3+i] = JTC3 * J_Mp[3+i] + JTC4 * J_Mp[8+i] + JTC5 * J_Mp[13+i];
-
-  for (int i=0; i<2; ++i) out5[6+i] = JTC6 * J_Mp[16+i] + JTC7 * J_Mp[21+i] + JTC8 * J_Mp[26+i];
-  for (int i=0; i<2; ++i) out5[8+i] = JTC9 * J_Mp[3+i] + JTC10 * J_Mp[8+i] + JTC11 * J_Mp[13+i];
-
-  out5[10+2] = (J_Mp[15+2] * cov6[18+3] + J_Mp[20+2] * cov6[24+3] + J_Mp[25+2] * cov6[30+3]) * J_Mp[15+2] + (J_Mp[15+2] * cov6[24+3] + J_Mp[20+2] * cov6[24+4] + J_Mp[25+2] * cov6[30+4]) * J_Mp[20+2] + (J_Mp[15+2] * cov6[30+3] + J_Mp[20+2] * cov6[30+4] + J_Mp[25+2] * cov6[30+5]) * J_Mp[25+2];
-  for (int i=0; i<2; ++i) out5[13+i] = JTC12 * J_Mp[3+i] + JTC13 * J_Mp[8+i] + JTC14 * J_Mp[13+i];
-
-  for (int i=0; i<2; ++i) out5[18+i] = JTC15 * J_Mp[3+i] + JTC16 * J_Mp[8+i] + JTC17 * J_Mp[13+i];
-
-  out5[20+4] = (J_Mp[4] * cov6[0] + J_Mp[5+4] * cov6[6] + J_Mp[10+4] * cov6[12]) * J_Mp[4] + (J_Mp[4] * cov6[6] + J_Mp[5+4] * cov6[6+1] + J_Mp[10+4] * cov6[12+1]) * J_Mp[5+4] + (J_Mp[4] * cov6[12] + J_Mp[5+4] * cov6[12+1] + J_Mp[10+4] * cov6[12+2]) * J_Mp[10+4];
-
-  // symmetric part
-  out5[5] = out5[1];
-  out5[10] = out5[2];  out5[10+1] = out5[5+2];
-  out5[15] = out5[3];  out5[15+1] = out5[5+3];  out5[15+2] = out5[10+3];
-  out5[20] = out5[4];  out5[20+1] = out5[5+4];  out5[20+2] = out5[10+4];  out5[20+3] = out5[15+4];
-
-}
-
-void RKTools::J_pMTTxJ_MMTTxJ_MpTT(const M7x5& J_pMT, const M7x7& J_MMT, const M5x7& J_MpT, M5x5& J_pp)
-{
+  void RKTools::J_pMTxcov5xJ_pM(const M5x7& J_pM, const M5x5& cov5, M7x7& out7)
+  {
+    // 5D -> 7D
+
+    // J_pM
+    // 0 0 0 0 0 0 1
+    // 0 0 0 x x x 0
+    // 0 0 0 x x x 0
+    // x x x 0 0 0 0
+    // x x x 0 0 0 0
+
+    // it is assumed that J_pM is only non-zero here:
+    // [6] = 1
+
+    // [1*7+3]
+    // [1*7+4]
+    // [1*7+5]
+
+    // [2*7+3]
+    // [2*7+4]
+    // [2*7+5]
+
+    // [3*7+0]
+    // [3*7+1]
+    // [3*7+2]
+
+    // [4*7+0]
+    // [4*7+1]
+    // [4*7+2]
+
+    double JTC0  = J_pM[21] * cov5[18] + J_pM[28] * cov5[23];
+    double JTC1  = J_pM[21] * cov5[23] + J_pM[28] * cov5[24];
+    double JTC2  = J_pM[21] * cov5[16] + J_pM[28] * cov5[21];
+    double JTC3  = J_pM[21] * cov5[17] + J_pM[28] * cov5[22];
+    double JTC4  = J_pM[22] * cov5[18] + J_pM[29] * cov5[23];
+    double JTC5  = J_pM[22] * cov5[23] + J_pM[29] * cov5[24];
+    double JTC6  = J_pM[22] * cov5[16] + J_pM[29] * cov5[21];
+    double JTC7  = J_pM[22] * cov5[17] + J_pM[29] * cov5[22];
+    double JTC8  = J_pM[23] * cov5[18] + J_pM[30] * cov5[23];
+    double JTC9  = J_pM[23] * cov5[23] + J_pM[30] * cov5[24];
+    double JTC10 = J_pM[23] * cov5[16] + J_pM[30] * cov5[21];
+    double JTC11 = J_pM[23] * cov5[17] + J_pM[30] * cov5[22];
+    double JTC12 = J_pM[10] * cov5[6]  + J_pM[17] * cov5[11];
+    double JTC13 = J_pM[10] * cov5[11] + J_pM[17] * cov5[12];
+    double JTC14 = J_pM[11] * cov5[6]  + J_pM[18] * cov5[11];
+    double JTC15 = J_pM[11] * cov5[11] + J_pM[18] * cov5[12];
+
+    // loops are vectorizable by the compiler!
+    for (int i = 0; i < 3; ++i) out7[i]  = JTC0 * J_pM[21 + i] + JTC1 * J_pM[28 + i];
+    for (int i = 0; i < 3; ++i) out7[3 + i]  = JTC2 * J_pM[10 + i] + JTC3 * J_pM[17 + i];
+    out7[6]  =  J_pM[21] * cov5[15] + J_pM[28] * cov5[20];
+
+    for (int i = 0; i < 2; ++i) out7[8 + i]  = JTC4 * J_pM[22 + i] + JTC5 * J_pM[29 + i];
+    for (int i = 0; i < 3; ++i) out7[10 + i] = JTC6 * J_pM[10 + i] + JTC7 * J_pM[17 + i];
+    out7[13] = J_pM[22] * cov5[15] + J_pM[29] * cov5[20];
+
+    out7[16] = JTC8 * J_pM[23] + JTC9 * J_pM[30];
+    for (int i = 0; i < 3; ++i) out7[17 + i] = JTC10 * J_pM[10 + i] + JTC11 * J_pM[17 + i];
+    out7[20] = J_pM[23] * cov5[15] + J_pM[30] * cov5[20];
+
+    for (int i = 0; i < 3; ++i) out7[24 + i] = JTC12 * J_pM[10 + i] + JTC13 * J_pM[17 + i];
+    out7[27] = J_pM[10] * cov5[5] + J_pM[17] * cov5[10];
+
+    for (int i = 0; i < 2; ++i) out7[32 + i] = JTC14 * J_pM[11 + i] + JTC15 * J_pM[18 + i];
+    out7[34] = J_pM[11] * cov5[5] + J_pM[18] * cov5[10];
+
+    out7[40] = (J_pM[12] * cov5[6] + J_pM[19] * cov5[11]) * J_pM[12] + (J_pM[12] * cov5[11] + J_pM[19] * cov5[12]) * J_pM[19];
+    out7[41] = J_pM[12] * cov5[5] + J_pM[19] * cov5[10];
+
+    out7[48] = cov5[0];
+
+    // symmetric part
+    out7[7]  = out7[1];
+    out7[14] = out7[2];  out7[15] = out7[9];
+    out7[21] = out7[3];  out7[22] = out7[10];  out7[23] = out7[17];
+    out7[28] = out7[4];  out7[29] = out7[11];  out7[30] = out7[18];  out7[31] = out7[25];
+    out7[35] = out7[5];  out7[36] = out7[12];  out7[37] = out7[19];  out7[38] = out7[26];  out7[39] = out7[33];
+    out7[42] = out7[6];  out7[43] = out7[13];  out7[44] = out7[20];  out7[45] = out7[27];  out7[46] = out7[34];  out7[47] = out7[41];
+
+  }
+
+
+  void RKTools::J_pMTxcov5xJ_pM(const M5x6& J_pM, const M5x5& cov5, M6x6& out6)
+  {
+    // 5D -> 6D
+
+    // J_pM
+    // 0 0 0 x x x
+    // 0 0 0 x x x
+    // 0 0 0 x x x
+    // x x x 0 0 0
+    // x x x 0 0 0
+
+    // it is assumed that J_pM is only non-zero here:
+    // [3]
+    // [4]
+    // [5]
+
+    // [1*6+3]
+    // [1*6+4]
+    // [1*6+5]
+
+    // [2*6+3]
+    // [2*6+4]
+    // [2*6+5]
+
+    // [3*6+0]
+    // [3*6+1]
+    // [3*6+2]
+
+    // [4*6+0]
+    // [4*6+1]
+    // [4*6+2]
+
+    double JTC0  = J_pM[18] * cov5[15 + 3] + J_pM[24] * cov5[20 + 3];
+    double JTC1  = J_pM[18] * cov5[20 + 3] + J_pM[24] * cov5[20 + 4];
+    double JTC2  = J_pM[18] * cov5[15] + J_pM[24] * cov5[20];
+    double JTC3  = J_pM[18] * cov5[15 + 1] + J_pM[24] * cov5[20 + 1];
+    double JTC4  = J_pM[18] * cov5[15 + 2] + J_pM[24] * cov5[20 + 2];
+    double JTC5  = J_pM[18 + 1] * cov5[15 + 3] + J_pM[24 + 1] * cov5[20 + 3];
+    double JTC6  = J_pM[18 + 1] * cov5[20 + 3] + J_pM[24 + 1] * cov5[20 + 4];
+    double JTC7  = J_pM[18 + 1] * cov5[15] + J_pM[24 + 1] * cov5[20];
+    double JTC8  = J_pM[18 + 1] * cov5[15 + 1] + J_pM[24 + 1] * cov5[20 + 1];
+    double JTC9  = J_pM[18 + 1] * cov5[15 + 2] + J_pM[24 + 1] * cov5[20 + 2];
+    double JTC10 = J_pM[18 + 2] * cov5[15] + J_pM[24 + 2] * cov5[20];
+    double JTC11 = J_pM[18 + 2] * cov5[15 + 1] + J_pM[24 + 2] * cov5[20 + 1];
+    double JTC12 = J_pM[18 + 2] * cov5[15 + 2] + J_pM[24 + 2] * cov5[20 + 2];
+    double JTC13 = J_pM[3] * cov5[0 * 5] + J_pM[6 + 3] * cov5[5] + J_pM[12 + 3] * cov5[10];
+    double JTC14 = J_pM[3] * cov5[5] + J_pM[6 + 3] * cov5[5 + 1] + J_pM[12 + 3] * cov5[10 + 1];
+    double JTC15 = J_pM[3] * cov5[10] + J_pM[6 + 3] * cov5[10 + 1] + J_pM[12 + 3] * cov5[10 + 2];
+    double JTC16 = J_pM[4] * cov5[0 * 5] + J_pM[6 + 4] * cov5[5] + J_pM[12 + 4] * cov5[10];
+    double JTC17 = J_pM[4] * cov5[5] + J_pM[6 + 4] * cov5[5 + 1] + J_pM[12 + 4] * cov5[10 + 1];
+    double JTC18 = J_pM[4] * cov5[10] + J_pM[6 + 4] * cov5[10 + 1] + J_pM[12 + 4] * cov5[10 + 2];
+
+    // loops are vectorizable by the compiler!
+    for (int i = 0; i < 3; ++i) out6[i] = JTC0 * J_pM[18 + i] + JTC1 * J_pM[24 + i];
+    for (int i = 0; i < 3; ++i) out6[3 + i] = JTC2 * J_pM[3 + i] + JTC3 * J_pM[9 + i] + JTC4 * J_pM[15 + i];
+
+    for (int i = 0; i < 2; ++i) out6[7 + i] = JTC5 * J_pM[19 + i] + JTC6 * J_pM[25 + i];
+    for (int i = 0; i < 3; ++i) out6[9 + i] = JTC7 * J_pM[3 + i] + JTC8 * J_pM[9 + i] + JTC9 * J_pM[15 + i];
+
+    out6[12 + 2] = (J_pM[18 + 2] * cov5[15 + 3] + J_pM[24 + 2] * cov5[20 + 3]) * J_pM[18 + 2] + (J_pM[18 + 2] * cov5[20 + 3] + J_pM[24 +
+                   2] * cov5[20 + 4]) * J_pM[24 + 2];
+    for (int i = 0; i < 3; ++i) out6[15 + i] = JTC10 * J_pM[3 + i] + JTC11 * J_pM[9 + i] + JTC12 * J_pM[15 + i];
+
+    for (int i = 0; i < 3; ++i) out6[21 + i] = JTC13 * J_pM[3 + i] + JTC14 * J_pM[9 + i] + JTC15 * J_pM[15 + i];
+
+    for (int i = 0; i < 3; ++i) out6[28 + i] = JTC16 * J_pM[4 + i] + JTC17 * J_pM[10 + i] + JTC18 * J_pM[16 + i];
+
+    out6[30 + 5] = (J_pM[5] * cov5[0 * 5] + J_pM[6 + 5] * cov5[5] + J_pM[12 + 5] * cov5[10]) * J_pM[5] +
+                   (J_pM[5] * cov5[5] + J_pM[6 + 5] * cov5[5 + 1] + J_pM[12 + 5] * cov5[10 + 1]) * J_pM[6 + 5] +
+                   (J_pM[5] * cov5[10] + J_pM[6 + 5] * cov5[10 + 1] + J_pM[12 + 5] * cov5[10 + 2]) * J_pM[12 + 5];
+
+    // symmetric part
+    out6[6] = out6[1];
+    out6[12] = out6[2];  out6[12 + 1] = out6[6 + 2];
+    out6[18] = out6[3];  out6[18 + 1] = out6[6 + 3];  out6[18 + 2] = out6[12 + 3];
+    out6[24] = out6[4];  out6[24 + 1] = out6[6 + 4];  out6[24 + 2] = out6[12 + 4];  out6[24 + 3] = out6[18 + 4];
+    out6[30] = out6[5];  out6[30 + 1] = out6[6 + 5];  out6[30 + 2] = out6[12 + 5];  out6[30 + 3] = out6[18 + 5];
+    out6[30 + 4] = out6[24 + 5];
+
+  }
+
+
+  void RKTools::J_MpTxcov7xJ_Mp(const M7x5& J_Mp, const M7x7& cov7, M5x5& out5)
+  {
+    // 7D -> 5D
+
+    // J_Mp
+    // 0 0 0 x x
+    // 0 0 0 x x
+    // 0 0 0 x x
+    // 0 x x 0 0
+    // 0 x x 0 0
+    // 0 x x 0 0
+    // 1 0 0 0 0
+
+    // it is assumed that J_Mp is only non-zero here:
+    // [3]
+    // [1*7+3]
+    // [2*7+3]
+
+    // [4]
+    // [1*7+4]
+    // [2*7+4]
+
+    // [3*7+1]
+    // [4*7+1]
+    // [5*7+1]
+
+    // [3*7+2]
+    // [4*7+2]
+    // [5*7+2]
+
+    // [6*7+0] = 1
+
+
+    double JTC0  = (J_Mp[16] * cov7[24] + J_Mp[21] * cov7[31] + J_Mp[26] * cov7[38]);
+    double JTC1  = (J_Mp[16] * cov7[31] + J_Mp[21] * cov7[32] + J_Mp[26] * cov7[39]);
+    double JTC2  = (J_Mp[16] * cov7[38] + J_Mp[21] * cov7[39] + J_Mp[26] * cov7[40]);
+    double JTC3  = (J_Mp[16] * cov7[21] + J_Mp[21] * cov7[28] + J_Mp[26] * cov7[35]);
+    double JTC4  = (J_Mp[16] * cov7[22] + J_Mp[21] * cov7[29] + J_Mp[26] * cov7[36]);
+    double JTC5  = (J_Mp[16] * cov7[23] + J_Mp[21] * cov7[30] + J_Mp[26] * cov7[37]);
+    double JTC6  = (J_Mp[17] * cov7[21] + J_Mp[22] * cov7[28] + J_Mp[27] * cov7[35]);
+    double JTC7  = (J_Mp[17] * cov7[22] + J_Mp[22] * cov7[29] + J_Mp[27] * cov7[36]);
+    double JTC8  = (J_Mp[17] * cov7[23] + J_Mp[22] * cov7[30] + J_Mp[27] * cov7[37]);
+    double JTC9  = (J_Mp[3] * cov7[0] + J_Mp[8] * cov7[7] + J_Mp[13] * cov7[14]);
+    double JTC10 = (J_Mp[3] * cov7[7] + J_Mp[8] * cov7[8] + J_Mp[13] * cov7[15]);
+    double JTC11 = (J_Mp[3] * cov7[14] + J_Mp[8] * cov7[15] + J_Mp[13] * cov7[16]);
+
+    out5[0] = cov7[48];
+    out5[1] = J_Mp[16] * cov7[45] + J_Mp[21] * cov7[46] + J_Mp[26] * cov7[47];
+    out5[2] = J_Mp[17] * cov7[45] + J_Mp[22] * cov7[46] + J_Mp[27] * cov7[47];
+    out5[3] = J_Mp[3] * cov7[42] + J_Mp[8] * cov7[43] + J_Mp[13] * cov7[44];
+    out5[4] = J_Mp[4] * cov7[42] + J_Mp[9] * cov7[43] + J_Mp[14] * cov7[44];
+
+    // loops are vectorizable by the compiler!
+    for (int i = 0; i < 2; ++i) out5[6 + i] = JTC0 * J_Mp[16 + i] + JTC1 * J_Mp[21 + i] + JTC2 * J_Mp[26 + i];
+    for (int i = 0; i < 2; ++i) out5[8 + i] = JTC3 * J_Mp[3 + i] + JTC4 * J_Mp[8 + i] + JTC5 * J_Mp[13 + i];
+
+    out5[12] = (J_Mp[17] * cov7[24] + J_Mp[22] * cov7[31] + J_Mp[27] * cov7[38]) * J_Mp[17] + (J_Mp[17] * cov7[31] + J_Mp[22] * cov7[32]
+               + J_Mp[27] * cov7[39]) * J_Mp[22] + (J_Mp[17] * cov7[38] + J_Mp[22] * cov7[39] + J_Mp[27] * cov7[40]) * J_Mp[27];
+    for (int i = 0; i < 2; ++i) out5[13 + i] = JTC6 * J_Mp[3 + i] + JTC7 * J_Mp[8 + i] + JTC8 * J_Mp[13 + i];
+
+    for (int i = 0; i < 2; ++i) out5[18 + i] = JTC9 * J_Mp[3 + i] + JTC10 * J_Mp[8 + i] + JTC11 * J_Mp[13 + i];
+
+    out5[24] = (J_Mp[4] * cov7[0] + J_Mp[9] * cov7[7] + J_Mp[14] * cov7[14]) * J_Mp[4] + (J_Mp[4] * cov7[7] + J_Mp[9] * cov7[8] +
+               J_Mp[14] * cov7[15]) * J_Mp[9] + (J_Mp[4] * cov7[14] + J_Mp[9] * cov7[15] + J_Mp[14] * cov7[16]) * J_Mp[14];
+
+    // symmetric part
+    out5[5] = out5[1];
+    out5[10] = out5[2];  out5[11] = out5[7];
+    out5[15] = out5[3];  out5[16] = out5[8];  out5[17] = out5[13];
+    out5[20] = out5[4];  out5[21] = out5[9];  out5[22] = out5[14];  out5[23] = out5[19];
+
+  }
+
+
+  void RKTools::J_MpTxcov6xJ_Mp(const M6x5& J_Mp, const M6x6& cov6, M5x5& out5)
+  {
+    // 6D -> 5D
+
+    // J_Mp
+    // 0 0 0 x x
+    // 0 0 0 x x
+    // 0 0 0 x x
+    // x x x 0 0
+    // x x x 0 0
+    // x x x 0 0
+
+    // it is assumed that J_Mp is only non-zero here:
+    // [3]
+    // [1*6+3]
+    // [2*6+3]
+
+    // [4]
+    // [1*6+4]
+    // [2*6+4]
+
+    // [3*6+0]
+    // [4*6+0]
+    // [5*6+0]
+
+    // [3*6+1]
+    // [4*6+1]
+    // [5*6+1]
+
+    // [3*6+2]
+    // [4*6+2]
+    // [5*6+2]
+
+    double JTC0  = (J_Mp[15] * cov6[18 + 3] + J_Mp[20] * cov6[24 + 3] + J_Mp[25] * cov6[30 + 3]);
+    double JTC1  = (J_Mp[15] * cov6[24 + 3] + J_Mp[20] * cov6[24 + 4] + J_Mp[25] * cov6[30 + 4]);
+    double JTC2  = (J_Mp[15] * cov6[30 + 3] + J_Mp[20] * cov6[30 + 4] + J_Mp[25] * cov6[30 + 5]);
+    double JTC3  = (J_Mp[15] * cov6[18] + J_Mp[20] * cov6[24] + J_Mp[25] * cov6[30]);
+    double JTC4  = (J_Mp[15] * cov6[18 + 1] + J_Mp[20] * cov6[24 + 1] + J_Mp[25] * cov6[30 + 1]);
+    double JTC5  = (J_Mp[15] * cov6[18 + 2] + J_Mp[20] * cov6[24 + 2] + J_Mp[25] * cov6[30 + 2]);
+    double JTC6  = (J_Mp[15 + 1] * cov6[18 + 3] + J_Mp[20 + 1] * cov6[24 + 3] + J_Mp[25 + 1] * cov6[30 + 3]);
+    double JTC7  = (J_Mp[15 + 1] * cov6[24 + 3] + J_Mp[20 + 1] * cov6[24 + 4] + J_Mp[25 + 1] * cov6[30 + 4]);
+    double JTC8  = (J_Mp[15 + 1] * cov6[30 + 3] + J_Mp[20 + 1] * cov6[30 + 4] + J_Mp[25 + 1] * cov6[30 + 5]);
+    double JTC9  = (J_Mp[15 + 1] * cov6[18] + J_Mp[20 + 1] * cov6[24] + J_Mp[25 + 1] * cov6[30]);
+    double JTC10 = (J_Mp[15 + 1] * cov6[18 + 1] + J_Mp[20 + 1] * cov6[24 + 1] + J_Mp[25 + 1] * cov6[30 + 1]);
+    double JTC11 = (J_Mp[15 + 1] * cov6[18 + 2] + J_Mp[20 + 1] * cov6[24 + 2] + J_Mp[25 + 1] * cov6[30 + 2]);
+    double JTC12 = (J_Mp[15 + 2] * cov6[18] + J_Mp[20 + 2] * cov6[24] + J_Mp[25 + 2] * cov6[30]);
+    double JTC13 = (J_Mp[15 + 2] * cov6[18 + 1] + J_Mp[20 + 2] * cov6[24 + 1] + J_Mp[25 + 2] * cov6[30 + 1]);
+    double JTC14 = (J_Mp[15 + 2] * cov6[18 + 2] + J_Mp[20 + 2] * cov6[24 + 2] + J_Mp[25 + 2] * cov6[30 + 2]);
+    double JTC15 = (J_Mp[3] * cov6[0] + J_Mp[5 + 3] * cov6[6] + J_Mp[10 + 3] * cov6[12]);
+    double JTC16 = (J_Mp[3] * cov6[6] + J_Mp[5 + 3] * cov6[6 + 1] + J_Mp[10 + 3] * cov6[12 + 1]);
+    double JTC17 = (J_Mp[3] * cov6[12] + J_Mp[5 + 3] * cov6[12 + 1] + J_Mp[10 + 3] * cov6[12 + 2]);
+
+    // loops are vectorizable by the compiler!
+    for (int i = 0; i < 3; ++i) out5[i] = JTC0 * J_Mp[15 + i] + JTC1 * J_Mp[20 + i] + JTC2 * J_Mp[25 + i];
+    for (int i = 0; i < 2; ++i) out5[3 + i] = JTC3 * J_Mp[3 + i] + JTC4 * J_Mp[8 + i] + JTC5 * J_Mp[13 + i];
+
+    for (int i = 0; i < 2; ++i) out5[6 + i] = JTC6 * J_Mp[16 + i] + JTC7 * J_Mp[21 + i] + JTC8 * J_Mp[26 + i];
+    for (int i = 0; i < 2; ++i) out5[8 + i] = JTC9 * J_Mp[3 + i] + JTC10 * J_Mp[8 + i] + JTC11 * J_Mp[13 + i];
+
+    out5[10 + 2] = (J_Mp[15 + 2] * cov6[18 + 3] + J_Mp[20 + 2] * cov6[24 + 3] + J_Mp[25 + 2] * cov6[30 + 3]) * J_Mp[15 + 2] +
+                   (J_Mp[15 + 2] * cov6[24 + 3] + J_Mp[20 + 2] * cov6[24 + 4] + J_Mp[25 + 2] * cov6[30 + 4]) * J_Mp[20 + 2] +
+                   (J_Mp[15 + 2] * cov6[30 + 3] + J_Mp[20 + 2] * cov6[30 + 4] + J_Mp[25 + 2] * cov6[30 + 5]) * J_Mp[25 + 2];
+    for (int i = 0; i < 2; ++i) out5[13 + i] = JTC12 * J_Mp[3 + i] + JTC13 * J_Mp[8 + i] + JTC14 * J_Mp[13 + i];
+
+    for (int i = 0; i < 2; ++i) out5[18 + i] = JTC15 * J_Mp[3 + i] + JTC16 * J_Mp[8 + i] + JTC17 * J_Mp[13 + i];
+
+    out5[20 + 4] = (J_Mp[4] * cov6[0] + J_Mp[5 + 4] * cov6[6] + J_Mp[10 + 4] * cov6[12]) * J_Mp[4] +
+                   (J_Mp[4] * cov6[6] + J_Mp[5 + 4] * cov6[6 + 1] + J_Mp[10 + 4] * cov6[12 + 1]) * J_Mp[5 + 4] +
+                   (J_Mp[4] * cov6[12] + J_Mp[5 + 4] * cov6[12 + 1] + J_Mp[10 + 4] * cov6[12 + 2]) * J_Mp[10 + 4];
+
+    // symmetric part
+    out5[5] = out5[1];
+    out5[10] = out5[2];  out5[10 + 1] = out5[5 + 2];
+    out5[15] = out5[3];  out5[15 + 1] = out5[5 + 3];  out5[15 + 2] = out5[10 + 3];
+    out5[20] = out5[4];  out5[20 + 1] = out5[5 + 4];  out5[20 + 2] = out5[10 + 4];  out5[20 + 3] = out5[15 + 4];
+
+  }
+
+  void RKTools::J_pMTTxJ_MMTTxJ_MpTT(const M7x5& J_pMT, const M7x7& J_MMT, const M5x7& J_MpT, M5x5& J_pp)
+  {
     // calculates  J_pp = J_pM * J_MM * J_Mp
     // input J_MMT is transposed version of actual jacobian J_MM
     // input J_pMT is transposed version of actual jacobian J_pM (Master to plane)
     // input J_MpT is transposed version of actual jacobian J_Mp (plane to Master)
 
-  // J_pMT
-  // 0 0 0 x x
-  // 0 0 0 x x
-  // 0 0 0 x x
-  // 0 x x 0 0
-  // 0 x x 0 0
-  // 0 x x 0 0
-  // 1 0 0 0 0
+    // J_pMT
+    // 0 0 0 x x
+    // 0 0 0 x x
+    // 0 0 0 x x
+    // 0 x x 0 0
+    // 0 x x 0 0
+    // 0 x x 0 0
+    // 1 0 0 0 0
 
-  // J_MMT if MMproj == true
-  // x x x x x x 0
-  // x x x x x x 0
-  // x x x x x x 0
-  // x x x x x x 0
-  // x x x x x x 0
-  // x x x x x x 0
-  // x x x x x x x
+    // J_MMT if MMproj == true
+    // x x x x x x 0
+    // x x x x x x 0
+    // x x x x x x 0
+    // x x x x x x 0
+    // x x x x x x 0
+    // x x x x x x 0
+    // x x x x x x x
 
-  // J_MpT
-  // 0 0 0 0 0 0 1
-  // 0 0 0 x x x 0
-  // 0 0 0 x x x 0
-  // x x x 0 0 0 0
-  // x x x 0 0 0 0
-
-
-  J_pp[0*5+0] = J_MMT[6*7+6];
-  J_pp[0*5+1] = 0;
-  J_pp[0*5+2] = 0;
-  J_pp[0*5+3] = 0;
-  J_pp[0*5+4] = 0;
-
-  J_pp[1*5+0] = J_pMT[3*5+1] * J_MMT[6*7+3] + J_pMT[4*5+1] * J_MMT[6*7+4] + J_pMT[5*5+1] * J_MMT[6*7+5];
-  J_pp[1*5+1] = (  (J_pMT[3*5+1] * J_MMT[3*7+3] + J_pMT[4*5+1] * J_MMT[3*7+4] + J_pMT[5*5+1] * J_MMT[3*7+5]) * J_MpT[1*7+3] 
-                 + (J_pMT[3*5+1] * J_MMT[4*7+3] + J_pMT[4*5+1] * J_MMT[4*7+4] + J_pMT[5*5+1] * J_MMT[4*7+5]) * J_MpT[1*7+4]
-                 + (J_pMT[3*5+1] * J_MMT[5*7+3] + J_pMT[4*5+1] * J_MMT[5*7+4] + J_pMT[5*5+1] * J_MMT[5*7+5]) * J_MpT[1*7+5]);
-  J_pp[1*5+2] = (  (J_pMT[3*5+1] * J_MMT[3*7+3] + J_pMT[4*5+1] * J_MMT[3*7+4] + J_pMT[5*5+1] * J_MMT[3*7+5]) * J_MpT[2*7+3]
-                 + (J_pMT[3*5+1] * J_MMT[4*7+3] + J_pMT[4*5+1] * J_MMT[4*7+4] + J_pMT[5*5+1] * J_MMT[4*7+5]) * J_MpT[2*7+4]
-                 + (J_pMT[3*5+1] * J_MMT[5*7+3] + J_pMT[4*5+1] * J_MMT[5*7+4] + J_pMT[5*5+1] * J_MMT[5*7+5]) * J_MpT[2*7+5]);
-  J_pp[1*5+3] = (  (J_pMT[3*5+1] * J_MMT[0*7+3] + J_pMT[4*5+1] * J_MMT[0*7+4] + J_pMT[5*5+1] * J_MMT[0*7+5]) * J_MpT[3*7+0]
-                 + (J_pMT[3*5+1] * J_MMT[1*7+3] + J_pMT[4*5+1] * J_MMT[1*7+4] + J_pMT[5*5+1] * J_MMT[1*7+5]) * J_MpT[3*7+1]
-                 + (J_pMT[3*5+1] * J_MMT[2*7+3] + J_pMT[4*5+1] * J_MMT[2*7+4] + J_pMT[5*5+1] * J_MMT[2*7+5]) * J_MpT[3*7+2]);
-  J_pp[1*5+4] = (  (J_pMT[3*5+1] * J_MMT[0*7+3] + J_pMT[4*5+1] * J_MMT[0*7+4] + J_pMT[5*5+1] * J_MMT[0*7+5]) * J_MpT[4*7+0]
-                 + (J_pMT[3*5+1] * J_MMT[1*7+3] + J_pMT[4*5+1] * J_MMT[1*7+4] + J_pMT[5*5+1] * J_MMT[1*7+5]) * J_MpT[4*7+1]
-                 + (J_pMT[3*5+1] * J_MMT[2*7+3] + J_pMT[4*5+1] * J_MMT[2*7+4] + J_pMT[5*5+1] * J_MMT[2*7+5]) * J_MpT[4*7+2]);
-
-  J_pp[2*5+0] =  J_pMT[3*5+2] * J_MMT[6*7+3] + J_pMT[4*5+2] * J_MMT[6*7+4] + J_pMT[5*5+2] * J_MMT[6*7+5];
-  J_pp[2*5+1] = (  (J_pMT[3*5+2] * J_MMT[3*7+3] + J_pMT[4*5+2] * J_MMT[3*7+4] + J_pMT[5*5+2] * J_MMT[3*7+5]) * J_MpT[1*7+3]
-                 + (J_pMT[3*5+2] * J_MMT[4*7+3] + J_pMT[4*5+2] * J_MMT[4*7+4] + J_pMT[5*5+2] * J_MMT[4*7+5]) * J_MpT[1*7+4]
-                 + (J_pMT[3*5+2] * J_MMT[5*7+3] + J_pMT[4*5+2] * J_MMT[5*7+4] + J_pMT[5*5+2] * J_MMT[5*7+5]) * J_MpT[1*7+5]);
-  J_pp[2*5+2] = (  (J_pMT[3*5+2] * J_MMT[3*7+3] + J_pMT[4*5+2] * J_MMT[3*7+4] + J_pMT[5*5+2] * J_MMT[3*7+5]) * J_MpT[2*7+3]
-                 + (J_pMT[3*5+2] * J_MMT[4*7+3] + J_pMT[4*5+2] * J_MMT[4*7+4] + J_pMT[5*5+2] * J_MMT[4*7+5]) * J_MpT[2*7+4]
-                 + (J_pMT[3*5+2] * J_MMT[5*7+3] + J_pMT[4*5+2] * J_MMT[5*7+4] + J_pMT[5*5+2] * J_MMT[5*7+5]) * J_MpT[2*7+5]);
-  J_pp[2*5+3] = (  (J_pMT[3*5+2] * J_MMT[0*7+3] + J_pMT[4*5+2] * J_MMT[0*7+4] + J_pMT[5*5+2] * J_MMT[0*7+5]) * J_MpT[3*7+0]
-                 + (J_pMT[3*5+2] * J_MMT[1*7+3] + J_pMT[4*5+2] * J_MMT[1*7+4] + J_pMT[5*5+2] * J_MMT[1*7+5]) * J_MpT[3*7+1]
-                 + (J_pMT[3*5+2] * J_MMT[2*7+3] + J_pMT[4*5+2] * J_MMT[2*7+4] + J_pMT[5*5+2] * J_MMT[2*7+5]) * J_MpT[3*7+2]);
-  J_pp[2*5+4] = (  (J_pMT[3*5+2] * J_MMT[0*7+3] + J_pMT[4*5+2] * J_MMT[0*7+4] + J_pMT[5*5+2] * J_MMT[0*7+5]) * J_MpT[4*7+0]
-                 + (J_pMT[3*5+2] * J_MMT[1*7+3] + J_pMT[4*5+2] * J_MMT[1*7+4] + J_pMT[5*5+2] * J_MMT[1*7+5]) * J_MpT[4*7+1]
-                 + (J_pMT[3*5+2] * J_MMT[2*7+3] + J_pMT[4*5+2] * J_MMT[2*7+4] + J_pMT[5*5+2] * J_MMT[2*7+5]) * J_MpT[4*7+2]);
-
-  J_pp[3*5+0] =  J_pMT[0*5+3] * J_MMT[6*7+0] + J_pMT[1*5+3] * J_MMT[6*7+1] + J_pMT[2*5+3] * J_MMT[6*7+2];
-  J_pp[3*5+1] = (  (J_pMT[0*5+3] * J_MMT[3*7+0] + J_pMT[1*5+3] * J_MMT[3*7+1] + J_pMT[2*5+3] * J_MMT[3*7+2]) * J_MpT[1*7+3]
-                 + (J_pMT[0*5+3] * J_MMT[4*7+0] + J_pMT[1*5+3] * J_MMT[4*7+1] + J_pMT[2*5+3] * J_MMT[4*7+2]) * J_MpT[1*7+4]
-                 + (J_pMT[0*5+3] * J_MMT[5*7+0] + J_pMT[1*5+3] * J_MMT[5*7+1] + J_pMT[2*5+3] * J_MMT[5*7+2]) * J_MpT[1*7+5]);
-  J_pp[3*5+2] = (  (J_pMT[0*5+3] * J_MMT[3*7+0] + J_pMT[1*5+3] * J_MMT[3*7+1] + J_pMT[2*5+3] * J_MMT[3*7+2]) * J_MpT[2*7+3]
-                 + (J_pMT[0*5+3] * J_MMT[4*7+0] + J_pMT[1*5+3] * J_MMT[4*7+1] + J_pMT[2*5+3] * J_MMT[4*7+2]) * J_MpT[2*7+4]
-                 + (J_pMT[0*5+3] * J_MMT[5*7+0] + J_pMT[1*5+3] * J_MMT[5*7+1] + J_pMT[2*5+3] * J_MMT[5*7+2]) * J_MpT[2*7+5]);
-  J_pp[3*5+3] = (  (J_pMT[0*5+3] * J_MMT[0*7+0] + J_pMT[1*5+3] * J_MMT[0*7+1] + J_pMT[2*5+3] * J_MMT[0*7+2]) * J_MpT[3*7+0]
-                 + (J_pMT[0*5+3] * J_MMT[1*7+0] + J_pMT[1*5+3] * J_MMT[1*7+1] + J_pMT[2*5+3] * J_MMT[1*7+2]) * J_MpT[3*7+1]
-                 + (J_pMT[0*5+3] * J_MMT[2*7+0] + J_pMT[1*5+3] * J_MMT[2*7+1] + J_pMT[2*5+3] * J_MMT[2*7+2]) * J_MpT[3*7+2]);
-  J_pp[3*5+4] = (  (J_pMT[0*5+3] * J_MMT[0*7+0] + J_pMT[1*5+3] * J_MMT[0*7+1] + J_pMT[2*5+3] * J_MMT[0*7+2]) * J_MpT[4*7+0]
-                 + (J_pMT[0*5+3] * J_MMT[1*7+0] + J_pMT[1*5+3] * J_MMT[1*7+1] + J_pMT[2*5+3] * J_MMT[1*7+2]) * J_MpT[4*7+1]
-                 + (J_pMT[0*5+3] * J_MMT[2*7+0] + J_pMT[1*5+3] * J_MMT[2*7+1] + J_pMT[2*5+3] * J_MMT[2*7+2]) * J_MpT[4*7+2]);
-
-  J_pp[4*5+0] =  J_pMT[0*5+4] * J_MMT[6*7+0] + J_pMT[1*5+4] * J_MMT[6*7+1] + J_pMT[2*5+4] * J_MMT[6*7+2];
-  J_pp[4*5+1] = (  (J_pMT[0*5+4] * J_MMT[3*7+0] + J_pMT[1*5+4] * J_MMT[3*7+1] + J_pMT[2*5+4] * J_MMT[3*7+2]) * J_MpT[1*7+3]
-                 + (J_pMT[0*5+4] * J_MMT[4*7+0] + J_pMT[1*5+4] * J_MMT[4*7+1] + J_pMT[2*5+4] * J_MMT[4*7+2]) * J_MpT[1*7+4]
-                 + (J_pMT[0*5+4] * J_MMT[5*7+0] + J_pMT[1*5+4] * J_MMT[5*7+1] + J_pMT[2*5+4] * J_MMT[5*7+2]) * J_MpT[1*7+5]);
-  J_pp[4*5+2] = (  (J_pMT[0*5+4] * J_MMT[3*7+0] + J_pMT[1*5+4] * J_MMT[3*7+1] + J_pMT[2*5+4] * J_MMT[3*7+2]) * J_MpT[2*7+3]
-                 + (J_pMT[0*5+4] * J_MMT[4*7+0] + J_pMT[1*5+4] * J_MMT[4*7+1] + J_pMT[2*5+4] * J_MMT[4*7+2]) * J_MpT[2*7+4]
-                 + (J_pMT[0*5+4] * J_MMT[5*7+0] + J_pMT[1*5+4] * J_MMT[5*7+1] + J_pMT[2*5+4] * J_MMT[5*7+2]) * J_MpT[2*7+5]);
-  J_pp[4*5+3] = (  (J_pMT[0*5+4] * J_MMT[0*7+0] + J_pMT[1*5+4] * J_MMT[0*7+1] + J_pMT[2*5+4] * J_MMT[0*7+2]) * J_MpT[3*7+0]
-                 + (J_pMT[0*5+4] * J_MMT[1*7+0] + J_pMT[1*5+4] * J_MMT[1*7+1] + J_pMT[2*5+4] * J_MMT[1*7+2]) * J_MpT[3*7+1]
-                 + (J_pMT[0*5+4] * J_MMT[2*7+0] + J_pMT[1*5+4] * J_MMT[2*7+1] + J_pMT[2*5+4] * J_MMT[2*7+2]) * J_MpT[3*7+2]);
-  J_pp[4*5+4] = (  (J_pMT[0*5+4] * J_MMT[0*7+0] + J_pMT[1*5+4] * J_MMT[0*7+1] + J_pMT[2*5+4] * J_MMT[0*7+2]) * J_MpT[4*7+0]
-                 + (J_pMT[0*5+4] * J_MMT[1*7+0] + J_pMT[1*5+4] * J_MMT[1*7+1] + J_pMT[2*5+4] * J_MMT[1*7+2]) * J_MpT[4*7+1]
-                 + (J_pMT[0*5+4] * J_MMT[2*7+0] + J_pMT[1*5+4] * J_MMT[2*7+1] + J_pMT[2*5+4] * J_MMT[2*7+2]) * J_MpT[4*7+2]);
-}
+    // J_MpT
+    // 0 0 0 0 0 0 1
+    // 0 0 0 x x x 0
+    // 0 0 0 x x x 0
+    // x x x 0 0 0 0
+    // x x x 0 0 0 0
 
 
-void RKTools::Np_N_NpT(const M7x7& Np, M7x7& N) {
+    J_pp[0 * 5 + 0] = J_MMT[6 * 7 + 6];
+    J_pp[0 * 5 + 1] = 0;
+    J_pp[0 * 5 + 2] = 0;
+    J_pp[0 * 5 + 3] = 0;
+    J_pp[0 * 5 + 4] = 0;
 
-  // N is symmetric
+    J_pp[1 * 5 + 0] = J_pMT[3 * 5 + 1] * J_MMT[6 * 7 + 3] + J_pMT[4 * 5 + 1] * J_MMT[6 * 7 + 4] + J_pMT[5 * 5 + 1] * J_MMT[6 * 7 + 5];
+    J_pp[1 * 5 + 1] = ((J_pMT[3 * 5 + 1] * J_MMT[3 * 7 + 3] + J_pMT[4 * 5 + 1] * J_MMT[3 * 7 + 4] + J_pMT[5 * 5 + 1] * J_MMT[3 * 7 + 5])
+                       * J_MpT[1 * 7 + 3]
+                       + (J_pMT[3 * 5 + 1] * J_MMT[4 * 7 + 3] + J_pMT[4 * 5 + 1] * J_MMT[4 * 7 + 4] + J_pMT[5 * 5 + 1] * J_MMT[4 * 7 + 5]) * J_MpT[1 * 7 +
+                           4]
+                       + (J_pMT[3 * 5 + 1] * J_MMT[5 * 7 + 3] + J_pMT[4 * 5 + 1] * J_MMT[5 * 7 + 4] + J_pMT[5 * 5 + 1] * J_MMT[5 * 7 + 5]) * J_MpT[1 * 7 +
+                           5]);
+    J_pp[1 * 5 + 2] = ((J_pMT[3 * 5 + 1] * J_MMT[3 * 7 + 3] + J_pMT[4 * 5 + 1] * J_MMT[3 * 7 + 4] + J_pMT[5 * 5 + 1] * J_MMT[3 * 7 + 5])
+                       * J_MpT[2 * 7 + 3]
+                       + (J_pMT[3 * 5 + 1] * J_MMT[4 * 7 + 3] + J_pMT[4 * 5 + 1] * J_MMT[4 * 7 + 4] + J_pMT[5 * 5 + 1] * J_MMT[4 * 7 + 5]) * J_MpT[2 * 7 +
+                           4]
+                       + (J_pMT[3 * 5 + 1] * J_MMT[5 * 7 + 3] + J_pMT[4 * 5 + 1] * J_MMT[5 * 7 + 4] + J_pMT[5 * 5 + 1] * J_MMT[5 * 7 + 5]) * J_MpT[2 * 7 +
+                           5]);
+    J_pp[1 * 5 + 3] = ((J_pMT[3 * 5 + 1] * J_MMT[0 * 7 + 3] + J_pMT[4 * 5 + 1] * J_MMT[0 * 7 + 4] + J_pMT[5 * 5 + 1] * J_MMT[0 * 7 + 5])
+                       * J_MpT[3 * 7 + 0]
+                       + (J_pMT[3 * 5 + 1] * J_MMT[1 * 7 + 3] + J_pMT[4 * 5 + 1] * J_MMT[1 * 7 + 4] + J_pMT[5 * 5 + 1] * J_MMT[1 * 7 + 5]) * J_MpT[3 * 7 +
+                           1]
+                       + (J_pMT[3 * 5 + 1] * J_MMT[2 * 7 + 3] + J_pMT[4 * 5 + 1] * J_MMT[2 * 7 + 4] + J_pMT[5 * 5 + 1] * J_MMT[2 * 7 + 5]) * J_MpT[3 * 7 +
+                           2]);
+    J_pp[1 * 5 + 4] = ((J_pMT[3 * 5 + 1] * J_MMT[0 * 7 + 3] + J_pMT[4 * 5 + 1] * J_MMT[0 * 7 + 4] + J_pMT[5 * 5 + 1] * J_MMT[0 * 7 + 5])
+                       * J_MpT[4 * 7 + 0]
+                       + (J_pMT[3 * 5 + 1] * J_MMT[1 * 7 + 3] + J_pMT[4 * 5 + 1] * J_MMT[1 * 7 + 4] + J_pMT[5 * 5 + 1] * J_MMT[1 * 7 + 5]) * J_MpT[4 * 7 +
+                           1]
+                       + (J_pMT[3 * 5 + 1] * J_MMT[2 * 7 + 3] + J_pMT[4 * 5 + 1] * J_MMT[2 * 7 + 4] + J_pMT[5 * 5 + 1] * J_MMT[2 * 7 + 5]) * J_MpT[4 * 7 +
+                           2]);
 
-  // Np
-  // x x x 0 0 0 0
-  // x x x 0 0 0 0
-  // x x x 0 0 0 0
-  // x x x 1 0 0 0
-  // x x x 0 1 0 0
-  // x x x 0 0 1 0
-  // 0 0 0 0 0 0 1
+    J_pp[2 * 5 + 0] =  J_pMT[3 * 5 + 2] * J_MMT[6 * 7 + 3] + J_pMT[4 * 5 + 2] * J_MMT[6 * 7 + 4] + J_pMT[5 * 5 + 2] * J_MMT[6 * 7 + 5];
+    J_pp[2 * 5 + 1] = ((J_pMT[3 * 5 + 2] * J_MMT[3 * 7 + 3] + J_pMT[4 * 5 + 2] * J_MMT[3 * 7 + 4] + J_pMT[5 * 5 + 2] * J_MMT[3 * 7 + 5])
+                       * J_MpT[1 * 7 + 3]
+                       + (J_pMT[3 * 5 + 2] * J_MMT[4 * 7 + 3] + J_pMT[4 * 5 + 2] * J_MMT[4 * 7 + 4] + J_pMT[5 * 5 + 2] * J_MMT[4 * 7 + 5]) * J_MpT[1 * 7 +
+                           4]
+                       + (J_pMT[3 * 5 + 2] * J_MMT[5 * 7 + 3] + J_pMT[4 * 5 + 2] * J_MMT[5 * 7 + 4] + J_pMT[5 * 5 + 2] * J_MMT[5 * 7 + 5]) * J_MpT[1 * 7 +
+                           5]);
+    J_pp[2 * 5 + 2] = ((J_pMT[3 * 5 + 2] * J_MMT[3 * 7 + 3] + J_pMT[4 * 5 + 2] * J_MMT[3 * 7 + 4] + J_pMT[5 * 5 + 2] * J_MMT[3 * 7 + 5])
+                       * J_MpT[2 * 7 + 3]
+                       + (J_pMT[3 * 5 + 2] * J_MMT[4 * 7 + 3] + J_pMT[4 * 5 + 2] * J_MMT[4 * 7 + 4] + J_pMT[5 * 5 + 2] * J_MMT[4 * 7 + 5]) * J_MpT[2 * 7 +
+                           4]
+                       + (J_pMT[3 * 5 + 2] * J_MMT[5 * 7 + 3] + J_pMT[4 * 5 + 2] * J_MMT[5 * 7 + 4] + J_pMT[5 * 5 + 2] * J_MMT[5 * 7 + 5]) * J_MpT[2 * 7 +
+                           5]);
+    J_pp[2 * 5 + 3] = ((J_pMT[3 * 5 + 2] * J_MMT[0 * 7 + 3] + J_pMT[4 * 5 + 2] * J_MMT[0 * 7 + 4] + J_pMT[5 * 5 + 2] * J_MMT[0 * 7 + 5])
+                       * J_MpT[3 * 7 + 0]
+                       + (J_pMT[3 * 5 + 2] * J_MMT[1 * 7 + 3] + J_pMT[4 * 5 + 2] * J_MMT[1 * 7 + 4] + J_pMT[5 * 5 + 2] * J_MMT[1 * 7 + 5]) * J_MpT[3 * 7 +
+                           1]
+                       + (J_pMT[3 * 5 + 2] * J_MMT[2 * 7 + 3] + J_pMT[4 * 5 + 2] * J_MMT[2 * 7 + 4] + J_pMT[5 * 5 + 2] * J_MMT[2 * 7 + 5]) * J_MpT[3 * 7 +
+                           2]);
+    J_pp[2 * 5 + 4] = ((J_pMT[3 * 5 + 2] * J_MMT[0 * 7 + 3] + J_pMT[4 * 5 + 2] * J_MMT[0 * 7 + 4] + J_pMT[5 * 5 + 2] * J_MMT[0 * 7 + 5])
+                       * J_MpT[4 * 7 + 0]
+                       + (J_pMT[3 * 5 + 2] * J_MMT[1 * 7 + 3] + J_pMT[4 * 5 + 2] * J_MMT[1 * 7 + 4] + J_pMT[5 * 5 + 2] * J_MMT[1 * 7 + 5]) * J_MpT[4 * 7 +
+                           1]
+                       + (J_pMT[3 * 5 + 2] * J_MMT[2 * 7 + 3] + J_pMT[4 * 5 + 2] * J_MMT[2 * 7 + 4] + J_pMT[5 * 5 + 2] * J_MMT[2 * 7 + 5]) * J_MpT[4 * 7 +
+                           2]);
 
-  // calculate:
-  // Np * N * Np^T
+    J_pp[3 * 5 + 0] =  J_pMT[0 * 5 + 3] * J_MMT[6 * 7 + 0] + J_pMT[1 * 5 + 3] * J_MMT[6 * 7 + 1] + J_pMT[2 * 5 + 3] * J_MMT[6 * 7 + 2];
+    J_pp[3 * 5 + 1] = ((J_pMT[0 * 5 + 3] * J_MMT[3 * 7 + 0] + J_pMT[1 * 5 + 3] * J_MMT[3 * 7 + 1] + J_pMT[2 * 5 + 3] * J_MMT[3 * 7 + 2])
+                       * J_MpT[1 * 7 + 3]
+                       + (J_pMT[0 * 5 + 3] * J_MMT[4 * 7 + 0] + J_pMT[1 * 5 + 3] * J_MMT[4 * 7 + 1] + J_pMT[2 * 5 + 3] * J_MMT[4 * 7 + 2]) * J_MpT[1 * 7 +
+                           4]
+                       + (J_pMT[0 * 5 + 3] * J_MMT[5 * 7 + 0] + J_pMT[1 * 5 + 3] * J_MMT[5 * 7 + 1] + J_pMT[2 * 5 + 3] * J_MMT[5 * 7 + 2]) * J_MpT[1 * 7 +
+                           5]);
+    J_pp[3 * 5 + 2] = ((J_pMT[0 * 5 + 3] * J_MMT[3 * 7 + 0] + J_pMT[1 * 5 + 3] * J_MMT[3 * 7 + 1] + J_pMT[2 * 5 + 3] * J_MMT[3 * 7 + 2])
+                       * J_MpT[2 * 7 + 3]
+                       + (J_pMT[0 * 5 + 3] * J_MMT[4 * 7 + 0] + J_pMT[1 * 5 + 3] * J_MMT[4 * 7 + 1] + J_pMT[2 * 5 + 3] * J_MMT[4 * 7 + 2]) * J_MpT[2 * 7 +
+                           4]
+                       + (J_pMT[0 * 5 + 3] * J_MMT[5 * 7 + 0] + J_pMT[1 * 5 + 3] * J_MMT[5 * 7 + 1] + J_pMT[2 * 5 + 3] * J_MMT[5 * 7 + 2]) * J_MpT[2 * 7 +
+                           5]);
+    J_pp[3 * 5 + 3] = ((J_pMT[0 * 5 + 3] * J_MMT[0 * 7 + 0] + J_pMT[1 * 5 + 3] * J_MMT[0 * 7 + 1] + J_pMT[2 * 5 + 3] * J_MMT[0 * 7 + 2])
+                       * J_MpT[3 * 7 + 0]
+                       + (J_pMT[0 * 5 + 3] * J_MMT[1 * 7 + 0] + J_pMT[1 * 5 + 3] * J_MMT[1 * 7 + 1] + J_pMT[2 * 5 + 3] * J_MMT[1 * 7 + 2]) * J_MpT[3 * 7 +
+                           1]
+                       + (J_pMT[0 * 5 + 3] * J_MMT[2 * 7 + 0] + J_pMT[1 * 5 + 3] * J_MMT[2 * 7 + 1] + J_pMT[2 * 5 + 3] * J_MMT[2 * 7 + 2]) * J_MpT[3 * 7 +
+                           2]);
+    J_pp[3 * 5 + 4] = ((J_pMT[0 * 5 + 3] * J_MMT[0 * 7 + 0] + J_pMT[1 * 5 + 3] * J_MMT[0 * 7 + 1] + J_pMT[2 * 5 + 3] * J_MMT[0 * 7 + 2])
+                       * J_MpT[4 * 7 + 0]
+                       + (J_pMT[0 * 5 + 3] * J_MMT[1 * 7 + 0] + J_pMT[1 * 5 + 3] * J_MMT[1 * 7 + 1] + J_pMT[2 * 5 + 3] * J_MMT[1 * 7 + 2]) * J_MpT[4 * 7 +
+                           1]
+                       + (J_pMT[0 * 5 + 3] * J_MMT[2 * 7 + 0] + J_pMT[1 * 5 + 3] * J_MMT[2 * 7 + 1] + J_pMT[2 * 5 + 3] * J_MMT[2 * 7 + 2]) * J_MpT[4 * 7 +
+                           2]);
 
-  double N00(N[0*7+0]), N11(N[1*7+1]), N22(N[2*7+2]), N33(N[3*7+3]), N44(N[4*7+4]), N55(N[5*7+5]);
-
-  // replace lower left triangle using the original values from upper right triangle plus the cached diagonal values
-  N[0*7+0] = (Np[0*7+0] * N00 + Np[0*7+1] * N[0*7+1] + Np[0*7+2] * N[0*7+2]) * Np[0*7+0] + (Np[0*7+0] * N[0*7+1] + Np[0*7+1] * N11 + Np[0*7+2] * N[1*7+2]) * Np[0*7+1] + (Np[0*7+0] * N[0*7+2] + Np[0*7+1] * N[1*7+2] + Np[0*7+2] * N22) * Np[0*7+2];
-
-  N[1*7+0] = (Np[1*7+0] * N00 + Np[1*7+1] * N[0*7+1] + Np[1*7+2] * N[0*7+2]) * Np[0*7+0] + (Np[1*7+0] * N[0*7+1] + Np[1*7+1] * N11 + Np[1*7+2] * N[1*7+2]) * Np[0*7+1] + (Np[1*7+0] * N[0*7+2] + Np[1*7+1] * N[1*7+2] + Np[1*7+2] * N22) * Np[0*7+2];
-  N[1*7+1] = (Np[1*7+0] * N00 + Np[1*7+1] * N[0*7+1] + Np[1*7+2] * N[0*7+2]) * Np[1*7+0] + (Np[1*7+0] * N[0*7+1] + Np[1*7+1] * N11 + Np[1*7+2] * N[1*7+2]) * Np[1*7+1] + (Np[1*7+0] * N[0*7+2] + Np[1*7+1] * N[1*7+2] + Np[1*7+2] * N22) * Np[1*7+2];
-
-  N[2*7+0] = (Np[2*7+0] * N00 + Np[2*7+1] * N[0*7+1] + Np[2*7+2] * N[0*7+2]) * Np[0*7+0] + (Np[2*7+0] * N[0*7+1] + Np[2*7+1] * N11 + Np[2*7+2] * N[1*7+2]) * Np[0*7+1] + (Np[2*7+0] * N[0*7+2] + Np[2*7+1] * N[1*7+2] + Np[2*7+2] * N22) * Np[0*7+2];
-  N[2*7+1] = (Np[2*7+0] * N00 + Np[2*7+1] * N[0*7+1] + Np[2*7+2] * N[0*7+2]) * Np[1*7+0] + (Np[2*7+0] * N[0*7+1] + Np[2*7+1] * N11 + Np[2*7+2] * N[1*7+2]) * Np[1*7+1] + (Np[2*7+0] * N[0*7+2] + Np[2*7+1] * N[1*7+2] + Np[2*7+2] * N22) * Np[1*7+2];
-  N[2*7+2] = (Np[2*7+0] * N00 + Np[2*7+1] * N[0*7+1] + Np[2*7+2] * N[0*7+2]) * Np[2*7+0] + (Np[2*7+0] * N[0*7+1] + Np[2*7+1] * N11 + Np[2*7+2] * N[1*7+2]) * Np[2*7+1] + (Np[2*7+0] * N[0*7+2] + Np[2*7+1] * N[1*7+2] + Np[2*7+2] * N22) * Np[2*7+2];
-
-  N[3*7+0] = (Np[3*7+0] * N00 + Np[3*7+1] * N[0*7+1] + Np[3*7+2] * N[0*7+2] + N[0*7+3]) * Np[0*7+0] + (Np[3*7+0] * N[0*7+1] + Np[3*7+1] * N11 + Np[3*7+2] * N[1*7+2] + N[1*7+3]) * Np[0*7+1] + (Np[3*7+0] * N[0*7+2] + Np[3*7+1] * N[1*7+2] + Np[3*7+2] * N22 + N[2*7+3]) * Np[0*7+2];
-  N[3*7+1] = (Np[3*7+0] * N00 + Np[3*7+1] * N[0*7+1] + Np[3*7+2] * N[0*7+2] + N[0*7+3]) * Np[1*7+0] + (Np[3*7+0] * N[0*7+1] + Np[3*7+1] * N11 + Np[3*7+2] * N[1*7+2] + N[1*7+3]) * Np[1*7+1] + (Np[3*7+0] * N[0*7+2] + Np[3*7+1] * N[1*7+2] + Np[3*7+2] * N22 + N[2*7+3]) * Np[1*7+2];
-  N[3*7+2] = (Np[3*7+0] * N00 + Np[3*7+1] * N[0*7+1] + Np[3*7+2] * N[0*7+2] + N[0*7+3]) * Np[2*7+0] + (Np[3*7+0] * N[0*7+1] + Np[3*7+1] * N11 + Np[3*7+2] * N[1*7+2] + N[1*7+3]) * Np[2*7+1] + (Np[3*7+0] * N[0*7+2] + Np[3*7+1] * N[1*7+2] + Np[3*7+2] * N22 + N[2*7+3]) * Np[2*7+2];
-  N[3*7+3] = (Np[3*7+0] * N00 + Np[3*7+1] * N[0*7+1] + Np[3*7+2] * N[0*7+2] + N[0*7+3]) * Np[3*7+0] + (Np[3*7+0] * N[0*7+1] + Np[3*7+1] * N11 + Np[3*7+2] * N[1*7+2] + N[1*7+3]) * Np[3*7+1] + (Np[3*7+0] * N[0*7+2] + Np[3*7+1] * N[1*7+2] + Np[3*7+2] * N22 + N[2*7+3]) * Np[3*7+2] + Np[3*7+0] * N[0*7+3] + Np[3*7+1] * N[1*7+3] + Np[3*7+2] * N[2*7+3] + N33;
-
-  N[4*7+0] = (Np[4*7+0] * N00 + Np[4*7+1] * N[0*7+1] + Np[4*7+2] * N[0*7+2] + N[0*7+4]) * Np[0*7+0] + (Np[4*7+0] * N[0*7+1] + Np[4*7+1] * N11 + Np[4*7+2] * N[1*7+2] + N[1*7+4]) * Np[0*7+1] + (Np[4*7+0] * N[0*7+2] + Np[4*7+1] * N[1*7+2] + Np[4*7+2] * N22 + N[2*7+4]) * Np[0*7+2];
-  N[4*7+1] = (Np[4*7+0] * N00 + Np[4*7+1] * N[0*7+1] + Np[4*7+2] * N[0*7+2] + N[0*7+4]) * Np[1*7+0] + (Np[4*7+0] * N[0*7+1] + Np[4*7+1] * N11 + Np[4*7+2] * N[1*7+2] + N[1*7+4]) * Np[1*7+1] + (Np[4*7+0] * N[0*7+2] + Np[4*7+1] * N[1*7+2] + Np[4*7+2] * N22 + N[2*7+4]) * Np[1*7+2];
-  N[4*7+2] = (Np[4*7+0] * N00 + Np[4*7+1] * N[0*7+1] + Np[4*7+2] * N[0*7+2] + N[0*7+4]) * Np[2*7+0] + (Np[4*7+0] * N[0*7+1] + Np[4*7+1] * N11 + Np[4*7+2] * N[1*7+2] + N[1*7+4]) * Np[2*7+1] + (Np[4*7+0] * N[0*7+2] + Np[4*7+1] * N[1*7+2] + Np[4*7+2] * N22 + N[2*7+4]) * Np[2*7+2];
-  N[4*7+3] = (Np[4*7+0] * N00 + Np[4*7+1] * N[0*7+1] + Np[4*7+2] * N[0*7+2] + N[0*7+4]) * Np[3*7+0] + (Np[4*7+0] * N[0*7+1] + Np[4*7+1] * N11 + Np[4*7+2] * N[1*7+2] + N[1*7+4]) * Np[3*7+1] + (Np[4*7+0] * N[0*7+2] + Np[4*7+1] * N[1*7+2] + Np[4*7+2] * N22 + N[2*7+4]) * Np[3*7+2] + Np[4*7+0] * N[0*7+3] + Np[4*7+1] * N[1*7+3] + Np[4*7+2] * N[2*7+3] + N[3*7+4];
-  N[4*7+4] = (Np[4*7+0] * N00 + Np[4*7+1] * N[0*7+1] + Np[4*7+2] * N[0*7+2] + N[0*7+4]) * Np[4*7+0] + (Np[4*7+0] * N[0*7+1] + Np[4*7+1] * N11 + Np[4*7+2] * N[1*7+2] + N[1*7+4]) * Np[4*7+1] + (Np[4*7+0] * N[0*7+2] + Np[4*7+1] * N[1*7+2] + Np[4*7+2] * N22 + N[2*7+4]) * Np[4*7+2] + Np[4*7+0] * N[0*7+4] + Np[4*7+1] * N[1*7+4] + Np[4*7+2] * N[2*7+4] + N44;
-
-  N[5*7+0] = (Np[5*7+0] * N00 + Np[5*7+1] * N[0*7+1] + Np[5*7+2] * N[0*7+2] + N[0*7+5]) * Np[0*7+0] + (Np[5*7+0] * N[0*7+1] + Np[5*7+1] * N11 + Np[5*7+2] * N[1*7+2] + N[1*7+5]) * Np[0*7+1] + (Np[5*7+0] * N[0*7+2] + Np[5*7+1] * N[1*7+2] + Np[5*7+2] * N22 + N[2*7+5]) * Np[0*7+2];
-  N[5*7+1] = (Np[5*7+0] * N00 + Np[5*7+1] * N[0*7+1] + Np[5*7+2] * N[0*7+2] + N[0*7+5]) * Np[1*7+0] + (Np[5*7+0] * N[0*7+1] + Np[5*7+1] * N11 + Np[5*7+2] * N[1*7+2] + N[1*7+5]) * Np[1*7+1] + (Np[5*7+0] * N[0*7+2] + Np[5*7+1] * N[1*7+2] + Np[5*7+2] * N22 + N[2*7+5]) * Np[1*7+2];
-  N[5*7+2] = (Np[5*7+0] * N00 + Np[5*7+1] * N[0*7+1] + Np[5*7+2] * N[0*7+2] + N[0*7+5]) * Np[2*7+0] + (Np[5*7+0] * N[0*7+1] + Np[5*7+1] * N11 + Np[5*7+2] * N[1*7+2] + N[1*7+5]) * Np[2*7+1] + (Np[5*7+0] * N[0*7+2] + Np[5*7+1] * N[1*7+2] + Np[5*7+2] * N22 + N[2*7+5]) * Np[2*7+2];
-  N[5*7+3] = (Np[5*7+0] * N00 + Np[5*7+1] * N[0*7+1] + Np[5*7+2] * N[0*7+2] + N[0*7+5]) * Np[3*7+0] + (Np[5*7+0] * N[0*7+1] + Np[5*7+1] * N11 + Np[5*7+2] * N[1*7+2] + N[1*7+5]) * Np[3*7+1] + (Np[5*7+0] * N[0*7+2] + Np[5*7+1] * N[1*7+2] + Np[5*7+2] * N22 + N[2*7+5]) * Np[3*7+2] + Np[5*7+0] * N[0*7+3] + Np[5*7+1] * N[1*7+3] + Np[5*7+2] * N[2*7+3] + N[3*7+5];
-  N[5*7+4] = (Np[5*7+0] * N00 + Np[5*7+1] * N[0*7+1] + Np[5*7+2] * N[0*7+2] + N[0*7+5]) * Np[4*7+0] + (Np[5*7+0] * N[0*7+1] + Np[5*7+1] * N11 + Np[5*7+2] * N[1*7+2] + N[1*7+5]) * Np[4*7+1] + (Np[5*7+0] * N[0*7+2] + Np[5*7+1] * N[1*7+2] + Np[5*7+2] * N22 + N[2*7+5]) * Np[4*7+2] + Np[5*7+0] * N[0*7+4] + Np[5*7+1] * N[1*7+4] + Np[5*7+2] * N[2*7+4] + N[4*7+5];
-  N[5*7+5] = (Np[5*7+0] * N00 + Np[5*7+1] * N[0*7+1] + Np[5*7+2] * N[0*7+2] + N[0*7+5]) * Np[5*7+0] + (Np[5*7+0] * N[0*7+1] + Np[5*7+1] * N11 + Np[5*7+2] * N[1*7+2] + N[1*7+5]) * Np[5*7+1] + (Np[5*7+0] * N[0*7+2] + Np[5*7+1] * N[1*7+2] + Np[5*7+2] * N22 + N[2*7+5]) * Np[5*7+2] + Np[5*7+0] * N[0*7+5] + Np[5*7+1] * N[1*7+5] + Np[5*7+2] * N[2*7+5] + N55;
-
-  N[6*7+0] = Np[0*7+0] * N[0*7+6] + Np[0*7+1] * N[1*7+6] + Np[0*7+2] * N[2*7+6];
-  N[6*7+1] = Np[1*7+0] * N[0*7+6] + Np[1*7+1] * N[1*7+6] + Np[1*7+2] * N[2*7+6];
-  N[6*7+2] = Np[2*7+0] * N[0*7+6] + Np[2*7+1] * N[1*7+6] + Np[2*7+2] * N[2*7+6];
-  N[6*7+3] = Np[3*7+0] * N[0*7+6] + Np[3*7+1] * N[1*7+6] + Np[3*7+2] * N[2*7+6] + N[3*7+6];
-  N[6*7+4] = Np[4*7+0] * N[0*7+6] + Np[4*7+1] * N[1*7+6] + Np[4*7+2] * N[2*7+6] + N[4*7+6];
-  N[6*7+5] = Np[5*7+0] * N[0*7+6] + Np[5*7+1] * N[1*7+6] + Np[5*7+2] * N[2*7+6] + N[5*7+6];
-  //N[6*7+6] = N[6*7+6]; remains unchanged
-
-
-  // copy the results from the lower left triangle to the upper right triangle as well
-  N[5*7+6] = N[6*7+5];
-  N[4*7+5] = N[5*7+4];  N[4*7+6] = N[6*7+4];
-  N[3*7+4] = N[4*7+3];  N[3*7+5] = N[5*7+3];  N[3*7+6] = N[6*7+3];
-  N[2*7+3] = N[3*7+2];  N[2*7+4] = N[4*7+2];  N[2*7+5] = N[5*7+2];  N[2*7+6] = N[6*7+2];
-  N[1*7+2] = N[2*7+1];  N[1*7+3] = N[3*7+1];  N[1*7+4] = N[4*7+1];  N[1*7+5] = N[5*7+1];  N[1*7+6] = N[6*7+1];
-  N[0*7+1] = N[1*7+0];  N[0*7+2] = N[2*7+0];  N[0*7+3] = N[3*7+0];  N[0*7+4] = N[4*7+0];  N[0*7+5] = N[5*7+0];  N[0*7+6] = N[6*7+0];
-}
-
-
-void RKTools::printDim(const double* mat, unsigned int dimX, unsigned int dimY){
-
-  printOut << dimX << " x " << dimY << " matrix as follows: \n";
-  for (unsigned int i=0; i< dimX; ++i){
-    for (unsigned int j=0; j< dimY; ++j){
-      printf("  %11.5g", mat[i*dimY+j]);
-    }
-    printOut<<"\n";
+    J_pp[4 * 5 + 0] =  J_pMT[0 * 5 + 4] * J_MMT[6 * 7 + 0] + J_pMT[1 * 5 + 4] * J_MMT[6 * 7 + 1] + J_pMT[2 * 5 + 4] * J_MMT[6 * 7 + 2];
+    J_pp[4 * 5 + 1] = ((J_pMT[0 * 5 + 4] * J_MMT[3 * 7 + 0] + J_pMT[1 * 5 + 4] * J_MMT[3 * 7 + 1] + J_pMT[2 * 5 + 4] * J_MMT[3 * 7 + 2])
+                       * J_MpT[1 * 7 + 3]
+                       + (J_pMT[0 * 5 + 4] * J_MMT[4 * 7 + 0] + J_pMT[1 * 5 + 4] * J_MMT[4 * 7 + 1] + J_pMT[2 * 5 + 4] * J_MMT[4 * 7 + 2]) * J_MpT[1 * 7 +
+                           4]
+                       + (J_pMT[0 * 5 + 4] * J_MMT[5 * 7 + 0] + J_pMT[1 * 5 + 4] * J_MMT[5 * 7 + 1] + J_pMT[2 * 5 + 4] * J_MMT[5 * 7 + 2]) * J_MpT[1 * 7 +
+                           5]);
+    J_pp[4 * 5 + 2] = ((J_pMT[0 * 5 + 4] * J_MMT[3 * 7 + 0] + J_pMT[1 * 5 + 4] * J_MMT[3 * 7 + 1] + J_pMT[2 * 5 + 4] * J_MMT[3 * 7 + 2])
+                       * J_MpT[2 * 7 + 3]
+                       + (J_pMT[0 * 5 + 4] * J_MMT[4 * 7 + 0] + J_pMT[1 * 5 + 4] * J_MMT[4 * 7 + 1] + J_pMT[2 * 5 + 4] * J_MMT[4 * 7 + 2]) * J_MpT[2 * 7 +
+                           4]
+                       + (J_pMT[0 * 5 + 4] * J_MMT[5 * 7 + 0] + J_pMT[1 * 5 + 4] * J_MMT[5 * 7 + 1] + J_pMT[2 * 5 + 4] * J_MMT[5 * 7 + 2]) * J_MpT[2 * 7 +
+                           5]);
+    J_pp[4 * 5 + 3] = ((J_pMT[0 * 5 + 4] * J_MMT[0 * 7 + 0] + J_pMT[1 * 5 + 4] * J_MMT[0 * 7 + 1] + J_pMT[2 * 5 + 4] * J_MMT[0 * 7 + 2])
+                       * J_MpT[3 * 7 + 0]
+                       + (J_pMT[0 * 5 + 4] * J_MMT[1 * 7 + 0] + J_pMT[1 * 5 + 4] * J_MMT[1 * 7 + 1] + J_pMT[2 * 5 + 4] * J_MMT[1 * 7 + 2]) * J_MpT[3 * 7 +
+                           1]
+                       + (J_pMT[0 * 5 + 4] * J_MMT[2 * 7 + 0] + J_pMT[1 * 5 + 4] * J_MMT[2 * 7 + 1] + J_pMT[2 * 5 + 4] * J_MMT[2 * 7 + 2]) * J_MpT[3 * 7 +
+                           2]);
+    J_pp[4 * 5 + 4] = ((J_pMT[0 * 5 + 4] * J_MMT[0 * 7 + 0] + J_pMT[1 * 5 + 4] * J_MMT[0 * 7 + 1] + J_pMT[2 * 5 + 4] * J_MMT[0 * 7 + 2])
+                       * J_MpT[4 * 7 + 0]
+                       + (J_pMT[0 * 5 + 4] * J_MMT[1 * 7 + 0] + J_pMT[1 * 5 + 4] * J_MMT[1 * 7 + 1] + J_pMT[2 * 5 + 4] * J_MMT[1 * 7 + 2]) * J_MpT[4 * 7 +
+                           1]
+                       + (J_pMT[0 * 5 + 4] * J_MMT[2 * 7 + 0] + J_pMT[1 * 5 + 4] * J_MMT[2 * 7 + 1] + J_pMT[2 * 5 + 4] * J_MMT[2 * 7 + 2]) * J_MpT[4 * 7 +
+                           2]);
   }
-  printOut<<std::endl;
 
-}
+
+  void RKTools::Np_N_NpT(const M7x7& Np, M7x7& N)
+  {
+
+    // N is symmetric
+
+    // Np
+    // x x x 0 0 0 0
+    // x x x 0 0 0 0
+    // x x x 0 0 0 0
+    // x x x 1 0 0 0
+    // x x x 0 1 0 0
+    // x x x 0 0 1 0
+    // 0 0 0 0 0 0 1
+
+    // calculate:
+    // Np * N * Np^T
+
+    double N00(N[0 * 7 + 0]), N11(N[1 * 7 + 1]), N22(N[2 * 7 + 2]), N33(N[3 * 7 + 3]), N44(N[4 * 7 + 4]), N55(N[5 * 7 + 5]);
+
+    // replace lower left triangle using the original values from upper right triangle plus the cached diagonal values
+    N[0 * 7 + 0] = (Np[0 * 7 + 0] * N00 + Np[0 * 7 + 1] * N[0 * 7 + 1] + Np[0 * 7 + 2] * N[0 * 7 + 2]) * Np[0 * 7 + 0] +
+                   (Np[0 * 7 + 0] * N[0 * 7 + 1] + Np[0 * 7 + 1] * N11 + Np[0 * 7 + 2] * N[1 * 7 + 2]) * Np[0 * 7 + 1] +
+                   (Np[0 * 7 + 0] * N[0 * 7 + 2] + Np[0 * 7 + 1] * N[1 * 7 + 2] + Np[0 * 7 + 2] * N22) * Np[0 * 7 + 2];
+
+    N[1 * 7 + 0] = (Np[1 * 7 + 0] * N00 + Np[1 * 7 + 1] * N[0 * 7 + 1] + Np[1 * 7 + 2] * N[0 * 7 + 2]) * Np[0 * 7 + 0] +
+                   (Np[1 * 7 + 0] * N[0 * 7 + 1] + Np[1 * 7 + 1] * N11 + Np[1 * 7 + 2] * N[1 * 7 + 2]) * Np[0 * 7 + 1] +
+                   (Np[1 * 7 + 0] * N[0 * 7 + 2] + Np[1 * 7 + 1] * N[1 * 7 + 2] + Np[1 * 7 + 2] * N22) * Np[0 * 7 + 2];
+    N[1 * 7 + 1] = (Np[1 * 7 + 0] * N00 + Np[1 * 7 + 1] * N[0 * 7 + 1] + Np[1 * 7 + 2] * N[0 * 7 + 2]) * Np[1 * 7 + 0] +
+                   (Np[1 * 7 + 0] * N[0 * 7 + 1] + Np[1 * 7 + 1] * N11 + Np[1 * 7 + 2] * N[1 * 7 + 2]) * Np[1 * 7 + 1] +
+                   (Np[1 * 7 + 0] * N[0 * 7 + 2] + Np[1 * 7 + 1] * N[1 * 7 + 2] + Np[1 * 7 + 2] * N22) * Np[1 * 7 + 2];
+
+    N[2 * 7 + 0] = (Np[2 * 7 + 0] * N00 + Np[2 * 7 + 1] * N[0 * 7 + 1] + Np[2 * 7 + 2] * N[0 * 7 + 2]) * Np[0 * 7 + 0] +
+                   (Np[2 * 7 + 0] * N[0 * 7 + 1] + Np[2 * 7 + 1] * N11 + Np[2 * 7 + 2] * N[1 * 7 + 2]) * Np[0 * 7 + 1] +
+                   (Np[2 * 7 + 0] * N[0 * 7 + 2] + Np[2 * 7 + 1] * N[1 * 7 + 2] + Np[2 * 7 + 2] * N22) * Np[0 * 7 + 2];
+    N[2 * 7 + 1] = (Np[2 * 7 + 0] * N00 + Np[2 * 7 + 1] * N[0 * 7 + 1] + Np[2 * 7 + 2] * N[0 * 7 + 2]) * Np[1 * 7 + 0] +
+                   (Np[2 * 7 + 0] * N[0 * 7 + 1] + Np[2 * 7 + 1] * N11 + Np[2 * 7 + 2] * N[1 * 7 + 2]) * Np[1 * 7 + 1] +
+                   (Np[2 * 7 + 0] * N[0 * 7 + 2] + Np[2 * 7 + 1] * N[1 * 7 + 2] + Np[2 * 7 + 2] * N22) * Np[1 * 7 + 2];
+    N[2 * 7 + 2] = (Np[2 * 7 + 0] * N00 + Np[2 * 7 + 1] * N[0 * 7 + 1] + Np[2 * 7 + 2] * N[0 * 7 + 2]) * Np[2 * 7 + 0] +
+                   (Np[2 * 7 + 0] * N[0 * 7 + 1] + Np[2 * 7 + 1] * N11 + Np[2 * 7 + 2] * N[1 * 7 + 2]) * Np[2 * 7 + 1] +
+                   (Np[2 * 7 + 0] * N[0 * 7 + 2] + Np[2 * 7 + 1] * N[1 * 7 + 2] + Np[2 * 7 + 2] * N22) * Np[2 * 7 + 2];
+
+    N[3 * 7 + 0] = (Np[3 * 7 + 0] * N00 + Np[3 * 7 + 1] * N[0 * 7 + 1] + Np[3 * 7 + 2] * N[0 * 7 + 2] + N[0 * 7 + 3]) * Np[0 * 7 + 0]
+                   + (Np[3 * 7 + 0] * N[0 * 7 + 1] + Np[3 * 7 + 1] * N11 + Np[3 * 7 + 2] * N[1 * 7 + 2] + N[1 * 7 + 3]) * Np[0 * 7 + 1] +
+                   (Np[3 * 7 + 0] * N[0 * 7 + 2] + Np[3 * 7 + 1] * N[1 * 7 + 2] + Np[3 * 7 + 2] * N22 + N[2 * 7 + 3]) * Np[0 * 7 + 2];
+    N[3 * 7 + 1] = (Np[3 * 7 + 0] * N00 + Np[3 * 7 + 1] * N[0 * 7 + 1] + Np[3 * 7 + 2] * N[0 * 7 + 2] + N[0 * 7 + 3]) * Np[1 * 7 + 0]
+                   + (Np[3 * 7 + 0] * N[0 * 7 + 1] + Np[3 * 7 + 1] * N11 + Np[3 * 7 + 2] * N[1 * 7 + 2] + N[1 * 7 + 3]) * Np[1 * 7 + 1] +
+                   (Np[3 * 7 + 0] * N[0 * 7 + 2] + Np[3 * 7 + 1] * N[1 * 7 + 2] + Np[3 * 7 + 2] * N22 + N[2 * 7 + 3]) * Np[1 * 7 + 2];
+    N[3 * 7 + 2] = (Np[3 * 7 + 0] * N00 + Np[3 * 7 + 1] * N[0 * 7 + 1] + Np[3 * 7 + 2] * N[0 * 7 + 2] + N[0 * 7 + 3]) * Np[2 * 7 + 0]
+                   + (Np[3 * 7 + 0] * N[0 * 7 + 1] + Np[3 * 7 + 1] * N11 + Np[3 * 7 + 2] * N[1 * 7 + 2] + N[1 * 7 + 3]) * Np[2 * 7 + 1] +
+                   (Np[3 * 7 + 0] * N[0 * 7 + 2] + Np[3 * 7 + 1] * N[1 * 7 + 2] + Np[3 * 7 + 2] * N22 + N[2 * 7 + 3]) * Np[2 * 7 + 2];
+    N[3 * 7 + 3] = (Np[3 * 7 + 0] * N00 + Np[3 * 7 + 1] * N[0 * 7 + 1] + Np[3 * 7 + 2] * N[0 * 7 + 2] + N[0 * 7 + 3]) * Np[3 * 7 + 0]
+                   + (Np[3 * 7 + 0] * N[0 * 7 + 1] + Np[3 * 7 + 1] * N11 + Np[3 * 7 + 2] * N[1 * 7 + 2] + N[1 * 7 + 3]) * Np[3 * 7 + 1] +
+                   (Np[3 * 7 + 0] * N[0 * 7 + 2] + Np[3 * 7 + 1] * N[1 * 7 + 2] + Np[3 * 7 + 2] * N22 + N[2 * 7 + 3]) * Np[3 * 7 + 2] + Np[3 * 7 + 0] *
+                   N[0 * 7 + 3] + Np[3 * 7 + 1] * N[1 * 7 + 3] + Np[3 * 7 + 2] * N[2 * 7 + 3] + N33;
+
+    N[4 * 7 + 0] = (Np[4 * 7 + 0] * N00 + Np[4 * 7 + 1] * N[0 * 7 + 1] + Np[4 * 7 + 2] * N[0 * 7 + 2] + N[0 * 7 + 4]) * Np[0 * 7 + 0]
+                   + (Np[4 * 7 + 0] * N[0 * 7 + 1] + Np[4 * 7 + 1] * N11 + Np[4 * 7 + 2] * N[1 * 7 + 2] + N[1 * 7 + 4]) * Np[0 * 7 + 1] +
+                   (Np[4 * 7 + 0] * N[0 * 7 + 2] + Np[4 * 7 + 1] * N[1 * 7 + 2] + Np[4 * 7 + 2] * N22 + N[2 * 7 + 4]) * Np[0 * 7 + 2];
+    N[4 * 7 + 1] = (Np[4 * 7 + 0] * N00 + Np[4 * 7 + 1] * N[0 * 7 + 1] + Np[4 * 7 + 2] * N[0 * 7 + 2] + N[0 * 7 + 4]) * Np[1 * 7 + 0]
+                   + (Np[4 * 7 + 0] * N[0 * 7 + 1] + Np[4 * 7 + 1] * N11 + Np[4 * 7 + 2] * N[1 * 7 + 2] + N[1 * 7 + 4]) * Np[1 * 7 + 1] +
+                   (Np[4 * 7 + 0] * N[0 * 7 + 2] + Np[4 * 7 + 1] * N[1 * 7 + 2] + Np[4 * 7 + 2] * N22 + N[2 * 7 + 4]) * Np[1 * 7 + 2];
+    N[4 * 7 + 2] = (Np[4 * 7 + 0] * N00 + Np[4 * 7 + 1] * N[0 * 7 + 1] + Np[4 * 7 + 2] * N[0 * 7 + 2] + N[0 * 7 + 4]) * Np[2 * 7 + 0]
+                   + (Np[4 * 7 + 0] * N[0 * 7 + 1] + Np[4 * 7 + 1] * N11 + Np[4 * 7 + 2] * N[1 * 7 + 2] + N[1 * 7 + 4]) * Np[2 * 7 + 1] +
+                   (Np[4 * 7 + 0] * N[0 * 7 + 2] + Np[4 * 7 + 1] * N[1 * 7 + 2] + Np[4 * 7 + 2] * N22 + N[2 * 7 + 4]) * Np[2 * 7 + 2];
+    N[4 * 7 + 3] = (Np[4 * 7 + 0] * N00 + Np[4 * 7 + 1] * N[0 * 7 + 1] + Np[4 * 7 + 2] * N[0 * 7 + 2] + N[0 * 7 + 4]) * Np[3 * 7 + 0]
+                   + (Np[4 * 7 + 0] * N[0 * 7 + 1] + Np[4 * 7 + 1] * N11 + Np[4 * 7 + 2] * N[1 * 7 + 2] + N[1 * 7 + 4]) * Np[3 * 7 + 1] +
+                   (Np[4 * 7 + 0] * N[0 * 7 + 2] + Np[4 * 7 + 1] * N[1 * 7 + 2] + Np[4 * 7 + 2] * N22 + N[2 * 7 + 4]) * Np[3 * 7 + 2] + Np[4 * 7 + 0] *
+                   N[0 * 7 + 3] + Np[4 * 7 + 1] * N[1 * 7 + 3] + Np[4 * 7 + 2] * N[2 * 7 + 3] + N[3 * 7 + 4];
+    N[4 * 7 + 4] = (Np[4 * 7 + 0] * N00 + Np[4 * 7 + 1] * N[0 * 7 + 1] + Np[4 * 7 + 2] * N[0 * 7 + 2] + N[0 * 7 + 4]) * Np[4 * 7 + 0]
+                   + (Np[4 * 7 + 0] * N[0 * 7 + 1] + Np[4 * 7 + 1] * N11 + Np[4 * 7 + 2] * N[1 * 7 + 2] + N[1 * 7 + 4]) * Np[4 * 7 + 1] +
+                   (Np[4 * 7 + 0] * N[0 * 7 + 2] + Np[4 * 7 + 1] * N[1 * 7 + 2] + Np[4 * 7 + 2] * N22 + N[2 * 7 + 4]) * Np[4 * 7 + 2] + Np[4 * 7 + 0] *
+                   N[0 * 7 + 4] + Np[4 * 7 + 1] * N[1 * 7 + 4] + Np[4 * 7 + 2] * N[2 * 7 + 4] + N44;
+
+    N[5 * 7 + 0] = (Np[5 * 7 + 0] * N00 + Np[5 * 7 + 1] * N[0 * 7 + 1] + Np[5 * 7 + 2] * N[0 * 7 + 2] + N[0 * 7 + 5]) * Np[0 * 7 + 0]
+                   + (Np[5 * 7 + 0] * N[0 * 7 + 1] + Np[5 * 7 + 1] * N11 + Np[5 * 7 + 2] * N[1 * 7 + 2] + N[1 * 7 + 5]) * Np[0 * 7 + 1] +
+                   (Np[5 * 7 + 0] * N[0 * 7 + 2] + Np[5 * 7 + 1] * N[1 * 7 + 2] + Np[5 * 7 + 2] * N22 + N[2 * 7 + 5]) * Np[0 * 7 + 2];
+    N[5 * 7 + 1] = (Np[5 * 7 + 0] * N00 + Np[5 * 7 + 1] * N[0 * 7 + 1] + Np[5 * 7 + 2] * N[0 * 7 + 2] + N[0 * 7 + 5]) * Np[1 * 7 + 0]
+                   + (Np[5 * 7 + 0] * N[0 * 7 + 1] + Np[5 * 7 + 1] * N11 + Np[5 * 7 + 2] * N[1 * 7 + 2] + N[1 * 7 + 5]) * Np[1 * 7 + 1] +
+                   (Np[5 * 7 + 0] * N[0 * 7 + 2] + Np[5 * 7 + 1] * N[1 * 7 + 2] + Np[5 * 7 + 2] * N22 + N[2 * 7 + 5]) * Np[1 * 7 + 2];
+    N[5 * 7 + 2] = (Np[5 * 7 + 0] * N00 + Np[5 * 7 + 1] * N[0 * 7 + 1] + Np[5 * 7 + 2] * N[0 * 7 + 2] + N[0 * 7 + 5]) * Np[2 * 7 + 0]
+                   + (Np[5 * 7 + 0] * N[0 * 7 + 1] + Np[5 * 7 + 1] * N11 + Np[5 * 7 + 2] * N[1 * 7 + 2] + N[1 * 7 + 5]) * Np[2 * 7 + 1] +
+                   (Np[5 * 7 + 0] * N[0 * 7 + 2] + Np[5 * 7 + 1] * N[1 * 7 + 2] + Np[5 * 7 + 2] * N22 + N[2 * 7 + 5]) * Np[2 * 7 + 2];
+    N[5 * 7 + 3] = (Np[5 * 7 + 0] * N00 + Np[5 * 7 + 1] * N[0 * 7 + 1] + Np[5 * 7 + 2] * N[0 * 7 + 2] + N[0 * 7 + 5]) * Np[3 * 7 + 0]
+                   + (Np[5 * 7 + 0] * N[0 * 7 + 1] + Np[5 * 7 + 1] * N11 + Np[5 * 7 + 2] * N[1 * 7 + 2] + N[1 * 7 + 5]) * Np[3 * 7 + 1] +
+                   (Np[5 * 7 + 0] * N[0 * 7 + 2] + Np[5 * 7 + 1] * N[1 * 7 + 2] + Np[5 * 7 + 2] * N22 + N[2 * 7 + 5]) * Np[3 * 7 + 2] + Np[5 * 7 + 0] *
+                   N[0 * 7 + 3] + Np[5 * 7 + 1] * N[1 * 7 + 3] + Np[5 * 7 + 2] * N[2 * 7 + 3] + N[3 * 7 + 5];
+    N[5 * 7 + 4] = (Np[5 * 7 + 0] * N00 + Np[5 * 7 + 1] * N[0 * 7 + 1] + Np[5 * 7 + 2] * N[0 * 7 + 2] + N[0 * 7 + 5]) * Np[4 * 7 + 0]
+                   + (Np[5 * 7 + 0] * N[0 * 7 + 1] + Np[5 * 7 + 1] * N11 + Np[5 * 7 + 2] * N[1 * 7 + 2] + N[1 * 7 + 5]) * Np[4 * 7 + 1] +
+                   (Np[5 * 7 + 0] * N[0 * 7 + 2] + Np[5 * 7 + 1] * N[1 * 7 + 2] + Np[5 * 7 + 2] * N22 + N[2 * 7 + 5]) * Np[4 * 7 + 2] + Np[5 * 7 + 0] *
+                   N[0 * 7 + 4] + Np[5 * 7 + 1] * N[1 * 7 + 4] + Np[5 * 7 + 2] * N[2 * 7 + 4] + N[4 * 7 + 5];
+    N[5 * 7 + 5] = (Np[5 * 7 + 0] * N00 + Np[5 * 7 + 1] * N[0 * 7 + 1] + Np[5 * 7 + 2] * N[0 * 7 + 2] + N[0 * 7 + 5]) * Np[5 * 7 + 0]
+                   + (Np[5 * 7 + 0] * N[0 * 7 + 1] + Np[5 * 7 + 1] * N11 + Np[5 * 7 + 2] * N[1 * 7 + 2] + N[1 * 7 + 5]) * Np[5 * 7 + 1] +
+                   (Np[5 * 7 + 0] * N[0 * 7 + 2] + Np[5 * 7 + 1] * N[1 * 7 + 2] + Np[5 * 7 + 2] * N22 + N[2 * 7 + 5]) * Np[5 * 7 + 2] + Np[5 * 7 + 0] *
+                   N[0 * 7 + 5] + Np[5 * 7 + 1] * N[1 * 7 + 5] + Np[5 * 7 + 2] * N[2 * 7 + 5] + N55;
+
+    N[6 * 7 + 0] = Np[0 * 7 + 0] * N[0 * 7 + 6] + Np[0 * 7 + 1] * N[1 * 7 + 6] + Np[0 * 7 + 2] * N[2 * 7 + 6];
+    N[6 * 7 + 1] = Np[1 * 7 + 0] * N[0 * 7 + 6] + Np[1 * 7 + 1] * N[1 * 7 + 6] + Np[1 * 7 + 2] * N[2 * 7 + 6];
+    N[6 * 7 + 2] = Np[2 * 7 + 0] * N[0 * 7 + 6] + Np[2 * 7 + 1] * N[1 * 7 + 6] + Np[2 * 7 + 2] * N[2 * 7 + 6];
+    N[6 * 7 + 3] = Np[3 * 7 + 0] * N[0 * 7 + 6] + Np[3 * 7 + 1] * N[1 * 7 + 6] + Np[3 * 7 + 2] * N[2 * 7 + 6] + N[3 * 7 + 6];
+    N[6 * 7 + 4] = Np[4 * 7 + 0] * N[0 * 7 + 6] + Np[4 * 7 + 1] * N[1 * 7 + 6] + Np[4 * 7 + 2] * N[2 * 7 + 6] + N[4 * 7 + 6];
+    N[6 * 7 + 5] = Np[5 * 7 + 0] * N[0 * 7 + 6] + Np[5 * 7 + 1] * N[1 * 7 + 6] + Np[5 * 7 + 2] * N[2 * 7 + 6] + N[5 * 7 + 6];
+    //N[6*7+6] = N[6*7+6]; remains unchanged
+
+
+    // copy the results from the lower left triangle to the upper right triangle as well
+    N[5 * 7 + 6] = N[6 * 7 + 5];
+    N[4 * 7 + 5] = N[5 * 7 + 4];  N[4 * 7 + 6] = N[6 * 7 + 4];
+    N[3 * 7 + 4] = N[4 * 7 + 3];  N[3 * 7 + 5] = N[5 * 7 + 3];  N[3 * 7 + 6] = N[6 * 7 + 3];
+    N[2 * 7 + 3] = N[3 * 7 + 2];  N[2 * 7 + 4] = N[4 * 7 + 2];  N[2 * 7 + 5] = N[5 * 7 + 2];  N[2 * 7 + 6] = N[6 * 7 + 2];
+    N[1 * 7 + 2] = N[2 * 7 + 1];  N[1 * 7 + 3] = N[3 * 7 + 1];  N[1 * 7 + 4] = N[4 * 7 + 1];  N[1 * 7 + 5] = N[5 * 7 + 1];
+    N[1 * 7 + 6] = N[6 * 7 + 1];
+    N[0 * 7 + 1] = N[1 * 7 + 0];  N[0 * 7 + 2] = N[2 * 7 + 0];  N[0 * 7 + 3] = N[3 * 7 + 0];  N[0 * 7 + 4] = N[4 * 7 + 0];
+    N[0 * 7 + 5] = N[5 * 7 + 0];  N[0 * 7 + 6] = N[6 * 7 + 0];
+  }
+
+
+  void RKTools::printDim(const double* mat, unsigned int dimX, unsigned int dimY)
+  {
+
+    printOut << dimX << " x " << dimY << " matrix as follows: \n";
+    for (unsigned int i = 0; i < dimX; ++i) {
+      for (unsigned int j = 0; j < dimY; ++j) {
+        printf("  %11.5g", mat[i * dimY + j]);
+      }
+      printOut << "\n";
+    }
+    printOut << std::endl;
+
+  }
 
 
 } /* End of namespace genfit */

--- a/trackReps/src/RKTrackRep.cc
+++ b/trackReps/src/RKTrackRep.cc
@@ -42,1730 +42,1775 @@ namespace {
 namespace genfit {
 
 
-RKTrackRep::RKTrackRep() :
-  AbsTrackRep(),
-  lastStartState_(this),
-  lastEndState_(this),
-  RKStepsFXStart_(0),
-  RKStepsFXStop_(0),
-  fJacobian_(5,5),
-  fNoise_(5),
-  useCache_(false),
-  cachePos_(0)
-{
-  initArrays();
-}
-
-
-RKTrackRep::RKTrackRep(int pdgCode, char propDir) :
-  AbsTrackRep(pdgCode, propDir),
-  lastStartState_(this),
-  lastEndState_(this),
-  RKStepsFXStart_(0),
-  RKStepsFXStop_(0),
-  fJacobian_(5,5),
-  fNoise_(5),
-  useCache_(false),
-  cachePos_(0)
-{
-  initArrays();
-}
-
-
-RKTrackRep::~RKTrackRep() {
-  ;
-}
-
-
-double RKTrackRep::extrapolateToPlane(StateOnPlane& state,
-    const SharedPlanePtr& plane,
-    bool stopAtBoundary,
-    bool calcJacobianNoise) const {
-
-  if (debugLvl_ > 0) {
-    debugOut << "RKTrackRep::extrapolateToPlane()\n";
+  RKTrackRep::RKTrackRep() :
+    AbsTrackRep(),
+    lastStartState_(this),
+    lastEndState_(this),
+    RKStepsFXStart_(0),
+    RKStepsFXStop_(0),
+    fJacobian_(5, 5),
+    fNoise_(5),
+    useCache_(false),
+    cachePos_(0)
+  {
+    initArrays();
   }
 
 
-  if (state.getPlane() == plane) {
+  RKTrackRep::RKTrackRep(int pdgCode, char propDir) :
+    AbsTrackRep(pdgCode, propDir),
+    lastStartState_(this),
+    lastEndState_(this),
+    RKStepsFXStart_(0),
+    RKStepsFXStop_(0),
+    fJacobian_(5, 5),
+    fNoise_(5),
+    useCache_(false),
+    cachePos_(0)
+  {
+    initArrays();
+  }
+
+
+  RKTrackRep::~RKTrackRep()
+  {
+    ;
+  }
+
+
+  double RKTrackRep::extrapolateToPlane(StateOnPlane& state,
+                                        const SharedPlanePtr& plane,
+                                        bool stopAtBoundary,
+                                        bool calcJacobianNoise) const
+  {
+
     if (debugLvl_ > 0) {
-      debugOut << "state is already defined at plane. Do nothing! \n";
-    }
-    return 0;
-  }
-
-  checkCache(state, &plane);
-
-  // to 7D
-  M1x7 state7 = {{0, 0, 0, 0, 0, 0, 0}};
-  getState7(state, state7);
-
-  TMatrixDSym* covPtr(nullptr);
-  bool fillExtrapSteps(false);
-  if (dynamic_cast<MeasuredStateOnPlane*>(&state) != nullptr) {
-    covPtr = &(static_cast<MeasuredStateOnPlane*>(&state)->getCov());
-    fillExtrapSteps = true;
-  }
-  else if (calcJacobianNoise)
-    fillExtrapSteps = true;
-
-  // actual extrapolation
-  bool isAtBoundary(false);
-  double flightTime( 0. );
-  double coveredDistance( Extrap(*(state.getPlane()), *plane, getCharge(state), getMass(state), isAtBoundary, state7, flightTime, fillExtrapSteps, covPtr, false, stopAtBoundary) );
-
-  if (stopAtBoundary && isAtBoundary) {
-    state.setPlane(SharedPlanePtr(new DetPlane(TVector3(state7[0], state7[1], state7[2]),
-                                                TVector3(state7[3], state7[4], state7[5]))));
-  }
-  else {
-    state.setPlane(plane);
-  }
-
-  // back to 5D
-  getState5(state, state7);
-  setTime(state, getTime(state) + flightTime);
-
-  lastEndState_ = state;
-
-  return coveredDistance;
-}
-
-
-double RKTrackRep::extrapolateToLine(StateOnPlane& state,
-    const TVector3& linePoint,
-    const TVector3& lineDirection,
-    bool stopAtBoundary,
-    bool calcJacobianNoise) const {
-
-  if (debugLvl_ > 0) {
-    debugOut << "RKTrackRep::extrapolateToLine()\n";
-  }
-
-  checkCache(state, nullptr);
-
-  static const unsigned int maxIt(1000);
-
-  // to 7D
-  M1x7 state7;
-  getState7(state, state7);
-
-  bool fillExtrapSteps(false);
-  if (dynamic_cast<MeasuredStateOnPlane*>(&state) != nullptr) {
-    fillExtrapSteps = true;
-  }
-  else if (calcJacobianNoise)
-    fillExtrapSteps = true;
-
-  // cppcheck-suppress unreadVariable
-  double step(0.), lastStep(0.), maxStep(1.E99), angle(0), distToPoca(0), tracklength(0);
-  double charge = getCharge(state);
-  double mass = getMass(state);
-  double flightTime = 0;
-  TVector3 dir(state7[3], state7[4], state7[5]);
-  TVector3 lastDir(0,0,0);
-  TVector3 poca, poca_onwire;
-  bool isAtBoundary(false);
-
-  DetPlane startPlane(*(state.getPlane()));
-  SharedPlanePtr plane(new DetPlane(linePoint, dir.Cross(lineDirection), lineDirection));
-  unsigned int iterations(0);
-
-  while(true){
-    if(++iterations == maxIt) {
-      Exception exc("RKTrackRep::extrapolateToLine ==> extrapolation to line failed, maximum number of iterations reached",__LINE__,__FILE__);
-      exc.setFatal();
-      throw exc;
+      debugOut << "RKTrackRep::extrapolateToPlane()\n";
     }
 
-    lastStep = step;
-    lastDir = dir;
 
-    step = this->Extrap(startPlane, *plane, charge, mass, isAtBoundary, state7, flightTime, false, nullptr, true, stopAtBoundary, maxStep);
-    tracklength += step;
+    if (state.getPlane() == plane) {
+      if (debugLvl_ > 0) {
+        debugOut << "state is already defined at plane. Do nothing! \n";
+      }
+      return 0;
+    }
 
-    dir.SetXYZ(state7[3], state7[4], state7[5]);
-    poca.SetXYZ(state7[0], state7[1], state7[2]);
-    poca_onwire = pocaOnLine(linePoint, lineDirection, poca);
+    checkCache(state, &plane);
 
-    // check break conditions
+    // to 7D
+    M1x7 state7 = {{0, 0, 0, 0, 0, 0, 0}};
+    getState7(state, state7);
+
+    TMatrixDSym* covPtr(nullptr);
+    bool fillExtrapSteps(false);
+    if (dynamic_cast<MeasuredStateOnPlane*>(&state) != nullptr) {
+      covPtr = &(static_cast<MeasuredStateOnPlane*>(&state)->getCov());
+      fillExtrapSteps = true;
+    } else if (calcJacobianNoise)
+      fillExtrapSteps = true;
+
+    // actual extrapolation
+    bool isAtBoundary(false);
+    double flightTime(0.);
+    double coveredDistance(Extrap(*(state.getPlane()), *plane, getCharge(state), getMass(state), isAtBoundary, state7, flightTime,
+                                  fillExtrapSteps, covPtr, false, stopAtBoundary));
+
     if (stopAtBoundary && isAtBoundary) {
-      plane->setON(dir, poca);
-      break;
+      state.setPlane(SharedPlanePtr(new DetPlane(TVector3(state7[0], state7[1], state7[2]),
+                                                 TVector3(state7[3], state7[4], state7[5]))));
+    } else {
+      state.setPlane(plane);
     }
 
-    angle = fabs(dir.Angle((poca_onwire-poca))-TMath::PiOver2()); // angle between direction and connection to point - 90 deg
-    distToPoca = (poca_onwire-poca).Mag();
-    if (angle*distToPoca < 0.1*MINSTEP) break;
-
-    // if lastStep and step have opposite sign, the real normal vector lies somewhere between the last two normal vectors (i.e. the directions)
-    // -> try mean value of the two (normalization not needed)
-    if (lastStep*step < 0){
-      dir += lastDir;
-      maxStep = 0.5*fabs(lastStep); // make it converge!
-    }
-
-    startPlane = *plane;
-    plane->setU(dir.Cross(lineDirection));
-  }
-
-  if (fillExtrapSteps) { // now do the full extrapolation with covariance matrix
-    // make use of the cache
-    lastEndState_.setPlane(plane);
-    getState5(lastEndState_, state7);
-
-    tracklength = extrapolateToPlane(state, plane, false, true);
-    lastEndState_.getAuxInfo()(1) = state.getAuxInfo()(1); // Flight time
-  }
-  else {
-    state.setPlane(plane);
+    // back to 5D
     getState5(state, state7);
-    state.getAuxInfo()(1) += flightTime;
+    setTime(state, getTime(state) + flightTime);
+
+    lastEndState_ = state;
+
+    return coveredDistance;
   }
 
-  if (debugLvl_ > 0) {
-    debugOut << "RKTrackRep::extrapolateToLine(): Reached POCA after " << iterations+1 << " iterations. Distance: " << (poca_onwire-poca).Mag() << " cm. Angle deviation: " << dir.Angle((poca_onwire-poca))-TMath::PiOver2() << " rad \n";
-  }
 
-  lastEndState_ = state;
+  double RKTrackRep::extrapolateToLine(StateOnPlane& state,
+                                       const TVector3& linePoint,
+                                       const TVector3& lineDirection,
+                                       bool stopAtBoundary,
+                                       bool calcJacobianNoise) const
+  {
 
-  return tracklength;
-}
-
-
-double RKTrackRep::extrapToPoint(StateOnPlane& state,
-    const TVector3& point,
-    const TMatrixDSym* G,
-    bool stopAtBoundary,
-    bool calcJacobianNoise) const {
-
-  if (debugLvl_ > 0) {
-    debugOut << "RKTrackRep::extrapolateToPoint()\n";
-  }
-
-  checkCache(state, nullptr);
-
-  static const unsigned int maxIt(1000);
-
-  // to 7D
-  M1x7 state7;
-  getState7(state, state7);
-
-  bool fillExtrapSteps(false);
-  if (dynamic_cast<MeasuredStateOnPlane*>(&state) != nullptr) {
-    fillExtrapSteps = true;
-  }
-  else if (calcJacobianNoise)
-    fillExtrapSteps = true;
-
-  // cppcheck-suppress unreadVariable
-  double step(0.), lastStep(0.), maxStep(1.E99), angle(0), distToPoca(0), tracklength(0);
-  TVector3 dir(state7[3], state7[4], state7[5]);
-  if (G != nullptr) {
-    if(G->GetNrows() != 3) {
-      Exception exc("RKTrackRep::extrapolateToLine ==> G is not 3x3",__LINE__,__FILE__);
-      exc.setFatal();
-      throw exc;
-    }
-    dir = TMatrix(*G) * dir;
-  }
-  TVector3 lastDir(0,0,0);
-
-  TVector3 poca;
-  bool isAtBoundary(false);
-
-  DetPlane startPlane(*(state.getPlane()));
-  SharedPlanePtr plane(new DetPlane(point, dir));
-  unsigned int iterations(0);
-  double charge = getCharge(state);
-  double mass = getMass(state);
-  double flightTime = 0;
-
-  while(true){
-    if(++iterations == maxIt) {
-      Exception exc("RKTrackRep::extrapolateToPoint ==> extrapolation to point failed, maximum number of iterations reached",__LINE__,__FILE__);
-      exc.setFatal();
-      throw exc;
+    if (debugLvl_ > 0) {
+      debugOut << "RKTrackRep::extrapolateToLine()\n";
     }
 
-    lastStep = step;
-    lastDir = dir;
+    checkCache(state, nullptr);
 
-    step = this->Extrap(startPlane, *plane, charge, mass, isAtBoundary, state7, flightTime, false, nullptr, true, stopAtBoundary, maxStep);
-    tracklength += step;
+    static const unsigned int maxIt(1000);
 
-    dir.SetXYZ(state7[3], state7[4], state7[5]);
+    // to 7D
+    M1x7 state7;
+    getState7(state, state7);
+
+    bool fillExtrapSteps(false);
+    if (dynamic_cast<MeasuredStateOnPlane*>(&state) != nullptr) {
+      fillExtrapSteps = true;
+    } else if (calcJacobianNoise)
+      fillExtrapSteps = true;
+
+    // cppcheck-suppress unreadVariable
+    double step(0.), lastStep(0.), maxStep(1.E99), angle(0), distToPoca(0), tracklength(0);
+    double charge = getCharge(state);
+    double mass = getMass(state);
+    double flightTime = 0;
+    TVector3 dir(state7[3], state7[4], state7[5]);
+    TVector3 lastDir(0, 0, 0);
+    TVector3 poca, poca_onwire;
+    bool isAtBoundary(false);
+
+    DetPlane startPlane(*(state.getPlane()));
+    SharedPlanePtr plane(new DetPlane(linePoint, dir.Cross(lineDirection), lineDirection));
+    unsigned int iterations(0);
+
+    while (true) {
+      if (++iterations == maxIt) {
+        Exception exc("RKTrackRep::extrapolateToLine ==> extrapolation to line failed, maximum number of iterations reached", __LINE__,
+                      __FILE__);
+        exc.setFatal();
+        throw exc;
+      }
+
+      lastStep = step;
+      lastDir = dir;
+
+      step = this->Extrap(startPlane, *plane, charge, mass, isAtBoundary, state7, flightTime, false, nullptr, true, stopAtBoundary,
+                          maxStep);
+      tracklength += step;
+
+      dir.SetXYZ(state7[3], state7[4], state7[5]);
+      poca.SetXYZ(state7[0], state7[1], state7[2]);
+      poca_onwire = pocaOnLine(linePoint, lineDirection, poca);
+
+      // check break conditions
+      if (stopAtBoundary && isAtBoundary) {
+        plane->setON(dir, poca);
+        break;
+      }
+
+      angle = fabs(dir.Angle((poca_onwire - poca)) - TMath::PiOver2()); // angle between direction and connection to point - 90 deg
+      distToPoca = (poca_onwire - poca).Mag();
+      if (angle * distToPoca < 0.1 * MINSTEP) break;
+
+      // if lastStep and step have opposite sign, the real normal vector lies somewhere between the last two normal vectors (i.e. the directions)
+      // -> try mean value of the two (normalization not needed)
+      if (lastStep * step < 0) {
+        dir += lastDir;
+        maxStep = 0.5 * fabs(lastStep); // make it converge!
+      }
+
+      startPlane = *plane;
+      plane->setU(dir.Cross(lineDirection));
+    }
+
+    if (fillExtrapSteps) { // now do the full extrapolation with covariance matrix
+      // make use of the cache
+      lastEndState_.setPlane(plane);
+      getState5(lastEndState_, state7);
+
+      tracklength = extrapolateToPlane(state, plane, false, true);
+      lastEndState_.getAuxInfo()(1) = state.getAuxInfo()(1); // Flight time
+    } else {
+      state.setPlane(plane);
+      getState5(state, state7);
+      state.getAuxInfo()(1) += flightTime;
+    }
+
+    if (debugLvl_ > 0) {
+      debugOut << "RKTrackRep::extrapolateToLine(): Reached POCA after " << iterations + 1 << " iterations. Distance: " <<
+               (poca_onwire - poca).Mag() << " cm. Angle deviation: " << dir.Angle((poca_onwire - poca)) - TMath::PiOver2() << " rad \n";
+    }
+
+    lastEndState_ = state;
+
+    return tracklength;
+  }
+
+
+  double RKTrackRep::extrapToPoint(StateOnPlane& state,
+                                   const TVector3& point,
+                                   const TMatrixDSym* G,
+                                   bool stopAtBoundary,
+                                   bool calcJacobianNoise) const
+  {
+
+    if (debugLvl_ > 0) {
+      debugOut << "RKTrackRep::extrapolateToPoint()\n";
+    }
+
+    checkCache(state, nullptr);
+
+    static const unsigned int maxIt(1000);
+
+    // to 7D
+    M1x7 state7;
+    getState7(state, state7);
+
+    bool fillExtrapSteps(false);
+    if (dynamic_cast<MeasuredStateOnPlane*>(&state) != nullptr) {
+      fillExtrapSteps = true;
+    } else if (calcJacobianNoise)
+      fillExtrapSteps = true;
+
+    // cppcheck-suppress unreadVariable
+    double step(0.), lastStep(0.), maxStep(1.E99), angle(0), distToPoca(0), tracklength(0);
+    TVector3 dir(state7[3], state7[4], state7[5]);
     if (G != nullptr) {
+      if (G->GetNrows() != 3) {
+        Exception exc("RKTrackRep::extrapolateToLine ==> G is not 3x3", __LINE__, __FILE__);
+        exc.setFatal();
+        throw exc;
+      }
       dir = TMatrix(*G) * dir;
     }
-    poca.SetXYZ(state7[0], state7[1], state7[2]);
+    TVector3 lastDir(0, 0, 0);
 
-    // check break conditions
-    if (stopAtBoundary && isAtBoundary) {
-      plane->setON(dir, poca);
-      break;
-    }
+    TVector3 poca;
+    bool isAtBoundary(false);
 
-    angle = fabs(dir.Angle((point-poca))-TMath::PiOver2()); // angle between direction and connection to point - 90 deg
-    distToPoca = (point-poca).Mag();
-    if (angle*distToPoca < 0.1*MINSTEP) break;
+    DetPlane startPlane(*(state.getPlane()));
+    SharedPlanePtr plane(new DetPlane(point, dir));
+    unsigned int iterations(0);
+    double charge = getCharge(state);
+    double mass = getMass(state);
+    double flightTime = 0;
 
-    // if lastStep and step have opposite sign, the real normal vector lies somewhere between the last two normal vectors (i.e. the directions)
-    // -> try mean value of the two
-    if (lastStep*step < 0){
-      if (G != nullptr) { // after multiplication with G, dir has not length 1 anymore in general
-        dir.SetMag(1.);
-        lastDir.SetMag(1.);
+    while (true) {
+      if (++iterations == maxIt) {
+        Exception exc("RKTrackRep::extrapolateToPoint ==> extrapolation to point failed, maximum number of iterations reached", __LINE__,
+                      __FILE__);
+        exc.setFatal();
+        throw exc;
       }
-      dir += lastDir;
-      maxStep = 0.5*fabs(lastStep); // make it converge!
+
+      lastStep = step;
+      lastDir = dir;
+
+      step = this->Extrap(startPlane, *plane, charge, mass, isAtBoundary, state7, flightTime, false, nullptr, true, stopAtBoundary,
+                          maxStep);
+      tracklength += step;
+
+      dir.SetXYZ(state7[3], state7[4], state7[5]);
+      if (G != nullptr) {
+        dir = TMatrix(*G) * dir;
+      }
+      poca.SetXYZ(state7[0], state7[1], state7[2]);
+
+      // check break conditions
+      if (stopAtBoundary && isAtBoundary) {
+        plane->setON(dir, poca);
+        break;
+      }
+
+      angle = fabs(dir.Angle((point - poca)) - TMath::PiOver2()); // angle between direction and connection to point - 90 deg
+      distToPoca = (point - poca).Mag();
+      if (angle * distToPoca < 0.1 * MINSTEP) break;
+
+      // if lastStep and step have opposite sign, the real normal vector lies somewhere between the last two normal vectors (i.e. the directions)
+      // -> try mean value of the two
+      if (lastStep * step < 0) {
+        if (G != nullptr) { // after multiplication with G, dir has not length 1 anymore in general
+          dir.SetMag(1.);
+          lastDir.SetMag(1.);
+        }
+        dir += lastDir;
+        maxStep = 0.5 * fabs(lastStep); // make it converge!
+      }
+
+      startPlane = *plane;
+      plane->setNormal(dir);
     }
 
-    startPlane = *plane;
-    plane->setNormal(dir);
-  }
+    if (fillExtrapSteps) { // now do the full extrapolation with covariance matrix
+      // make use of the cache
+      lastEndState_.setPlane(plane);
+      getState5(lastEndState_, state7);
 
-  if (fillExtrapSteps) { // now do the full extrapolation with covariance matrix
-    // make use of the cache
-    lastEndState_.setPlane(plane);
-    getState5(lastEndState_, state7);
-
-    tracklength = extrapolateToPlane(state, plane, false, true);
-    lastEndState_.getAuxInfo()(1) = state.getAuxInfo()(1); // Flight time
-  }
-  else {
-    state.setPlane(plane);
-    getState5(state, state7);
-    state.getAuxInfo()(1) += flightTime;
-  }
-
-
-  if (debugLvl_ > 0) {
-    debugOut << "RKTrackRep::extrapolateToPoint(): Reached POCA after " << iterations+1 << " iterations. Distance: " << (point-poca).Mag() << " cm. Angle deviation: " << dir.Angle((point-poca))-TMath::PiOver2() << " rad \n";
-  }
-
-  lastEndState_ = state;
-
-  return tracklength;
-}
-
-
-double RKTrackRep::extrapolateToCylinder(StateOnPlane& state,
-    double radius,
-    const TVector3& linePoint,
-    const TVector3& lineDirection,
-    bool stopAtBoundary,
-    bool calcJacobianNoise) const {
-
-  if (debugLvl_ > 0) {
-    debugOut << "RKTrackRep::extrapolateToCylinder()\n";
-  }
-
-  checkCache(state, nullptr);
-
-  static const unsigned int maxIt(1000);
-
-  // to 7D
-  M1x7 state7;
-  getState7(state, state7);
-
-  bool fillExtrapSteps(false);
-  if (dynamic_cast<MeasuredStateOnPlane*>(&state) != nullptr) {
-    fillExtrapSteps = true;
-  }
-  else if (calcJacobianNoise)
-    fillExtrapSteps = true;
-
-  double tracklength(0.), maxStep(1.E99);
-
-  TVector3 dest, pos, dir;
-
-  bool isAtBoundary(false);
-
-  DetPlane startPlane(*(state.getPlane()));
-  SharedPlanePtr plane(new DetPlane());
-  unsigned int iterations(0);
-  double charge = getCharge(state);
-  double mass = getMass(state);
-  double flightTime = 0;
-
-  while(true){
-    if(++iterations == maxIt) {
-      Exception exc("RKTrackRep::extrapolateToCylinder ==> maximum number of iterations reached",__LINE__,__FILE__);
-      exc.setFatal();
-      throw exc;
+      tracklength = extrapolateToPlane(state, plane, false, true);
+      lastEndState_.getAuxInfo()(1) = state.getAuxInfo()(1); // Flight time
+    } else {
+      state.setPlane(plane);
+      getState5(state, state7);
+      state.getAuxInfo()(1) += flightTime;
     }
 
-    pos.SetXYZ(state7[0], state7[1], state7[2]);
-    dir.SetXYZ(state7[3], state7[4], state7[5]);
-
-    // solve quadratic equation
-    TVector3 AO = (pos - linePoint);
-    TVector3 AOxAB = (AO.Cross(lineDirection));
-    TVector3 VxAB  = (dir.Cross(lineDirection));
-    float ab2    = (lineDirection * lineDirection);
-    float a      = (VxAB * VxAB);
-    float b      = 2 * (VxAB * AOxAB);
-    float c      = (AOxAB * AOxAB) - (radius*radius * ab2);
-    double arg = b*b - 4.*a*c;
-    if(arg < 0) {
-      Exception exc("RKTrackRep::extrapolateToCylinder ==> cannot solve",__LINE__,__FILE__);
-      exc.setFatal();
-      throw exc;
-    }
-    double term = sqrt(arg);
-    double k1, k2;
-    if (b<0) {
-      k1 = (-b + term)/(2.*a);
-      k2 = 2.*c/(-b + term);
-    }
-    else {
-      k1 = 2.*c/(-b - term);
-      k2 = (-b - term)/(2.*a);
-    }
-
-    // select smallest absolute solution -> closest cylinder surface
-    double k = k1;
-    if (fabs(k2)<fabs(k))
-    k = k2;
 
     if (debugLvl_ > 0) {
-      debugOut << "RKTrackRep::extrapolateToCylinder(); k = " << k << "\n";
+      debugOut << "RKTrackRep::extrapolateToPoint(): Reached POCA after " << iterations + 1 << " iterations. Distance: " <<
+               (point - poca).Mag() << " cm. Angle deviation: " << dir.Angle((point - poca)) - TMath::PiOver2() << " rad \n";
     }
 
-    dest = pos + k * dir;
+    lastEndState_ = state;
 
-    plane->setO(dest);
-    plane->setUV((dest-linePoint).Cross(lineDirection), lineDirection);
-
-    tracklength += this->Extrap(startPlane, *plane, charge, mass, isAtBoundary, state7, flightTime, false, nullptr, true, stopAtBoundary, maxStep);
-
-    // check break conditions
-    if (stopAtBoundary && isAtBoundary) {
-      pos.SetXYZ(state7[0], state7[1], state7[2]);
-      dir.SetXYZ(state7[3], state7[4], state7[5]);
-      plane->setO(pos);
-      plane->setUV((pos-linePoint).Cross(lineDirection), lineDirection);
-      break;
-    }
-
-    if(fabs(k)<MINSTEP) break;
-
-    startPlane = *plane;
-
+    return tracklength;
   }
 
-  if (fillExtrapSteps) { // now do the full extrapolation with covariance matrix
-    // make use of the cache
-    lastEndState_.setPlane(plane);
-    getState5(lastEndState_, state7);
 
-    tracklength = extrapolateToPlane(state, plane, false, true);
-    lastEndState_.getAuxInfo()(1) = state.getAuxInfo()(1); // Flight time
-  }
-  else {
-    state.setPlane(plane);
-    getState5(state, state7);
-    state.getAuxInfo()(1) += flightTime;
-  }
-
-  lastEndState_ = state;
-
-  return tracklength;
-}
-
-  
-double RKTrackRep::extrapolateToCone(StateOnPlane& state,
-    double openingAngle,
-    const TVector3& conePoint,
-    const TVector3& coneDirection,
-    bool stopAtBoundary,
-    bool calcJacobianNoise) const {
-
-  if (debugLvl_ > 0) {
-    debugOut << "RKTrackRep::extrapolateToCone()\n";
-  }
-
-  checkCache(state, nullptr);
-
-  static const unsigned int maxIt(1000);
-
-  // to 7D
-  M1x7 state7;
-  getState7(state, state7);
-
-  bool fillExtrapSteps(false);
-  if (dynamic_cast<MeasuredStateOnPlane*>(&state) != nullptr) {
-    fillExtrapSteps = true;
-  }
-  else if (calcJacobianNoise)
-    fillExtrapSteps = true;
-
-  double tracklength(0.), maxStep(1.E99);
-
-  TVector3 dest, pos, dir;
-
-  bool isAtBoundary(false);
-
-  DetPlane startPlane(*(state.getPlane()));
-  SharedPlanePtr plane(new DetPlane());
-  unsigned int iterations(0);
-  double charge = getCharge(state);
-  double mass = getMass(state);
-  double flightTime = 0;
-
-  while(true){
-    if(++iterations == maxIt) {
-      Exception exc("RKTrackRep::extrapolateToCone ==> maximum number of iterations reached",__LINE__,__FILE__);
-      exc.setFatal();
-      throw exc;
-    }
-
-    pos.SetXYZ(state7[0], state7[1], state7[2]);
-    dir.SetXYZ(state7[3], state7[4], state7[5]);
-
-    // solve quadratic equation a k^2 + 2 b k + c = 0
-    // a = (U . D)^2 - cos^2 alpha * U^2
-    // b = (Delta . D) * (U . D) - cos^2 alpha * (U . Delta)
-    // c = (Delta . D)^2 - cos^2 alpha * Delta^2
-    // Delta = P - V, P track point, U track direction, V cone point, D cone direction, alpha opening angle of cone
-    TVector3 cDirection = coneDirection.Unit();
-    TVector3 Delta = (pos - conePoint);
-    double DirDelta = cDirection * Delta;
-    double Delta2 = Delta*Delta;
-    double UDir = dir * cDirection;
-    double UDelta = dir * Delta;
-    double U2 = dir * dir;
-    double cosAngle2 = cos(openingAngle)*cos(openingAngle);
-    double a = UDir*UDir - cosAngle2*U2;
-    double b = UDir*DirDelta - cosAngle2*UDelta;
-    double c = DirDelta*DirDelta - cosAngle2*Delta2;
-    
-    double arg = b*b - a*c;
-    if(arg < -1e-9) {
-      Exception exc("RKTrackRep::extrapolateToCone ==> cannot solve",__LINE__,__FILE__);
-      exc.setFatal();
-      throw exc;
-    } else if(arg < 0) {
-      arg = 0;
-    }
-
-    double term = sqrt(arg);
-    double k1, k2;
-    k1 = (-b + term) / a;
-    k2 = (-b - term) / a;
-
-    // select smallest absolute solution -> closest cone surface
-    double k = k1;
-    if(fabs(k2) < fabs(k)) {
-      k = k2;
-    }
+  double RKTrackRep::extrapolateToCylinder(StateOnPlane& state,
+                                           double radius,
+                                           const TVector3& linePoint,
+                                           const TVector3& lineDirection,
+                                           bool stopAtBoundary,
+                                           bool calcJacobianNoise) const
+  {
 
     if (debugLvl_ > 0) {
-      debugOut << "RKTrackRep::extrapolateToCone(); k = " << k << "\n";
+      debugOut << "RKTrackRep::extrapolateToCylinder()\n";
     }
 
-    dest = pos + k * dir;
-    // debugOut << "In cone extrapolation ";
-    // dest.Print();
+    checkCache(state, nullptr);
 
-    plane->setO(dest);
-    plane->setUV((dest-conePoint).Cross(coneDirection), dest-conePoint);
+    static const unsigned int maxIt(1000);
 
-    tracklength += this->Extrap(startPlane, *plane, charge, mass, isAtBoundary, state7, flightTime, false, nullptr, true, stopAtBoundary, maxStep);
+    // to 7D
+    M1x7 state7;
+    getState7(state, state7);
 
-    // check break conditions
-    if (stopAtBoundary && isAtBoundary) {
+    bool fillExtrapSteps(false);
+    if (dynamic_cast<MeasuredStateOnPlane*>(&state) != nullptr) {
+      fillExtrapSteps = true;
+    } else if (calcJacobianNoise)
+      fillExtrapSteps = true;
+
+    double tracklength(0.), maxStep(1.E99);
+
+    TVector3 dest, pos, dir;
+
+    bool isAtBoundary(false);
+
+    DetPlane startPlane(*(state.getPlane()));
+    SharedPlanePtr plane(new DetPlane());
+    unsigned int iterations(0);
+    double charge = getCharge(state);
+    double mass = getMass(state);
+    double flightTime = 0;
+
+    while (true) {
+      if (++iterations == maxIt) {
+        Exception exc("RKTrackRep::extrapolateToCylinder ==> maximum number of iterations reached", __LINE__, __FILE__);
+        exc.setFatal();
+        throw exc;
+      }
+
       pos.SetXYZ(state7[0], state7[1], state7[2]);
       dir.SetXYZ(state7[3], state7[4], state7[5]);
-      plane->setO(pos);
-      plane->setUV((pos-conePoint).Cross(coneDirection), pos-conePoint);
-      break;
-    }
 
-    if(fabs(k)<MINSTEP) break;
+      // solve quadratic equation
+      TVector3 AO = (pos - linePoint);
+      TVector3 AOxAB = (AO.Cross(lineDirection));
+      TVector3 VxAB  = (dir.Cross(lineDirection));
+      float ab2    = (lineDirection * lineDirection);
+      float a      = (VxAB * VxAB);
+      float b      = 2 * (VxAB * AOxAB);
+      float c      = (AOxAB * AOxAB) - (radius * radius * ab2);
+      double arg = b * b - 4.*a * c;
+      if (arg < 0) {
+        Exception exc("RKTrackRep::extrapolateToCylinder ==> cannot solve", __LINE__, __FILE__);
+        exc.setFatal();
+        throw exc;
+      }
+      double term = sqrt(arg);
+      double k1, k2;
+      if (b < 0) {
+        k1 = (-b + term) / (2.*a);
+        k2 = 2.*c / (-b + term);
+      } else {
+        k1 = 2.*c / (-b - term);
+        k2 = (-b - term) / (2.*a);
+      }
 
-    startPlane = *plane;
+      // select smallest absolute solution -> closest cylinder surface
+      double k = k1;
+      if (fabs(k2) < fabs(k))
+        k = k2;
 
-  }
-
-  if (fillExtrapSteps) { // now do the full extrapolation with covariance matrix
-    // make use of the cache
-    lastEndState_.setPlane(plane);
-    getState5(lastEndState_, state7);
-
-    tracklength = extrapolateToPlane(state, plane, false, true);
-    lastEndState_.getAuxInfo()(1) = state.getAuxInfo()(1); // Flight time
-  }
-  else {
-    state.setPlane(plane);
-    getState5(state, state7);
-    state.getAuxInfo()(1) += flightTime;
-  }
-
-  lastEndState_ = state;
-
-  return tracklength;
-}
-
-
-double RKTrackRep::extrapolateToSphere(StateOnPlane& state,
-    double radius,
-    const TVector3& point, // center
-    bool stopAtBoundary,
-    bool calcJacobianNoise) const {
-
-  if (debugLvl_ > 0) {
-    debugOut << "RKTrackRep::extrapolateToSphere()\n";
-  }
-
-  checkCache(state, nullptr);
-
-  static const unsigned int maxIt(1000);
-
-  // to 7D
-  M1x7 state7;
-  getState7(state, state7);
-
-  bool fillExtrapSteps(false);
-  if (dynamic_cast<MeasuredStateOnPlane*>(&state) != nullptr) {
-    fillExtrapSteps = true;
-  }
-  else if (calcJacobianNoise)
-    fillExtrapSteps = true;
-
-  double tracklength(0.), maxStep(1.E99);
-
-  TVector3 dest, pos, dir;
-
-  bool isAtBoundary(false);
-
-  DetPlane startPlane(*(state.getPlane()));
-  SharedPlanePtr plane(new DetPlane());
-  unsigned int iterations(0);
-  double charge = getCharge(state);
-  double mass = getMass(state);
-  double flightTime = 0;
-
-  while(true){
-    if(++iterations == maxIt) {
-      Exception exc("RKTrackRep::extrapolateToSphere ==> maximum number of iterations reached",__LINE__,__FILE__);
-      exc.setFatal();
-      throw exc;
-    }
-
-    pos.SetXYZ(state7[0], state7[1], state7[2]);
-    dir.SetXYZ(state7[3], state7[4], state7[5]);
-
-    // solve quadratic equation
-    TVector3 AO = (pos - point);
-    double dirAO = dir * AO;
-    double arg = dirAO*dirAO - AO*AO + radius*radius;
-    if(arg < 0) {
-      Exception exc("RKTrackRep::extrapolateToSphere ==> cannot solve",__LINE__,__FILE__);
-      exc.setFatal();
-      throw exc;
-    }
-    double term = sqrt(arg);
-    double k1, k2;
-    k1 = -dirAO + term;
-    k2 = -dirAO - term;
-
-    // select smallest absolute solution -> closest cylinder surface
-    double k = k1;
-    if (fabs(k2)<fabs(k))
-    k = k2;
-
-    if (debugLvl_ > 0) {
-      debugOut << "RKTrackRep::extrapolateToSphere(); k = " << k << "\n";
-    }
-
-    dest = pos + k * dir;
-
-    plane->setON(dest, dest-point);
-
-    tracklength += this->Extrap(startPlane, *plane, charge, mass, isAtBoundary, state7, flightTime, false, nullptr, true, stopAtBoundary, maxStep);
-
-    // check break conditions
-    if (stopAtBoundary && isAtBoundary) {
-      pos.SetXYZ(state7[0], state7[1], state7[2]);
-      dir.SetXYZ(state7[3], state7[4], state7[5]);
-      plane->setON(pos, pos-point);
-      break;
-    }
-
-    if(fabs(k)<MINSTEP) break;
-
-    startPlane = *plane;
-
-  }
-
-  if (fillExtrapSteps) { // now do the full extrapolation with covariance matrix
-    // make use of the cache
-    lastEndState_.setPlane(plane);
-    getState5(lastEndState_, state7);
-
-    tracklength = extrapolateToPlane(state, plane, false, true);
-    lastEndState_.getAuxInfo()(1) = state.getAuxInfo()(1); // Flight time
-  }
-  else {
-    state.setPlane(plane);
-    getState5(state, state7);
-    state.getAuxInfo()(1) += flightTime;
-  }
-
-  lastEndState_ = state;
-
-  return tracklength;
-}
-
-
-double RKTrackRep::extrapolateBy(StateOnPlane& state,
-    double step,
-    bool stopAtBoundary,
-    bool calcJacobianNoise) const {
-
-  if (debugLvl_ > 0) {
-    debugOut << "RKTrackRep::extrapolateBy()\n";
-  }
-
-  checkCache(state, nullptr);
-
-  static const unsigned int maxIt(1000);
-
-  // to 7D
-  M1x7 state7;
-  getState7(state, state7);
-
-  bool fillExtrapSteps(false);
-  if (dynamic_cast<MeasuredStateOnPlane*>(&state) != nullptr) {
-    fillExtrapSteps = true;
-  }
-  else if (calcJacobianNoise)
-    fillExtrapSteps = true;
-
-  double tracklength(0.);
-
-  TVector3 dest, pos, dir;
-
-  bool isAtBoundary(false);
-
-  DetPlane startPlane(*(state.getPlane()));
-  SharedPlanePtr plane(new DetPlane());
-  unsigned int iterations(0);
-  double charge = getCharge(state);
-  double mass = getMass(state);
-  double flightTime = 0;
-
-  while(true){
-    if(++iterations == maxIt) {
-      Exception exc("RKTrackRep::extrapolateBy ==> maximum number of iterations reached",__LINE__,__FILE__);
-      exc.setFatal();
-      throw exc;
-    }
-
-    pos.SetXYZ(state7[0], state7[1], state7[2]);
-    dir.SetXYZ(state7[3], state7[4], state7[5]);
-
-    dest = pos + 1.5*(step-tracklength) * dir;
-
-    plane->setON(dest, dir);
-
-    tracklength += this->Extrap(startPlane, *plane, charge, mass, isAtBoundary, state7, flightTime, false, nullptr, true, stopAtBoundary, (step-tracklength));
-
-    // check break conditions
-    if (stopAtBoundary && isAtBoundary) {
-      pos.SetXYZ(state7[0], state7[1], state7[2]);
-      dir.SetXYZ(state7[3], state7[4], state7[5]);
-      plane->setON(pos, dir);
-      break;
-    }
-
-    if (fabs(tracklength-step) < MINSTEP) {
       if (debugLvl_ > 0) {
-        debugOut << "RKTrackRep::extrapolateBy(): reached after " << iterations << " iterations. \n";
+        debugOut << "RKTrackRep::extrapolateToCylinder(); k = " << k << "\n";
       }
+
+      dest = pos + k * dir;
+
+      plane->setO(dest);
+      plane->setUV((dest - linePoint).Cross(lineDirection), lineDirection);
+
+      tracklength += this->Extrap(startPlane, *plane, charge, mass, isAtBoundary, state7, flightTime, false, nullptr, true,
+                                  stopAtBoundary, maxStep);
+
+      // check break conditions
+      if (stopAtBoundary && isAtBoundary) {
+        pos.SetXYZ(state7[0], state7[1], state7[2]);
+        dir.SetXYZ(state7[3], state7[4], state7[5]);
+        plane->setO(pos);
+        plane->setUV((pos - linePoint).Cross(lineDirection), lineDirection);
+        break;
+      }
+
+      if (fabs(k) < MINSTEP) break;
+
+      startPlane = *plane;
+
+    }
+
+    if (fillExtrapSteps) { // now do the full extrapolation with covariance matrix
+      // make use of the cache
+      lastEndState_.setPlane(plane);
+      getState5(lastEndState_, state7);
+
+      tracklength = extrapolateToPlane(state, plane, false, true);
+      lastEndState_.getAuxInfo()(1) = state.getAuxInfo()(1); // Flight time
+    } else {
+      state.setPlane(plane);
+      getState5(state, state7);
+      state.getAuxInfo()(1) += flightTime;
+    }
+
+    lastEndState_ = state;
+
+    return tracklength;
+  }
+
+
+  double RKTrackRep::extrapolateToCone(StateOnPlane& state,
+                                       double openingAngle,
+                                       const TVector3& conePoint,
+                                       const TVector3& coneDirection,
+                                       bool stopAtBoundary,
+                                       bool calcJacobianNoise) const
+  {
+
+    if (debugLvl_ > 0) {
+      debugOut << "RKTrackRep::extrapolateToCone()\n";
+    }
+
+    checkCache(state, nullptr);
+
+    static const unsigned int maxIt(1000);
+
+    // to 7D
+    M1x7 state7;
+    getState7(state, state7);
+
+    bool fillExtrapSteps(false);
+    if (dynamic_cast<MeasuredStateOnPlane*>(&state) != nullptr) {
+      fillExtrapSteps = true;
+    } else if (calcJacobianNoise)
+      fillExtrapSteps = true;
+
+    double tracklength(0.), maxStep(1.E99);
+
+    TVector3 dest, pos, dir;
+
+    bool isAtBoundary(false);
+
+    DetPlane startPlane(*(state.getPlane()));
+    SharedPlanePtr plane(new DetPlane());
+    unsigned int iterations(0);
+    double charge = getCharge(state);
+    double mass = getMass(state);
+    double flightTime = 0;
+
+    while (true) {
+      if (++iterations == maxIt) {
+        Exception exc("RKTrackRep::extrapolateToCone ==> maximum number of iterations reached", __LINE__, __FILE__);
+        exc.setFatal();
+        throw exc;
+      }
+
       pos.SetXYZ(state7[0], state7[1], state7[2]);
       dir.SetXYZ(state7[3], state7[4], state7[5]);
-      plane->setON(pos, dir);
-      break;
+
+      // solve quadratic equation a k^2 + 2 b k + c = 0
+      // a = (U . D)^2 - cos^2 alpha * U^2
+      // b = (Delta . D) * (U . D) - cos^2 alpha * (U . Delta)
+      // c = (Delta . D)^2 - cos^2 alpha * Delta^2
+      // Delta = P - V, P track point, U track direction, V cone point, D cone direction, alpha opening angle of cone
+      TVector3 cDirection = coneDirection.Unit();
+      TVector3 Delta = (pos - conePoint);
+      double DirDelta = cDirection * Delta;
+      double Delta2 = Delta * Delta;
+      double UDir = dir * cDirection;
+      double UDelta = dir * Delta;
+      double U2 = dir * dir;
+      double cosAngle2 = cos(openingAngle) * cos(openingAngle);
+      double a = UDir * UDir - cosAngle2 * U2;
+      double b = UDir * DirDelta - cosAngle2 * UDelta;
+      double c = DirDelta * DirDelta - cosAngle2 * Delta2;
+
+      double arg = b * b - a * c;
+      if (arg < -1e-9) {
+        Exception exc("RKTrackRep::extrapolateToCone ==> cannot solve", __LINE__, __FILE__);
+        exc.setFatal();
+        throw exc;
+      } else if (arg < 0) {
+        arg = 0;
+      }
+
+      double term = sqrt(arg);
+      double k1, k2;
+      k1 = (-b + term) / a;
+      k2 = (-b - term) / a;
+
+      // select smallest absolute solution -> closest cone surface
+      double k = k1;
+      if (fabs(k2) < fabs(k)) {
+        k = k2;
+      }
+
+      if (debugLvl_ > 0) {
+        debugOut << "RKTrackRep::extrapolateToCone(); k = " << k << "\n";
+      }
+
+      dest = pos + k * dir;
+      // debugOut << "In cone extrapolation ";
+      // dest.Print();
+
+      plane->setO(dest);
+      plane->setUV((dest - conePoint).Cross(coneDirection), dest - conePoint);
+
+      tracklength += this->Extrap(startPlane, *plane, charge, mass, isAtBoundary, state7, flightTime, false, nullptr, true,
+                                  stopAtBoundary, maxStep);
+
+      // check break conditions
+      if (stopAtBoundary && isAtBoundary) {
+        pos.SetXYZ(state7[0], state7[1], state7[2]);
+        dir.SetXYZ(state7[3], state7[4], state7[5]);
+        plane->setO(pos);
+        plane->setUV((pos - conePoint).Cross(coneDirection), pos - conePoint);
+        break;
+      }
+
+      if (fabs(k) < MINSTEP) break;
+
+      startPlane = *plane;
+
     }
 
-    startPlane = *plane;
+    if (fillExtrapSteps) { // now do the full extrapolation with covariance matrix
+      // make use of the cache
+      lastEndState_.setPlane(plane);
+      getState5(lastEndState_, state7);
 
-  }
-
-  if (fillExtrapSteps) { // now do the full extrapolation with covariance matrix
-    // make use of the cache
-    lastEndState_.setPlane(plane);
-    getState5(lastEndState_, state7);
-
-    tracklength = extrapolateToPlane(state, plane, false, true);
-    lastEndState_.getAuxInfo()(1) = state.getAuxInfo()(1); // Flight time
-  }
-  else {
-    state.setPlane(plane);
-    getState5(state, state7);
-    state.getAuxInfo()(1) += flightTime;
-  }
-
-  lastEndState_ = state;
-
-  return tracklength;
-}
-
-
-TVector3 RKTrackRep::getPos(const StateOnPlane& state) const {
-  M1x7 state7;
-  getState7(state, state7);
-
-  return TVector3(state7[0], state7[1], state7[2]);
-}
-
-
-TVector3 RKTrackRep::getMom(const StateOnPlane& state) const {
-  M1x7 state7 = {{0, 0, 0, 0, 0, 0, 0}};
-  getState7(state, state7);
-
-  TVector3 mom(state7[3], state7[4], state7[5]);
-  mom.SetMag(getCharge(state)/state7[6]);
-  return mom;
-}
-
-
-void RKTrackRep::getPosMom(const StateOnPlane& state, TVector3& pos, TVector3& mom) const {
-  M1x7 state7 = {{0, 0, 0, 0, 0, 0, 0}};
-  getState7(state, state7);
-
-  pos.SetXYZ(state7[0], state7[1], state7[2]);
-  mom.SetXYZ(state7[3], state7[4], state7[5]);
-  mom.SetMag(getCharge(state)/state7[6]);
-}
-
-
-void RKTrackRep::getPosMomCov(const MeasuredStateOnPlane& state, TVector3& pos, TVector3& mom, TMatrixDSym& cov) const {
-  getPosMom(state, pos, mom);
-  cov.ResizeTo(6,6);
-  transformPM6(state, *((M6x6*) cov.GetMatrixArray()));
-}
-
-
-TMatrixDSym RKTrackRep::get6DCov(const MeasuredStateOnPlane& state) const {
-  TMatrixDSym cov(6);
-  transformPM6(state, *((M6x6*) cov.GetMatrixArray()));
-
-  return cov;
-}
-
-
-double RKTrackRep::getCharge(const StateOnPlane& state) const {
-
-  if (dynamic_cast<const MeasurementOnPlane*>(&state) != nullptr) {
-    Exception exc("RKTrackRep::getCharge - cannot get charge from MeasurementOnPlane",__LINE__,__FILE__);
-    exc.setFatal();
-    throw exc;
-  }
-
-  double pdgCharge( this->getPDGCharge() );
-
-  // return pdgCharge with sign of q/p
-  if (state.getState()(0) * pdgCharge < 0)
-    return -pdgCharge;
-  else
-    return pdgCharge;
-}
-
-
-double RKTrackRep::getMomMag(const StateOnPlane& state) const {
-  // p = q / qop
-  double p = getCharge(state)/state.getState()(0);
-  assert (p>=0);
-  return p;
-}
-
-
-double RKTrackRep::getMomVar(const MeasuredStateOnPlane& state) const {
-
-  if (dynamic_cast<const MeasurementOnPlane*>(&state) != nullptr) {
-    Exception exc("RKTrackRep::getMomVar - cannot get momVar from MeasurementOnPlane",__LINE__,__FILE__);
-    exc.setFatal();
-    throw exc;
-  }
-
-  // p(qop) = q/qop
-  // dp/d(qop) = - q / (qop^2)
-  // (delta p) = (delta qop) * |dp/d(qop)| = delta qop * |q / (qop^2)|
-  // (var p) = (var qop) * q^2 / (qop^4)
-
-  // delta means sigma
-  // cov(0,0) is sigma^2
-
-  return state.getCov()(0,0) * pow(getCharge(state), 2)  / pow(state.getState()(0), 4);
-}
-
-
-double RKTrackRep::getSpu(const StateOnPlane& state) const {
-
-  if (dynamic_cast<const MeasurementOnPlane*>(&state) != nullptr) {
-    Exception exc("RKTrackRep::getSpu - cannot get spu from MeasurementOnPlane",__LINE__,__FILE__);
-    exc.setFatal();
-    throw exc;
-  }
-
-  const TVectorD& auxInfo = state.getAuxInfo();
-  if (auxInfo.GetNrows() == 2
-      || auxInfo.GetNrows() == 1) // backwards compatibility with old RKTrackRep
-    return state.getAuxInfo()(0);
-  else
-    return 1.;
-}
-
-double RKTrackRep::getTime(const StateOnPlane& state) const {
-
-  const TVectorD& auxInfo = state.getAuxInfo();
-  if (auxInfo.GetNrows() == 2)
-    return state.getAuxInfo()(1);
-  else
-    return 0.;
-}
-
-
-void RKTrackRep::calcForwardJacobianAndNoise(const M1x7& startState7, const DetPlane& startPlane,
-					     const M1x7& destState7, const DetPlane& destPlane) const {
-
-  if (debugLvl_ > 0) {
-    debugOut << "RKTrackRep::calcForwardJacobianAndNoise " << std::endl;
-  }
-
-  if (ExtrapSteps_.size() == 0) {
-    Exception exc("RKTrackRep::calcForwardJacobianAndNoise ==> cache is empty. Extrapolation must run with a MeasuredStateOnPlane.",__LINE__,__FILE__);
-    throw exc;
-  }
-
-  // The Jacobians returned from RKutta are transposed.
-  TMatrixD jac(TMatrixD::kTransposed, TMatrixD(7, 7, ExtrapSteps_.back().jac7_.begin()));
-  TMatrixDSym noise(7, ExtrapSteps_.back().noise7_.begin());
-  for (int i = ExtrapSteps_.size() - 2; i >= 0; --i) {
-    noise += TMatrixDSym(7, ExtrapSteps_[i].noise7_.begin()).Similarity(jac);
-    jac *= TMatrixD(TMatrixD::kTransposed, TMatrixD(7, 7, ExtrapSteps_[i].jac7_.begin()));
-  }
-
-  // Project into 5x5 space.
-  M1x3 pTilde = {{startState7[3], startState7[4], startState7[5]}};
-  const TVector3& normal = startPlane.getNormal();
-  double pTildeW = pTilde[0] * normal.X() + pTilde[1] * normal.Y() + pTilde[2] * normal.Z();
-  double spu = pTildeW > 0 ? 1 : -1;
-  for (unsigned int i=0; i<3; ++i) {
-    pTilde[i] *= spu/pTildeW; // | pTilde * W | has to be 1 (definition of pTilde)
-  }
-  M5x7 J_pM;
-  calcJ_pM_5x7(J_pM, startPlane.getU(), startPlane.getV(), pTilde, spu);
-  M7x5 J_Mp;
-  calcJ_Mp_7x5(J_Mp, destPlane.getU(), destPlane.getV(), destPlane.getNormal(), *((M1x3*) &destState7[3]));
-  jac.Transpose(jac); // Because the helper function wants transposed input.
-  RKTools::J_pMTTxJ_MMTTxJ_MpTT(J_Mp, *(M7x7 *)jac.GetMatrixArray(),
-				J_pM, *(M5x5 *)fJacobian_.GetMatrixArray());
-  RKTools::J_MpTxcov7xJ_Mp(J_Mp, *(M7x7 *)noise.GetMatrixArray(),
-			   *(M5x5 *)fNoise_.GetMatrixArray());
-
-  if (debugLvl_ > 0) {
-    debugOut << "total jacobian : "; fJacobian_.Print();
-    debugOut << "total noise : "; fNoise_.Print();
-  }
-
-}
-
-
-void RKTrackRep::getForwardJacobianAndNoise(TMatrixD& jacobian, TMatrixDSym& noise, TVectorD& deltaState) const {
-
-  jacobian.ResizeTo(5,5);
-  jacobian = fJacobian_;
-
-  noise.ResizeTo(5,5);
-  noise = fNoise_;
-
-  // lastEndState_ = jacobian * lastStartState_  + deltaState
-  deltaState.ResizeTo(5);
-  // Calculate this without temporaries:
-  //deltaState = lastEndState_.getState() - jacobian * lastStartState_.getState()
-  deltaState = lastStartState_.getState();
-  deltaState *= jacobian;
-  deltaState -= lastEndState_.getState();
-  deltaState *= -1;
-
-
-  if (debugLvl_ > 0) {
-    debugOut << "delta state : "; deltaState.Print();
-  }
-}
-
-
-void RKTrackRep::getBackwardJacobianAndNoise(TMatrixD& jacobian, TMatrixDSym& noise, TVectorD& deltaState) const {
-
-  if (debugLvl_ > 0) {
-    debugOut << "RKTrackRep::getBackwardJacobianAndNoise " << std::endl;
-  }
-
-  if (ExtrapSteps_.size() == 0) {
-    Exception exc("RKTrackRep::getBackwardJacobianAndNoise ==> cache is empty. Extrapolation must run with a MeasuredStateOnPlane.",__LINE__,__FILE__);
-    throw exc;
-  }
-
-  jacobian.ResizeTo(5,5);
-  jacobian = fJacobian_;
-  if (!useInvertFast) {
-    bool status = TDecompLU::InvertLU(jacobian, 0.0);
-    if(status == 0){
-      Exception e("cannot invert matrix, status = 0", __LINE__,__FILE__);
-      e.setFatal();
-      throw e;
+      tracklength = extrapolateToPlane(state, plane, false, true);
+      lastEndState_.getAuxInfo()(1) = state.getAuxInfo()(1); // Flight time
+    } else {
+      state.setPlane(plane);
+      getState5(state, state7);
+      state.getAuxInfo()(1) += flightTime;
     }
-  } else {
-    double det;
-    jacobian.InvertFast(&det);
-    if(det < 1e-80){
-      Exception e("cannot invert matrix, status = 0", __LINE__,__FILE__);
-      e.setFatal();
-      throw e;
+
+    lastEndState_ = state;
+
+    return tracklength;
+  }
+
+
+  double RKTrackRep::extrapolateToSphere(StateOnPlane& state,
+                                         double radius,
+                                         const TVector3& point, // center
+                                         bool stopAtBoundary,
+                                         bool calcJacobianNoise) const
+  {
+
+    if (debugLvl_ > 0) {
+      debugOut << "RKTrackRep::extrapolateToSphere()\n";
+    }
+
+    checkCache(state, nullptr);
+
+    static const unsigned int maxIt(1000);
+
+    // to 7D
+    M1x7 state7;
+    getState7(state, state7);
+
+    bool fillExtrapSteps(false);
+    if (dynamic_cast<MeasuredStateOnPlane*>(&state) != nullptr) {
+      fillExtrapSteps = true;
+    } else if (calcJacobianNoise)
+      fillExtrapSteps = true;
+
+    double tracklength(0.), maxStep(1.E99);
+
+    TVector3 dest, pos, dir;
+
+    bool isAtBoundary(false);
+
+    DetPlane startPlane(*(state.getPlane()));
+    SharedPlanePtr plane(new DetPlane());
+    unsigned int iterations(0);
+    double charge = getCharge(state);
+    double mass = getMass(state);
+    double flightTime = 0;
+
+    while (true) {
+      if (++iterations == maxIt) {
+        Exception exc("RKTrackRep::extrapolateToSphere ==> maximum number of iterations reached", __LINE__, __FILE__);
+        exc.setFatal();
+        throw exc;
+      }
+
+      pos.SetXYZ(state7[0], state7[1], state7[2]);
+      dir.SetXYZ(state7[3], state7[4], state7[5]);
+
+      // solve quadratic equation
+      TVector3 AO = (pos - point);
+      double dirAO = dir * AO;
+      double arg = dirAO * dirAO - AO * AO + radius * radius;
+      if (arg < 0) {
+        Exception exc("RKTrackRep::extrapolateToSphere ==> cannot solve", __LINE__, __FILE__);
+        exc.setFatal();
+        throw exc;
+      }
+      double term = sqrt(arg);
+      double k1, k2;
+      k1 = -dirAO + term;
+      k2 = -dirAO - term;
+
+      // select smallest absolute solution -> closest cylinder surface
+      double k = k1;
+      if (fabs(k2) < fabs(k))
+        k = k2;
+
+      if (debugLvl_ > 0) {
+        debugOut << "RKTrackRep::extrapolateToSphere(); k = " << k << "\n";
+      }
+
+      dest = pos + k * dir;
+
+      plane->setON(dest, dest - point);
+
+      tracklength += this->Extrap(startPlane, *plane, charge, mass, isAtBoundary, state7, flightTime, false, nullptr, true,
+                                  stopAtBoundary, maxStep);
+
+      // check break conditions
+      if (stopAtBoundary && isAtBoundary) {
+        pos.SetXYZ(state7[0], state7[1], state7[2]);
+        dir.SetXYZ(state7[3], state7[4], state7[5]);
+        plane->setON(pos, pos - point);
+        break;
+      }
+
+      if (fabs(k) < MINSTEP) break;
+
+      startPlane = *plane;
+
+    }
+
+    if (fillExtrapSteps) { // now do the full extrapolation with covariance matrix
+      // make use of the cache
+      lastEndState_.setPlane(plane);
+      getState5(lastEndState_, state7);
+
+      tracklength = extrapolateToPlane(state, plane, false, true);
+      lastEndState_.getAuxInfo()(1) = state.getAuxInfo()(1); // Flight time
+    } else {
+      state.setPlane(plane);
+      getState5(state, state7);
+      state.getAuxInfo()(1) += flightTime;
+    }
+
+    lastEndState_ = state;
+
+    return tracklength;
+  }
+
+
+  double RKTrackRep::extrapolateBy(StateOnPlane& state,
+                                   double step,
+                                   bool stopAtBoundary,
+                                   bool calcJacobianNoise) const
+  {
+
+    if (debugLvl_ > 0) {
+      debugOut << "RKTrackRep::extrapolateBy()\n";
+    }
+
+    checkCache(state, nullptr);
+
+    static const unsigned int maxIt(1000);
+
+    // to 7D
+    M1x7 state7;
+    getState7(state, state7);
+
+    bool fillExtrapSteps(false);
+    if (dynamic_cast<MeasuredStateOnPlane*>(&state) != nullptr) {
+      fillExtrapSteps = true;
+    } else if (calcJacobianNoise)
+      fillExtrapSteps = true;
+
+    double tracklength(0.);
+
+    TVector3 dest, pos, dir;
+
+    bool isAtBoundary(false);
+
+    DetPlane startPlane(*(state.getPlane()));
+    SharedPlanePtr plane(new DetPlane());
+    unsigned int iterations(0);
+    double charge = getCharge(state);
+    double mass = getMass(state);
+    double flightTime = 0;
+
+    while (true) {
+      if (++iterations == maxIt) {
+        Exception exc("RKTrackRep::extrapolateBy ==> maximum number of iterations reached", __LINE__, __FILE__);
+        exc.setFatal();
+        throw exc;
+      }
+
+      pos.SetXYZ(state7[0], state7[1], state7[2]);
+      dir.SetXYZ(state7[3], state7[4], state7[5]);
+
+      dest = pos + 1.5 * (step - tracklength) * dir;
+
+      plane->setON(dest, dir);
+
+      tracklength += this->Extrap(startPlane, *plane, charge, mass, isAtBoundary, state7, flightTime, false, nullptr, true,
+                                  stopAtBoundary, (step - tracklength));
+
+      // check break conditions
+      if (stopAtBoundary && isAtBoundary) {
+        pos.SetXYZ(state7[0], state7[1], state7[2]);
+        dir.SetXYZ(state7[3], state7[4], state7[5]);
+        plane->setON(pos, dir);
+        break;
+      }
+
+      if (fabs(tracklength - step) < MINSTEP) {
+        if (debugLvl_ > 0) {
+          debugOut << "RKTrackRep::extrapolateBy(): reached after " << iterations << " iterations. \n";
+        }
+        pos.SetXYZ(state7[0], state7[1], state7[2]);
+        dir.SetXYZ(state7[3], state7[4], state7[5]);
+        plane->setON(pos, dir);
+        break;
+      }
+
+      startPlane = *plane;
+
+    }
+
+    if (fillExtrapSteps) { // now do the full extrapolation with covariance matrix
+      // make use of the cache
+      lastEndState_.setPlane(plane);
+      getState5(lastEndState_, state7);
+
+      tracklength = extrapolateToPlane(state, plane, false, true);
+      lastEndState_.getAuxInfo()(1) = state.getAuxInfo()(1); // Flight time
+    } else {
+      state.setPlane(plane);
+      getState5(state, state7);
+      state.getAuxInfo()(1) += flightTime;
+    }
+
+    lastEndState_ = state;
+
+    return tracklength;
+  }
+
+
+  TVector3 RKTrackRep::getPos(const StateOnPlane& state) const
+  {
+    M1x7 state7;
+    getState7(state, state7);
+
+    return TVector3(state7[0], state7[1], state7[2]);
+  }
+
+
+  TVector3 RKTrackRep::getMom(const StateOnPlane& state) const
+  {
+    M1x7 state7 = {{0, 0, 0, 0, 0, 0, 0}};
+    getState7(state, state7);
+
+    TVector3 mom(state7[3], state7[4], state7[5]);
+    mom.SetMag(getCharge(state) / state7[6]);
+    return mom;
+  }
+
+
+  void RKTrackRep::getPosMom(const StateOnPlane& state, TVector3& pos, TVector3& mom) const
+  {
+    M1x7 state7 = {{0, 0, 0, 0, 0, 0, 0}};
+    getState7(state, state7);
+
+    pos.SetXYZ(state7[0], state7[1], state7[2]);
+    mom.SetXYZ(state7[3], state7[4], state7[5]);
+    mom.SetMag(getCharge(state) / state7[6]);
+  }
+
+
+  void RKTrackRep::getPosMomCov(const MeasuredStateOnPlane& state, TVector3& pos, TVector3& mom, TMatrixDSym& cov) const
+  {
+    getPosMom(state, pos, mom);
+    cov.ResizeTo(6, 6);
+    transformPM6(state, *((M6x6*) cov.GetMatrixArray()));
+  }
+
+
+  TMatrixDSym RKTrackRep::get6DCov(const MeasuredStateOnPlane& state) const
+  {
+    TMatrixDSym cov(6);
+    transformPM6(state, *((M6x6*) cov.GetMatrixArray()));
+
+    return cov;
+  }
+
+
+  double RKTrackRep::getCharge(const StateOnPlane& state) const
+  {
+
+    if (dynamic_cast<const MeasurementOnPlane*>(&state) != nullptr) {
+      Exception exc("RKTrackRep::getCharge - cannot get charge from MeasurementOnPlane", __LINE__, __FILE__);
+      exc.setFatal();
+      throw exc;
+    }
+
+    double pdgCharge(this->getPDGCharge());
+
+    // return pdgCharge with sign of q/p
+    if (state.getState()(0) * pdgCharge < 0)
+      return -pdgCharge;
+    else
+      return pdgCharge;
+  }
+
+
+  double RKTrackRep::getMomMag(const StateOnPlane& state) const
+  {
+    // p = q / qop
+    double p = getCharge(state) / state.getState()(0);
+    assert(p >= 0);
+    return p;
+  }
+
+
+  double RKTrackRep::getMomVar(const MeasuredStateOnPlane& state) const
+  {
+
+    if (dynamic_cast<const MeasurementOnPlane*>(&state) != nullptr) {
+      Exception exc("RKTrackRep::getMomVar - cannot get momVar from MeasurementOnPlane", __LINE__, __FILE__);
+      exc.setFatal();
+      throw exc;
+    }
+
+    // p(qop) = q/qop
+    // dp/d(qop) = - q / (qop^2)
+    // (delta p) = (delta qop) * |dp/d(qop)| = delta qop * |q / (qop^2)|
+    // (var p) = (var qop) * q^2 / (qop^4)
+
+    // delta means sigma
+    // cov(0,0) is sigma^2
+
+    return state.getCov()(0, 0) * pow(getCharge(state), 2)  / pow(state.getState()(0), 4);
+  }
+
+
+  double RKTrackRep::getSpu(const StateOnPlane& state) const
+  {
+
+    if (dynamic_cast<const MeasurementOnPlane*>(&state) != nullptr) {
+      Exception exc("RKTrackRep::getSpu - cannot get spu from MeasurementOnPlane", __LINE__, __FILE__);
+      exc.setFatal();
+      throw exc;
+    }
+
+    const TVectorD& auxInfo = state.getAuxInfo();
+    if (auxInfo.GetNrows() == 2
+        || auxInfo.GetNrows() == 1) // backwards compatibility with old RKTrackRep
+      return state.getAuxInfo()(0);
+    else
+      return 1.;
+  }
+
+  double RKTrackRep::getTime(const StateOnPlane& state) const
+  {
+
+    const TVectorD& auxInfo = state.getAuxInfo();
+    if (auxInfo.GetNrows() == 2)
+      return state.getAuxInfo()(1);
+    else
+      return 0.;
+  }
+
+
+  void RKTrackRep::calcForwardJacobianAndNoise(const M1x7& startState7, const DetPlane& startPlane,
+                                               const M1x7& destState7, const DetPlane& destPlane) const
+  {
+
+    if (debugLvl_ > 0) {
+      debugOut << "RKTrackRep::calcForwardJacobianAndNoise " << std::endl;
+    }
+
+    if (ExtrapSteps_.size() == 0) {
+      Exception exc("RKTrackRep::calcForwardJacobianAndNoise ==> cache is empty. Extrapolation must run with a MeasuredStateOnPlane.",
+                    __LINE__, __FILE__);
+      throw exc;
+    }
+
+    // The Jacobians returned from RKutta are transposed.
+    TMatrixD jac(TMatrixD::kTransposed, TMatrixD(7, 7, ExtrapSteps_.back().jac7_.begin()));
+    TMatrixDSym noise(7, ExtrapSteps_.back().noise7_.begin());
+    for (int i = ExtrapSteps_.size() - 2; i >= 0; --i) {
+      noise += TMatrixDSym(7, ExtrapSteps_[i].noise7_.begin()).Similarity(jac);
+      jac *= TMatrixD(TMatrixD::kTransposed, TMatrixD(7, 7, ExtrapSteps_[i].jac7_.begin()));
+    }
+
+    // Project into 5x5 space.
+    M1x3 pTilde = {{startState7[3], startState7[4], startState7[5]}};
+    const TVector3& normal = startPlane.getNormal();
+    double pTildeW = pTilde[0] * normal.X() + pTilde[1] * normal.Y() + pTilde[2] * normal.Z();
+    double spu = pTildeW > 0 ? 1 : -1;
+    for (unsigned int i = 0; i < 3; ++i) {
+      pTilde[i] *= spu / pTildeW; // | pTilde * W | has to be 1 (definition of pTilde)
+    }
+    M5x7 J_pM;
+    calcJ_pM_5x7(J_pM, startPlane.getU(), startPlane.getV(), pTilde, spu);
+    M7x5 J_Mp;
+    calcJ_Mp_7x5(J_Mp, destPlane.getU(), destPlane.getV(), destPlane.getNormal(), *((M1x3*) &destState7[3]));
+    jac.Transpose(jac); // Because the helper function wants transposed input.
+    RKTools::J_pMTTxJ_MMTTxJ_MpTT(J_Mp, *(M7x7*)jac.GetMatrixArray(),
+                                  J_pM, *(M5x5*)fJacobian_.GetMatrixArray());
+    RKTools::J_MpTxcov7xJ_Mp(J_Mp, *(M7x7*)noise.GetMatrixArray(),
+                             *(M5x5*)fNoise_.GetMatrixArray());
+
+    if (debugLvl_ > 0) {
+      debugOut << "total jacobian : "; fJacobian_.Print();
+      debugOut << "total noise : "; fNoise_.Print();
+    }
+
+  }
+
+
+  void RKTrackRep::getForwardJacobianAndNoise(TMatrixD& jacobian, TMatrixDSym& noise, TVectorD& deltaState) const
+  {
+
+    jacobian.ResizeTo(5, 5);
+    jacobian = fJacobian_;
+
+    noise.ResizeTo(5, 5);
+    noise = fNoise_;
+
+    // lastEndState_ = jacobian * lastStartState_  + deltaState
+    deltaState.ResizeTo(5);
+    // Calculate this without temporaries:
+    //deltaState = lastEndState_.getState() - jacobian * lastStartState_.getState()
+    deltaState = lastStartState_.getState();
+    deltaState *= jacobian;
+    deltaState -= lastEndState_.getState();
+    deltaState *= -1;
+
+
+    if (debugLvl_ > 0) {
+      debugOut << "delta state : "; deltaState.Print();
     }
   }
 
-  noise.ResizeTo(5,5);
-  noise = fNoise_;
-  noise.Similarity(jacobian);
 
-  // lastStartState_ = jacobian * lastEndState_  + deltaState
-  deltaState.ResizeTo(5);
-  deltaState = lastStartState_.getState() - jacobian * lastEndState_.getState();
-}
+  void RKTrackRep::getBackwardJacobianAndNoise(TMatrixD& jacobian, TMatrixDSym& noise, TVectorD& deltaState) const
+  {
 
+    if (debugLvl_ > 0) {
+      debugOut << "RKTrackRep::getBackwardJacobianAndNoise " << std::endl;
+    }
 
-std::vector<genfit::MatStep> RKTrackRep::getSteps() const {
+    if (ExtrapSteps_.size() == 0) {
+      Exception exc("RKTrackRep::getBackwardJacobianAndNoise ==> cache is empty. Extrapolation must run with a MeasuredStateOnPlane.",
+                    __LINE__, __FILE__);
+      throw exc;
+    }
 
-  // Todo: test
+    jacobian.ResizeTo(5, 5);
+    jacobian = fJacobian_;
+    if (!useInvertFast) {
+      bool status = TDecompLU::InvertLU(jacobian, 0.0);
+      if (status == 0) {
+        Exception e("cannot invert matrix, status = 0", __LINE__, __FILE__);
+        e.setFatal();
+        throw e;
+      }
+    } else {
+      double det;
+      jacobian.InvertFast(&det);
+      if (det < 1e-80) {
+        Exception e("cannot invert matrix, status = 0", __LINE__, __FILE__);
+        e.setFatal();
+        throw e;
+      }
+    }
 
-  if (RKSteps_.size() == 0) {
-    Exception exc("RKTrackRep::getSteps ==> cache is empty.",__LINE__,__FILE__);
-    throw exc;
+    noise.ResizeTo(5, 5);
+    noise = fNoise_;
+    noise.Similarity(jacobian);
+
+    // lastStartState_ = jacobian * lastEndState_  + deltaState
+    deltaState.ResizeTo(5);
+    deltaState = lastStartState_.getState() - jacobian * lastEndState_.getState();
   }
 
-  std::vector<MatStep> retVal;
-  retVal.reserve(RKSteps_.size());
 
-  for (unsigned int i = 0; i<RKSteps_.size(); ++i) {
-    retVal.push_back(RKSteps_[i].matStep_);
+  std::vector<genfit::MatStep> RKTrackRep::getSteps() const
+  {
+
+    // Todo: test
+
+    if (RKSteps_.size() == 0) {
+      Exception exc("RKTrackRep::getSteps ==> cache is empty.", __LINE__, __FILE__);
+      throw exc;
+    }
+
+    std::vector<MatStep> retVal;
+    retVal.reserve(RKSteps_.size());
+
+    for (unsigned int i = 0; i < RKSteps_.size(); ++i) {
+      retVal.push_back(RKSteps_[i].matStep_);
+    }
+
+    return retVal;
   }
 
-  return retVal;
-}
 
+  double RKTrackRep::getRadiationLenght() const
+  {
 
-double RKTrackRep::getRadiationLenght() const {
+    // Todo: test
 
-  // Todo: test
+    if (RKSteps_.size() == 0) {
+      Exception exc("RKTrackRep::getRadiationLenght ==> cache is empty.", __LINE__, __FILE__);
+      throw exc;
+    }
 
-  if (RKSteps_.size() == 0) {
-    Exception exc("RKTrackRep::getRadiationLenght ==> cache is empty.",__LINE__,__FILE__);
-    throw exc;
+    double radLen(0);
+
+    for (unsigned int i = 0; i < RKSteps_.size(); ++i) {
+      radLen += RKSteps_.at(i).matStep_.stepSize_ / RKSteps_.at(i).matStep_.material_.radiationLength;
+    }
+
+    return radLen;
   }
 
-  double radLen(0);
-
-  for (unsigned int i = 0; i<RKSteps_.size(); ++i) {
-    radLen += RKSteps_.at(i).matStep_.stepSize_ / RKSteps_.at(i).matStep_.material_.radiationLength;
-  }
-
-  return radLen;
-}
 
 
+  void RKTrackRep::setPosMom(StateOnPlane& state, const TVector3& pos, const TVector3& mom) const
+  {
 
-void RKTrackRep::setPosMom(StateOnPlane& state, const TVector3& pos, const TVector3& mom) const {
+    if (state.getRep() != this) {
+      Exception exc("RKTrackRep::setPosMom ==> state is defined wrt. another TrackRep", __LINE__, __FILE__);
+      throw exc;
+    }
 
-  if (state.getRep() != this){
-    Exception exc("RKTrackRep::setPosMom ==> state is defined wrt. another TrackRep",__LINE__,__FILE__);
-    throw exc;
-  }
+    if (dynamic_cast<MeasurementOnPlane*>(&state) != nullptr) {
+      Exception exc("RKTrackRep::setPosMom - cannot set pos/mom of a MeasurementOnPlane", __LINE__, __FILE__);
+      exc.setFatal();
+      throw exc;
+    }
 
-  if (dynamic_cast<MeasurementOnPlane*>(&state) != nullptr) {
-    Exception exc("RKTrackRep::setPosMom - cannot set pos/mom of a MeasurementOnPlane",__LINE__,__FILE__);
-    exc.setFatal();
-    throw exc;
-  }
+    if (mom.Mag2() == 0) {
+      Exception exc("RKTrackRep::setPosMom - momentum is 0", __LINE__, __FILE__);
+      exc.setFatal();
+      throw exc;
+    }
 
-  if (mom.Mag2() == 0) {
-    Exception exc("RKTrackRep::setPosMom - momentum is 0",__LINE__,__FILE__);
-    exc.setFatal();
-    throw exc;
-  }
+    // init auxInfo if that has not yet happened
+    TVectorD& auxInfo = state.getAuxInfo();
+    if (auxInfo.GetNrows() != 2) {
+      bool alreadySet = auxInfo.GetNrows() == 1;  // backwards compatibility: don't overwrite old setting
+      auxInfo.ResizeTo(2);
+      if (!alreadySet)
+        setSpu(state, 1.);
+    }
 
-  // init auxInfo if that has not yet happened
-  TVectorD& auxInfo = state.getAuxInfo();
-  if (auxInfo.GetNrows() != 2) {
-    bool alreadySet = auxInfo.GetNrows() == 1;  // backwards compatibility: don't overwrite old setting
-    auxInfo.ResizeTo(2);
-    if (!alreadySet)
+    if (state.getPlane() != nullptr && state.getPlane()->distance(pos) < MINSTEP) { // pos is on plane -> do not change plane!
+
+      M1x7 state7;
+
+      state7[0] = pos.X();
+      state7[1] = pos.Y();
+      state7[2] = pos.Z();
+
+      state7[3] = mom.X();
+      state7[4] = mom.Y();
+      state7[5] = mom.Z();
+
+      // normalize dir
+      double norm = 1. / sqrt(state7[3] * state7[3] + state7[4] * state7[4] + state7[5] * state7[5]);
+      for (unsigned int i = 3; i < 6; ++i)
+        state7[i] *= norm;
+
+      state7[6] = getCharge(state) * norm;
+
+      getState5(state, state7);
+
+    } else { // pos is not on plane -> create new plane!
+
+      // TODO: Raise Warning that a new plane has been created!
+      SharedPlanePtr plane(new DetPlane(pos, mom));
+      state.setPlane(plane);
+
+      TVectorD& state5(state.getState());
+
+      state5(0) = getCharge(state) / mom.Mag(); // q/p
+      state5(1) = 0.; // u'
+      state5(2) = 0.; // v'
+      state5(3) = 0.; // u
+      state5(4) = 0.; // v
+
       setSpu(state, 1.);
+    }
+
   }
 
-  if (state.getPlane() != nullptr && state.getPlane()->distance(pos) < MINSTEP) { // pos is on plane -> do not change plane!
+
+  void RKTrackRep::setPosMom(StateOnPlane& state, const TVectorD& state6) const
+  {
+    if (state6.GetNrows() != 6) {
+      Exception exc("RKTrackRep::setPosMom ==> state has to be 6d (x, y, z, px, py, pz)", __LINE__, __FILE__);
+      throw exc;
+    }
+    setPosMom(state, TVector3(state6(0), state6(1), state6(2)), TVector3(state6(3), state6(4), state6(5)));
+  }
+
+
+  void RKTrackRep::setPosMomErr(MeasuredStateOnPlane& state, const TVector3& pos, const TVector3& mom, const TVector3& posErr,
+                                const TVector3& momErr) const
+  {
+
+    // TODO: test!
+
+    setPosMom(state, pos, mom);
+
+    const TVector3& U(state.getPlane()->getU());
+    const TVector3& V(state.getPlane()->getV());
+    TVector3 W(state.getPlane()->getNormal());
+
+    double pw = mom * W;
+    double pu = mom * U;
+    double pv = mom * V;
+
+    TMatrixDSym& cov(state.getCov());
+
+    cov(0, 0) = pow(getCharge(state), 2) / pow(mom.Mag(), 6) *
+                (mom.X() * mom.X() * momErr.X() * momErr.X() +
+                 mom.Y() * mom.Y() * momErr.Y() * momErr.Y() +
+                 mom.Z() * mom.Z() * momErr.Z() * momErr.Z());
+
+    cov(1, 1) = pow((U.X() / pw - W.X() * pu / (pw * pw)), 2.) * momErr.X() * momErr.X() +
+                pow((U.Y() / pw - W.Y() * pu / (pw * pw)), 2.) * momErr.Y() * momErr.Y() +
+                pow((U.Z() / pw - W.Z() * pu / (pw * pw)), 2.) * momErr.Z() * momErr.Z();
+
+    cov(2, 2) = pow((V.X() / pw - W.X() * pv / (pw * pw)), 2.) * momErr.X() * momErr.X() +
+                pow((V.Y() / pw - W.Y() * pv / (pw * pw)), 2.) * momErr.Y() * momErr.Y() +
+                pow((V.Z() / pw - W.Z() * pv / (pw * pw)), 2.) * momErr.Z() * momErr.Z();
+
+    cov(3, 3) = posErr.X() * posErr.X() * U.X() * U.X() +
+                posErr.Y() * posErr.Y() * U.Y() * U.Y() +
+                posErr.Z() * posErr.Z() * U.Z() * U.Z();
+
+    cov(4, 4) = posErr.X() * posErr.X() * V.X() * V.X() +
+                posErr.Y() * posErr.Y() * V.Y() * V.Y() +
+                posErr.Z() * posErr.Z() * V.Z() * V.Z();
+
+  }
+
+
+
+
+  void RKTrackRep::setPosMomCov(MeasuredStateOnPlane& state, const TVector3& pos, const TVector3& mom,
+                                const TMatrixDSym& cov6x6) const
+  {
+
+    if (cov6x6.GetNcols() != 6 || cov6x6.GetNrows() != 6) {
+      Exception exc("RKTrackRep::setPosMomCov ==> cov has to be 6x6 (x, y, z, px, py, pz)", __LINE__, __FILE__);
+      throw exc;
+    }
+
+    setPosMom(state, pos, mom); // charge does not change!
 
     M1x7 state7;
+    getState7(state, state7);
 
-    state7[0] = pos.X();
-    state7[1] = pos.Y();
-    state7[2] = pos.Z();
+    const M6x6& cov6x6_(*((M6x6*) cov6x6.GetMatrixArray()));
 
-    state7[3] = mom.X();
-    state7[4] = mom.Y();
-    state7[5] = mom.Z();
+    transformM6P(cov6x6_, state7, state);
+
+  }
+
+  void RKTrackRep::setPosMomCov(MeasuredStateOnPlane& state, const TVectorD& state6, const TMatrixDSym& cov6x6) const
+  {
+
+    if (state6.GetNrows() != 6) {
+      Exception exc("RKTrackRep::setPosMomCov ==> state has to be 6d (x, y, z, px, py, pz)", __LINE__, __FILE__);
+      throw exc;
+    }
+
+    if (cov6x6.GetNcols() != 6 || cov6x6.GetNrows() != 6) {
+      Exception exc("RKTrackRep::setPosMomCov ==> cov has to be 6x6 (x, y, z, px, py, pz)", __LINE__, __FILE__);
+      throw exc;
+    }
+
+    TVector3 pos(state6(0), state6(1), state6(2));
+    TVector3 mom(state6(3), state6(4), state6(5));
+    setPosMom(state, pos, mom); // charge does not change!
+
+    M1x7 state7;
+    getState7(state, state7);
+
+    const M6x6& cov6x6_(*((M6x6*) cov6x6.GetMatrixArray()));
+
+    transformM6P(cov6x6_, state7, state);
+
+  }
+
+
+  void RKTrackRep::setChargeSign(StateOnPlane& state, double charge) const
+  {
+
+    if (dynamic_cast<MeasurementOnPlane*>(&state) != nullptr) {
+      Exception exc("RKTrackRep::setChargeSign - cannot set charge of a MeasurementOnPlane", __LINE__, __FILE__);
+      exc.setFatal();
+      throw exc;
+    }
+
+    if (state.getState()(0) * charge < 0) {
+      state.getState()(0) *= -1.;
+    }
+  }
+
+
+  void RKTrackRep::setSpu(StateOnPlane& state, double spu) const
+  {
+    state.getAuxInfo().ResizeTo(2);
+    (state.getAuxInfo())(0) = spu;
+  }
+
+  void RKTrackRep::setTime(StateOnPlane& state, double time) const
+  {
+    state.getAuxInfo().ResizeTo(2);
+    (state.getAuxInfo())(1) = time;
+  }
+
+
+
+  double RKTrackRep::RKPropagate(M1x7& state7,
+                                 M7x7* jacobianT,
+                                 M1x3& SA,
+                                 double S,
+                                 bool varField,
+                                 bool calcOnlyLastRowOfJ) const
+  {
+    // The algorithm is
+    //  E Lund et al 2009 JINST 4 P04001 doi:10.1088/1748-0221/4/04/P04001
+    //  "Track parameter propagation through the application of a new adaptive Runge-Kutta-Nyström method in the ATLAS experiment"
+    //  http://inspirehep.net/search?ln=en&ln=en&p=10.1088/1748-0221/4/04/P04001&of=hb&action_search=Search&sf=earliestdate&so=d&rm=&rg=25&sc=0
+    // where the transport of the Jacobian is described in
+    //   L. Bugge, J. Myrheim  Nucl.Instrum.Meth. 160 (1979) 43-48
+    //   "A Fast Runge-kutta Method For Fitting Tracks In A Magnetic Field"
+    //   http://inspirehep.net/record/145692
+    // and
+    //   L. Bugge, J. Myrheim  Nucl.Instrum.Meth. 179 (1981) 365-381
+    //   "Tracking And Track Fitting"
+    //   http://inspirehep.net/record/160548
+
+    // important fixed numbers
+    static const double EC(0.000149896229);      // c/(2*10^12) resp. c/2Tera
+    static const double P3(1. / 3.);             // 1/3
+    static const double DLT(.0002);              // max. deviation for approximation-quality test
+    // Aux parameters
+    M1x3&   R           = *((M1x3*) &state7[0]);       // Start coordinates  [cm]  (x,  y,  z)
+    M1x3&   A           = *((M1x3*) &state7[3]);       // Start directions         (ax, ay, az);   ax^2+ay^2+az^2=1
+    double  S3(0), S4(0), PS2(0);
+    M1x3     H0 = {{0., 0., 0.}}, H1 = {{0., 0., 0.}}, H2 = {{0., 0., 0.}};
+    M1x3     r = {{0., 0., 0.}};
+    // Variables for Runge Kutta solver
+    double   A0(0), A1(0), A2(0), A3(0), A4(0), A5(0), A6(0);
+    double   B0(0), B1(0), B2(0), B3(0), B4(0), B5(0), B6(0);
+    double   C0(0), C1(0), C2(0), C3(0), C4(0), C5(0), C6(0);
+
+    //
+    // Runge Kutta Extrapolation
+    //
+    S3 = P3 * S;
+    S4 = 0.25 * S;
+    PS2 = state7[6] * EC * S;
+
+    // First point
+    r[0] = R[0];           r[1] = R[1];           r[2] = R[2];
+    FieldManager::getInstance()->getFieldVal(r[0], r[1], r[2], H0[0], H0[1], H0[2]);       // magnetic field in 10^-1 T = kGauss
+    H0[0] *= PS2; H0[1] *= PS2; H0[2] *= PS2;     // H0 is PS2*(Hx, Hy, Hz) @ R0
+    A0 = A[1] * H0[2] - A[2] * H0[1]; B0 = A[2] * H0[0] - A[0] * H0[2]; C0 = A[0] * H0[1] - A[1] * H0[0]; // (ax, ay, az) x H0
+    A2 = A[0] + A0              ; B2 = A[1] + B0              ; C2 = A[2] + C0              ; // (A0, B0, C0) + (ax, ay, az)
+    A1 = A2 + A[0]              ; B1 = B2 + A[1]              ; C1 = C2 + A[2]              ; // (A0, B0, C0) + 2*(ax, ay, az)
+
+    // Second point
+    if (varField) {
+      r[0] += A1 * S4;         r[1] += B1 * S4;         r[2] += C1 * S4;
+      FieldManager::getInstance()->getFieldVal(r[0], r[1], r[2], H1[0], H1[1], H1[2]);
+      H1[0] *= PS2; H1[1] *= PS2; H1[2] *= PS2; // H1 is PS2*(Hx, Hy, Hz) @ (x, y, z) + 0.25*S * [(A0, B0, C0) + 2*(ax, ay, az)]
+    } else { H1 = H0; };
+    A3 = B2 * H1[2] - C2 * H1[1] + A[0]; B3 = C2 * H1[0] - A2 * H1[2] + A[1];
+    C3 = A2 * H1[1] - B2 * H1[0] + A[2]; // (A2, B2, C2) x H1 + (ax, ay, az)
+    A4 = B3 * H1[2] - C3 * H1[1] + A[0]; B4 = C3 * H1[0] - A3 * H1[2] + A[1];
+    C4 = A3 * H1[1] - B3 * H1[0] + A[2]; // (A3, B3, C3) x H1 + (ax, ay, az)
+    A5 = A4 - A[0] + A4            ; B5 = B4 - A[1] + B4            ;
+    C5 = C4 - A[2] + C4            ; //    2*(A4, B4, C4) - (ax, ay, az)
+
+    // Last point
+    if (varField) {
+      r[0] = R[0] + S * A4;         r[1] = R[1] + S * B4;         r[2] = R[2] + S * C4; //setup.Field(r,H2);
+      FieldManager::getInstance()->getFieldVal(r[0], r[1], r[2], H2[0], H2[1], H2[2]);
+      H2[0] *= PS2; H2[1] *= PS2; H2[2] *= PS2; // H2 is PS2*(Hx, Hy, Hz) @ (x, y, z) + 0.25*S * (A4, B4, C4)
+    } else { H2 = H0; };
+    A6 = B5 * H2[2] - C5 * H2[1]; B6 = C5 * H2[0] - A5 * H2[2]; C6 = A5 * H2[1] - B5 * H2[0]; // (A5, B5, C5) x H2
+
+
+    //
+    // Derivatives of track parameters
+    //
+    if (jacobianT != nullptr) {
+
+      // jacobianT
+      // 1 0 0 0 0 0 0  x
+      // 0 1 0 0 0 0 0  y
+      // 0 0 1 0 0 0 0  z
+      // x x x x x x 0  a_x
+      // x x x x x x 0  a_y
+      // x x x x x x 0  a_z
+      // x x x x x x 1  q/p
+      M7x7& J = *jacobianT;
+
+      double   dA0(0), dA2(0), dA3(0), dA4(0), dA5(0), dA6(0);
+      double   dB0(0), dB2(0), dB3(0), dB4(0), dB5(0), dB6(0);
+      double   dC0(0), dC2(0), dC3(0), dC4(0), dC5(0), dC6(0);
+
+      int start(0);
+
+      if (!calcOnlyLastRowOfJ) {
+
+        if (!varField) {
+          // d(x, y, z)/d(x, y, z) submatrix is unit matrix
+          J(0, 0) = 1;  J(1, 1) = 1;  J(2, 2) = 1;
+          // d(ax, ay, az)/d(ax, ay, az) submatrix is 0
+          // start with d(x, y, z)/d(ax, ay, az)
+          start = 3;
+        }
+
+        for (int i = start; i < 6; ++i) {
+
+          //first point
+          dA0 = H0[2] * J(i, 4) - H0[1] * J(i, 5); // dA0/dp }
+          dB0 = H0[0] * J(i, 5) - H0[2] * J(i, 3); // dB0/dp  } = dA x H0
+          dC0 = H0[1] * J(i, 3) - H0[0] * J(i, 4); // dC0/dp }
+
+          dA2 = dA0 + J(i, 3);      // }
+          dB2 = dB0 + J(i, 4);      //  } = (dA0, dB0, dC0) + dA
+          dC2 = dC0 + J(i, 5);      // }
+
+          //second point
+          dA3 = J(i, 3) + dB2 * H1[2] - dC2 * H1[1]; // dA3/dp }
+          dB3 = J(i, 4) + dC2 * H1[0] - dA2 * H1[2]; // dB3/dp  } = dA + (dA2, dB2, dC2) x H1
+          dC3 = J(i, 5) + dA2 * H1[1] - dB2 * H1[0]; // dC3/dp }
+
+          dA4 = J(i, 3) + dB3 * H1[2] - dC3 * H1[1]; // dA4/dp }
+          dB4 = J(i, 4) + dC3 * H1[0] - dA3 * H1[2]; // dB4/dp  } = dA + (dA3, dB3, dC3) x H1
+          dC4 = J(i, 5) + dA3 * H1[1] - dB3 * H1[0]; // dC4/dp }
+
+          //last point
+          dA5 = dA4 + dA4 - J(i, 3);  // }
+          dB5 = dB4 + dB4 - J(i, 4);  //  } =  2*(dA4, dB4, dC4) - dA
+          dC5 = dC4 + dC4 - J(i, 5);  // }
+
+          dA6 = dB5 * H2[2] - dC5 * H2[1]; // dA6/dp }
+          dB6 = dC5 * H2[0] - dA5 * H2[2]; // dB6/dp  } = (dA5, dB5, dC5) x H2
+          dC6 = dA5 * H2[1] - dB5 * H2[0]; // dC6/dp }
+
+          // this gives the same results as multiplying the old with the new Jacobian
+          J(i, 0) += (dA2 + dA3 + dA4) * S3;
+          J(i, 3) = ((dA0 + 2.*dA3) + (dA5 + dA6)) * P3; // dR := dR + S3*[(dA2, dB2, dC2) +   (dA3, dB3, dC3) + (dA4, dB4, dC4)]
+          J(i, 1) += (dB2 + dB3 + dB4) * S3;
+          J(i, 4) = ((dB0 + 2.*dB3) + (dB5 + dB6)) * P3; // dA :=     1/3*[(dA0, dB0, dC0) + 2*(dA3, dB3, dC3) + (dA5, dB5, dC5) + (dA6, dB6, dC6)]
+          J(i, 2) += (dC2 + dC3 + dC4) * S3;  J(i, 5) = ((dC0 + 2.*dC3) + (dC5 + dC6)) * P3;
+        }
+
+      } // end if (!calcOnlyLastRowOfJ)
+
+      J(6, 3) *= state7[6]; J(6, 4) *= state7[6]; J(6, 5) *= state7[6];
+
+      //first point
+      dA0 = H0[2] * J(6, 4) - H0[1] * J(6, 5) + A0; // dA0/dp }
+      dB0 = H0[0] * J(6, 5) - H0[2] * J(6, 3) + B0; // dB0/dp  } = dA x H0 + (A0, B0, C0)
+      dC0 = H0[1] * J(6, 3) - H0[0] * J(6, 4) + C0; // dC0/dp }
+
+      dA2 = dA0 + J(6, 3);      // }
+      dB2 = dB0 + J(6, 4);      //  } = (dA0, dB0, dC0) + dA
+      dC2 = dC0 + J(6, 5);      // }
+
+      //second point
+      dA3 = J(6, 3) + dB2 * H1[2] - dC2 * H1[1] + (A3 - A[0]); // dA3/dp }
+      dB3 = J(6, 4) + dC2 * H1[0] - dA2 * H1[2] + (B3 - A[1]); // dB3/dp  } = dA + (dA2, dB2, dC2) x H1
+      dC3 = J(6, 5) + dA2 * H1[1] - dB2 * H1[0] + (C3 - A[2]); // dC3/dp }
+
+      dA4 = J(6, 3) + dB3 * H1[2] - dC3 * H1[1] + (A4 - A[0]); // dA4/dp }
+      dB4 = J(6, 4) + dC3 * H1[0] - dA3 * H1[2] + (B4 - A[1]); // dB4/dp  } = dA + (dA3, dB3, dC3) x H1
+      dC4 = J(6, 5) + dA3 * H1[1] - dB3 * H1[0] + (C4 - A[2]); // dC4/dp }
+
+      //last point
+      dA5 = dA4 + dA4 - J(6, 3);  // }
+      dB5 = dB4 + dB4 - J(6, 4);  //  } =  2*(dA4, dB4, dC4) - dA
+      dC5 = dC4 + dC4 - J(6, 5);  // }
+
+      dA6 = dB5 * H2[2] - dC5 * H2[1] + A6; // dA6/dp }
+      dB6 = dC5 * H2[0] - dA5 * H2[2] + B6; // dB6/dp  } = (dA5, dB5, dC5) x H2 + (A6, B6, C6)
+      dC6 = dA5 * H2[1] - dB5 * H2[0] + C6; // dC6/dp }
+
+      // this gives the same results as multiplying the old with the new Jacobian
+      J(6, 0) += (dA2 + dA3 + dA4) * S3 / state7[6];
+      J(6, 3) = ((dA0 + 2.*dA3) + (dA5 + dA6)) * P3 / state7[6]; // dR := dR + S3*[(dA2, dB2, dC2) +   (dA3, dB3, dC3) + (dA4, dB4, dC4)]
+      J(6, 1) += (dB2 + dB3 + dB4) * S3 / state7[6];
+      J(6, 4) = ((dB0 + 2.*dB3) + (dB5 + dB6)) * P3 / state7[6]; // dA :=     1/3*[(dA0, dB0, dC0) + 2*(dA3, dB3, dC3) + (dA5, dB5, dC5) + (dA6, dB6, dC6)]
+      J(6, 2) += (dC2 + dC3 + dC4) * S3 / state7[6];  J(6, 5) = ((dC0 + 2.*dC3) + (dC5 + dC6)) * P3 / state7[6];
+
+    }
+
+    //
+    // Track parameters in last point
+    //
+    R[0] += (A2 + A3 + A4) * S3;
+    A[0] += (SA[0] = ((A0 + 2.*A3) + (A5 + A6)) * P3 - A[0]); // R  = R0 + S3*[(A2, B2, C2) +   (A3, B3, C3) + (A4, B4, C4)]
+    R[1] += (B2 + B3 + B4) * S3;
+    A[1] += (SA[1] = ((B0 + 2.*B3) + (B5 + B6)) * P3 - A[1]); // A  =     1/3*[(A0, B0, C0) + 2*(A3, B3, C3) + (A5, B5, C5) + (A6, B6, C6)]
+    R[2] += (C2 + C3 + C4) * S3;   A[2] += (SA[2] = ((C0 + 2.*C3) + (C5 + C6)) * P3 - A[2]); // SA = A_new - A_old
+
+    // normalize A
+    double CBA(1. / sqrt(A[0]*A[0] + A[1]*A[1] + A[2]*A[2])); // 1/|A|
+    A[0] *= CBA; A[1] *= CBA; A[2] *= CBA;
+
+
+    // Test approximation quality on given step
+    double EST(fabs((A1 + A6) - (A3 + A4)) +
+               fabs((B1 + B6) - (B3 + B4)) +
+               fabs((C1 + C6) - (C3 + C4))); // EST = ||(ABC1+ABC6)-(ABC3+ABC4)||_1  =  ||(axzy x H0 + ABC5 x H2) - (ABC2 x H1 + ABC3 x H1)||_1
+    if (debugLvl_ > 0) {
+      debugOut << "    RKTrackRep::RKPropagate. Step = " << S << "; quality EST = " << EST  << " \n";
+    }
+
+    // Prevent the step length increase from getting too large, this is
+    // just the point where it becomes 10.
+    if (EST < DLT * 1e-5)
+      return 10;
+
+    // Step length increase for a fifth order Runge-Kutta, see e.g. 17.2
+    // in Numerical Recipes.  FIXME: move to caller.
+    return pow(DLT / EST, 1. / 5.);
+  }
+
+
+
+  void RKTrackRep::initArrays() const
+  {
+    std::fill(noiseArray_.begin(), noiseArray_.end(), 0);
+    std::fill(noiseProjection_.begin(), noiseProjection_.end(), 0);
+    for (unsigned int i = 0; i < 7; ++i) // initialize as diagonal matrix
+      noiseProjection_[i * 8] = 1;
+    std::fill(J_MMT_.begin(), J_MMT_.end(), 0);
+
+    fJacobian_.UnitMatrix();
+    fNoise_.Zero();
+    limits_.reset();
+
+    RKSteps_.reserve(100);
+    ExtrapSteps_.reserve(100);
+
+    lastStartState_.getAuxInfo().ResizeTo(2);
+    lastEndState_.getAuxInfo().ResizeTo(2);
+  }
+
+
+  void RKTrackRep::getState7(const StateOnPlane& state, M1x7& state7) const
+  {
+
+    if (dynamic_cast<const MeasurementOnPlane*>(&state) != nullptr) {
+      Exception exc("RKTrackRep::getState7 - cannot get pos or mom from a MeasurementOnPlane", __LINE__, __FILE__);
+      exc.setFatal();
+      throw exc;
+    }
+
+    const TVector3& U(state.getPlane()->getU());
+    const TVector3& V(state.getPlane()->getV());
+    const TVector3& O(state.getPlane()->getO());
+    const TVector3& W(state.getPlane()->getNormal());
+
+    assert(state.getState().GetNrows() == 5);
+    const double* state5 = state.getState().GetMatrixArray();
+
+    double spu = getSpu(state);
+
+    state7[0] = O.X() + state5[3] * U.X() + state5[4] * V.X(); // x
+    state7[1] = O.Y() + state5[3] * U.Y() + state5[4] * V.Y(); // y
+    state7[2] = O.Z() + state5[3] * U.Z() + state5[4] * V.Z(); // z
+
+    state7[3] = spu * (W.X() + state5[1] * U.X() + state5[2] * V.X()); // a_x
+    state7[4] = spu * (W.Y() + state5[1] * U.Y() + state5[2] * V.Y()); // a_y
+    state7[5] = spu * (W.Z() + state5[1] * U.Z() + state5[2] * V.Z()); // a_z
 
     // normalize dir
-    double norm = 1. / sqrt(state7[3]*state7[3] + state7[4]*state7[4] + state7[5]*state7[5]);
-    for (unsigned int i=3; i<6; ++i)
-      state7[i] *= norm;
+    double norm = 1. / sqrt(state7[3] * state7[3] + state7[4] * state7[4] + state7[5] * state7[5]);
+    for (unsigned int i = 3; i < 6; ++i) state7[i] *= norm;
 
-    state7[6] = getCharge(state) * norm;
-
-    getState5(state, state7);
-
-  }
-  else { // pos is not on plane -> create new plane!
-
-    // TODO: Raise Warning that a new plane has been created!
-    SharedPlanePtr plane(new DetPlane(pos, mom));
-    state.setPlane(plane);
-
-    TVectorD& state5(state.getState());
-
-    state5(0) = getCharge(state)/mom.Mag(); // q/p
-    state5(1) = 0.; // u'
-    state5(2) = 0.; // v'
-    state5(3) = 0.; // u
-    state5(4) = 0.; // v
-
-    setSpu(state, 1.);
+    state7[6] = state5[0]; // q/p
   }
 
-}
 
-
-void RKTrackRep::setPosMom(StateOnPlane& state, const TVectorD& state6) const {
-  if (state6.GetNrows()!=6){
-    Exception exc("RKTrackRep::setPosMom ==> state has to be 6d (x, y, z, px, py, pz)",__LINE__,__FILE__);
-    throw exc;
-  }
-  setPosMom(state, TVector3(state6(0), state6(1), state6(2)), TVector3(state6(3), state6(4), state6(5)));
-}
-
-
-void RKTrackRep::setPosMomErr(MeasuredStateOnPlane& state, const TVector3& pos, const TVector3& mom, const TVector3& posErr, const TVector3& momErr) const {
-
-  // TODO: test!
-
-  setPosMom(state, pos, mom);
-
-  const TVector3& U(state.getPlane()->getU());
-  const TVector3& V(state.getPlane()->getV());
-  TVector3 W(state.getPlane()->getNormal());
-
-  double pw = mom * W;
-  double pu = mom * U;
-  double pv = mom * V;
-
-  TMatrixDSym& cov(state.getCov());
-
-  cov(0,0) = pow(getCharge(state), 2) / pow(mom.Mag(), 6) *
-             (mom.X()*mom.X() * momErr.X()*momErr.X()+
-              mom.Y()*mom.Y() * momErr.Y()*momErr.Y()+
-              mom.Z()*mom.Z() * momErr.Z()*momErr.Z());
-
-  cov(1,1) = pow((U.X()/pw - W.X()*pu/(pw*pw)),2.) * momErr.X()*momErr.X() +
-             pow((U.Y()/pw - W.Y()*pu/(pw*pw)),2.) * momErr.Y()*momErr.Y() +
-             pow((U.Z()/pw - W.Z()*pu/(pw*pw)),2.) * momErr.Z()*momErr.Z();
-
-  cov(2,2) = pow((V.X()/pw - W.X()*pv/(pw*pw)),2.) * momErr.X()*momErr.X() +
-             pow((V.Y()/pw - W.Y()*pv/(pw*pw)),2.) * momErr.Y()*momErr.Y() +
-             pow((V.Z()/pw - W.Z()*pv/(pw*pw)),2.) * momErr.Z()*momErr.Z();
-
-  cov(3,3) = posErr.X()*posErr.X() * U.X()*U.X() +
-             posErr.Y()*posErr.Y() * U.Y()*U.Y() +
-             posErr.Z()*posErr.Z() * U.Z()*U.Z();
-
-  cov(4,4) = posErr.X()*posErr.X() * V.X()*V.X() +
-             posErr.Y()*posErr.Y() * V.Y()*V.Y() +
-             posErr.Z()*posErr.Z() * V.Z()*V.Z();
-
-}
-
-
-
-
-void RKTrackRep::setPosMomCov(MeasuredStateOnPlane& state, const TVector3& pos, const TVector3& mom, const TMatrixDSym& cov6x6) const {
-
-  if (cov6x6.GetNcols()!=6 || cov6x6.GetNrows()!=6){
-    Exception exc("RKTrackRep::setPosMomCov ==> cov has to be 6x6 (x, y, z, px, py, pz)",__LINE__,__FILE__);
-    throw exc;
-  }
-
-  setPosMom(state, pos, mom); // charge does not change!
-
-  M1x7 state7;
-  getState7(state, state7);
-
-  const M6x6& cov6x6_( *((M6x6*) cov6x6.GetMatrixArray()) );
-
-  transformM6P(cov6x6_, state7, state);
-
-}
-
-void RKTrackRep::setPosMomCov(MeasuredStateOnPlane& state, const TVectorD& state6, const TMatrixDSym& cov6x6) const {
-
-  if (state6.GetNrows()!=6){
-    Exception exc("RKTrackRep::setPosMomCov ==> state has to be 6d (x, y, z, px, py, pz)",__LINE__,__FILE__);
-    throw exc;
-  }
-
-  if (cov6x6.GetNcols()!=6 || cov6x6.GetNrows()!=6){
-    Exception exc("RKTrackRep::setPosMomCov ==> cov has to be 6x6 (x, y, z, px, py, pz)",__LINE__,__FILE__);
-    throw exc;
-  }
-
-  TVector3 pos(state6(0), state6(1), state6(2));
-  TVector3 mom(state6(3), state6(4), state6(5));
-  setPosMom(state, pos, mom); // charge does not change!
-
-  M1x7 state7;
-  getState7(state, state7);
-
-  const M6x6& cov6x6_( *((M6x6*) cov6x6.GetMatrixArray()) );
-
-  transformM6P(cov6x6_, state7, state);
-
-}
-
-
-void RKTrackRep::setChargeSign(StateOnPlane& state, double charge) const {
-
-  if (dynamic_cast<MeasurementOnPlane*>(&state) != nullptr) {
-    Exception exc("RKTrackRep::setChargeSign - cannot set charge of a MeasurementOnPlane",__LINE__,__FILE__);
-    exc.setFatal();
-    throw exc;
-  }
-
-  if (state.getState()(0) * charge < 0) {
-    state.getState()(0) *= -1.;
-  }
-}
-
-
-void RKTrackRep::setSpu(StateOnPlane& state, double spu) const {
-  state.getAuxInfo().ResizeTo(2);
-  (state.getAuxInfo())(0) = spu;
-}
-
-void RKTrackRep::setTime(StateOnPlane& state, double time) const {
-  state.getAuxInfo().ResizeTo(2);
-  (state.getAuxInfo())(1) = time;
-}
-
-
-
-double RKTrackRep::RKPropagate(M1x7& state7,
-                        M7x7* jacobianT,
-                        M1x3& SA,
-                        double S,
-                        bool varField,
-                        bool calcOnlyLastRowOfJ) const {
-  // The algorithm is
-  //  E Lund et al 2009 JINST 4 P04001 doi:10.1088/1748-0221/4/04/P04001
-  //  "Track parameter propagation through the application of a new adaptive Runge-Kutta-Nyström method in the ATLAS experiment"
-  //  http://inspirehep.net/search?ln=en&ln=en&p=10.1088/1748-0221/4/04/P04001&of=hb&action_search=Search&sf=earliestdate&so=d&rm=&rg=25&sc=0
-  // where the transport of the Jacobian is described in
-  //   L. Bugge, J. Myrheim  Nucl.Instrum.Meth. 160 (1979) 43-48
-  //   "A Fast Runge-kutta Method For Fitting Tracks In A Magnetic Field"
-  //   http://inspirehep.net/record/145692
-  // and
-  //   L. Bugge, J. Myrheim  Nucl.Instrum.Meth. 179 (1981) 365-381
-  //   "Tracking And Track Fitting"
-  //   http://inspirehep.net/record/160548
-
-  // important fixed numbers
-  static const double EC  ( 0.000149896229 );  // c/(2*10^12) resp. c/2Tera
-  static const double P3  ( 1./3. );           // 1/3
-  static const double DLT ( .0002 );           // max. deviation for approximation-quality test
-  // Aux parameters
-  M1x3&   R           = *((M1x3*) &state7[0]);       // Start coordinates  [cm]  (x,  y,  z)
-  M1x3&   A           = *((M1x3*) &state7[3]);       // Start directions         (ax, ay, az);   ax^2+ay^2+az^2=1
-  double  S3(0), S4(0), PS2(0);
-  M1x3     H0 = {{0.,0.,0.}}, H1 = {{0.,0.,0.}}, H2 = {{0.,0.,0.}};
-  M1x3     r = {{0.,0.,0.}};
-  // Variables for Runge Kutta solver
-  double   A0(0), A1(0), A2(0), A3(0), A4(0), A5(0), A6(0);
-  double   B0(0), B1(0), B2(0), B3(0), B4(0), B5(0), B6(0);
-  double   C0(0), C1(0), C2(0), C3(0), C4(0), C5(0), C6(0);
-
-  //
-  // Runge Kutta Extrapolation
-  //
-  S3 = P3*S;
-  S4 = 0.25*S;
-  PS2 = state7[6]*EC * S;
-
-  // First point
-  r[0] = R[0];           r[1] = R[1];           r[2]=R[2];
-  FieldManager::getInstance()->getFieldVal(r[0], r[1], r[2], H0[0], H0[1], H0[2]);       // magnetic field in 10^-1 T = kGauss
-  H0[0] *= PS2; H0[1] *= PS2; H0[2] *= PS2;     // H0 is PS2*(Hx, Hy, Hz) @ R0
-  A0 = A[1]*H0[2]-A[2]*H0[1]; B0 = A[2]*H0[0]-A[0]*H0[2]; C0 = A[0]*H0[1]-A[1]*H0[0]; // (ax, ay, az) x H0
-  A2 = A[0]+A0              ; B2 = A[1]+B0              ; C2 = A[2]+C0              ; // (A0, B0, C0) + (ax, ay, az)
-  A1 = A2+A[0]              ; B1 = B2+A[1]              ; C1 = C2+A[2]              ; // (A0, B0, C0) + 2*(ax, ay, az)
-
-  // Second point
-  if (varField) {
-    r[0] += A1*S4;         r[1] += B1*S4;         r[2] += C1*S4;
-    FieldManager::getInstance()->getFieldVal(r[0], r[1], r[2], H1[0], H1[1], H1[2]);
-    H1[0] *= PS2; H1[1] *= PS2; H1[2] *= PS2; // H1 is PS2*(Hx, Hy, Hz) @ (x, y, z) + 0.25*S * [(A0, B0, C0) + 2*(ax, ay, az)]
-  }
-  else { H1 = H0; };
-  A3 = B2*H1[2]-C2*H1[1]+A[0]; B3 = C2*H1[0]-A2*H1[2]+A[1]; C3 = A2*H1[1]-B2*H1[0]+A[2]; // (A2, B2, C2) x H1 + (ax, ay, az)
-  A4 = B3*H1[2]-C3*H1[1]+A[0]; B4 = C3*H1[0]-A3*H1[2]+A[1]; C4 = A3*H1[1]-B3*H1[0]+A[2]; // (A3, B3, C3) x H1 + (ax, ay, az)
-  A5 = A4-A[0]+A4            ; B5 = B4-A[1]+B4            ; C5 = C4-A[2]+C4            ; //    2*(A4, B4, C4) - (ax, ay, az)
-
-  // Last point
-  if (varField) {
-    r[0]=R[0]+S*A4;         r[1]=R[1]+S*B4;         r[2]=R[2]+S*C4;  //setup.Field(r,H2);
-    FieldManager::getInstance()->getFieldVal(r[0], r[1], r[2], H2[0], H2[1], H2[2]);
-    H2[0] *= PS2; H2[1] *= PS2; H2[2] *= PS2; // H2 is PS2*(Hx, Hy, Hz) @ (x, y, z) + 0.25*S * (A4, B4, C4)
-  }
-  else { H2 = H0; };
-  A6 = B5*H2[2]-C5*H2[1]; B6 = C5*H2[0]-A5*H2[2]; C6 = A5*H2[1]-B5*H2[0]; // (A5, B5, C5) x H2
-
-
-  //
-  // Derivatives of track parameters
-  //
-  if(jacobianT != nullptr){
-
-    // jacobianT
-    // 1 0 0 0 0 0 0  x
-    // 0 1 0 0 0 0 0  y
-    // 0 0 1 0 0 0 0  z
-    // x x x x x x 0  a_x
-    // x x x x x x 0  a_y
-    // x x x x x x 0  a_z
-    // x x x x x x 1  q/p
-    M7x7& J = *jacobianT;
-
-    double   dA0(0), dA2(0), dA3(0), dA4(0), dA5(0), dA6(0);
-    double   dB0(0), dB2(0), dB3(0), dB4(0), dB5(0), dB6(0);
-    double   dC0(0), dC2(0), dC3(0), dC4(0), dC5(0), dC6(0);
-
-    int start(0);
-
-    if (!calcOnlyLastRowOfJ) {
-
-      if (!varField) {
-        // d(x, y, z)/d(x, y, z) submatrix is unit matrix
-        J(0, 0) = 1;  J(1, 1) = 1;  J(2, 2) = 1;
-        // d(ax, ay, az)/d(ax, ay, az) submatrix is 0
-        // start with d(x, y, z)/d(ax, ay, az)
-        start = 3;
-      }
-
-      for(int i=start; i<6; ++i) {
-
-        //first point
-        dA0 = H0[2]*J(i, 4)-H0[1]*J(i, 5);    // dA0/dp }
-        dB0 = H0[0]*J(i, 5)-H0[2]*J(i, 3);    // dB0/dp  } = dA x H0
-        dC0 = H0[1]*J(i, 3)-H0[0]*J(i, 4);    // dC0/dp }
-
-        dA2 = dA0+J(i, 3);        // }
-        dB2 = dB0+J(i, 4);        //  } = (dA0, dB0, dC0) + dA
-        dC2 = dC0+J(i, 5);        // }
-
-        //second point
-        dA3 = J(i, 3)+dB2*H1[2]-dC2*H1[1];    // dA3/dp }
-        dB3 = J(i, 4)+dC2*H1[0]-dA2*H1[2];    // dB3/dp  } = dA + (dA2, dB2, dC2) x H1
-        dC3 = J(i, 5)+dA2*H1[1]-dB2*H1[0];    // dC3/dp }
-
-        dA4 = J(i, 3)+dB3*H1[2]-dC3*H1[1];    // dA4/dp }
-        dB4 = J(i, 4)+dC3*H1[0]-dA3*H1[2];    // dB4/dp  } = dA + (dA3, dB3, dC3) x H1
-        dC4 = J(i, 5)+dA3*H1[1]-dB3*H1[0];    // dC4/dp }
-
-        //last point
-        dA5 = dA4+dA4-J(i, 3);      // }
-        dB5 = dB4+dB4-J(i, 4);      //  } =  2*(dA4, dB4, dC4) - dA
-        dC5 = dC4+dC4-J(i, 5);      // }
-
-        dA6 = dB5*H2[2]-dC5*H2[1];      // dA6/dp }
-        dB6 = dC5*H2[0]-dA5*H2[2];      // dB6/dp  } = (dA5, dB5, dC5) x H2
-        dC6 = dA5*H2[1]-dB5*H2[0];      // dC6/dp }
-
-        // this gives the same results as multiplying the old with the new Jacobian
-        J(i, 0) += (dA2+dA3+dA4)*S3;  J(i, 3) = ((dA0+2.*dA3)+(dA5+dA6))*P3; // dR := dR + S3*[(dA2, dB2, dC2) +   (dA3, dB3, dC3) + (dA4, dB4, dC4)]
-        J(i, 1) += (dB2+dB3+dB4)*S3;  J(i, 4) = ((dB0+2.*dB3)+(dB5+dB6))*P3; // dA :=     1/3*[(dA0, dB0, dC0) + 2*(dA3, dB3, dC3) + (dA5, dB5, dC5) + (dA6, dB6, dC6)]
-        J(i, 2) += (dC2+dC3+dC4)*S3;  J(i, 5) = ((dC0+2.*dC3)+(dC5+dC6))*P3;
-      }
-
-    } // end if (!calcOnlyLastRowOfJ)
-
-    J(6, 3) *= state7[6]; J(6, 4) *= state7[6]; J(6, 5) *= state7[6];
-
-    //first point
-    dA0 = H0[2]*J(6, 4)-H0[1]*J(6, 5) + A0;    // dA0/dp }
-    dB0 = H0[0]*J(6, 5)-H0[2]*J(6, 3) + B0;    // dB0/dp  } = dA x H0 + (A0, B0, C0)
-    dC0 = H0[1]*J(6, 3)-H0[0]*J(6, 4) + C0;    // dC0/dp }
-
-    dA2 = dA0+J(6, 3);        // }
-    dB2 = dB0+J(6, 4);        //  } = (dA0, dB0, dC0) + dA
-    dC2 = dC0+J(6, 5);        // }
-
-    //second point
-    dA3 = J(6, 3)+dB2*H1[2]-dC2*H1[1] + (A3-A[0]);    // dA3/dp }
-    dB3 = J(6, 4)+dC2*H1[0]-dA2*H1[2] + (B3-A[1]);    // dB3/dp  } = dA + (dA2, dB2, dC2) x H1
-    dC3 = J(6, 5)+dA2*H1[1]-dB2*H1[0] + (C3-A[2]);    // dC3/dp }
-
-    dA4 = J(6, 3)+dB3*H1[2]-dC3*H1[1] + (A4-A[0]);    // dA4/dp }
-    dB4 = J(6, 4)+dC3*H1[0]-dA3*H1[2] + (B4-A[1]);    // dB4/dp  } = dA + (dA3, dB3, dC3) x H1
-    dC4 = J(6, 5)+dA3*H1[1]-dB3*H1[0] + (C4-A[2]);    // dC4/dp }
-
-    //last point
-    dA5 = dA4+dA4-J(6, 3);      // }
-    dB5 = dB4+dB4-J(6, 4);      //  } =  2*(dA4, dB4, dC4) - dA
-    dC5 = dC4+dC4-J(6, 5);      // }
-
-    dA6 = dB5*H2[2]-dC5*H2[1] + A6;      // dA6/dp }
-    dB6 = dC5*H2[0]-dA5*H2[2] + B6;      // dB6/dp  } = (dA5, dB5, dC5) x H2 + (A6, B6, C6)
-    dC6 = dA5*H2[1]-dB5*H2[0] + C6;      // dC6/dp }
-
-    // this gives the same results as multiplying the old with the new Jacobian
-    J(6, 0) += (dA2+dA3+dA4)*S3/state7[6];  J(6, 3) = ((dA0+2.*dA3)+(dA5+dA6))*P3/state7[6]; // dR := dR + S3*[(dA2, dB2, dC2) +   (dA3, dB3, dC3) + (dA4, dB4, dC4)]
-    J(6, 1) += (dB2+dB3+dB4)*S3/state7[6];  J(6, 4) = ((dB0+2.*dB3)+(dB5+dB6))*P3/state7[6]; // dA :=     1/3*[(dA0, dB0, dC0) + 2*(dA3, dB3, dC3) + (dA5, dB5, dC5) + (dA6, dB6, dC6)]
-    J(6, 2) += (dC2+dC3+dC4)*S3/state7[6];  J(6, 5) = ((dC0+2.*dC3)+(dC5+dC6))*P3/state7[6];
+  void RKTrackRep::getState5(StateOnPlane& state, const M1x7& state7) const
+  {
+
+    // state5: (q/p, u', v'. u, v)
+
+    double spu(1.);
+
+    const TVector3& O(state.getPlane()->getO());
+    const TVector3& U(state.getPlane()->getU());
+    const TVector3& V(state.getPlane()->getV());
+    const TVector3& W(state.getPlane()->getNormal());
+
+    // force A to be in normal direction and set spu accordingly
+    double AtW(state7[3]*W.X() + state7[4]*W.Y() + state7[5]*W.Z());
+    if (AtW < 0.) {
+      //fDir *= -1.;
+      //AtW *= -1.;
+      spu = -1.;
+    }
+
+    double* state5 = state.getState().GetMatrixArray();
+
+    state5[0] = state7[6]; // q/p
+    state5[1] = (state7[3] * U.X() + state7[4] * U.Y() + state7[5] * U.Z()) / AtW; // u' = (A * U) / (A * W)
+    state5[2] = (state7[3] * V.X() + state7[4] * V.Y() + state7[5] * V.Z()) / AtW; // v' = (A * V) / (A * W)
+    state5[3] = ((state7[0] - O.X()) * U.X() +
+                 (state7[1] - O.Y()) * U.Y() +
+                 (state7[2] - O.Z()) * U.Z()); // u = (pos - O) * U
+    state5[4] = ((state7[0] - O.X()) * V.X() +
+                 (state7[1] - O.Y()) * V.Y() +
+                 (state7[2] - O.Z()) * V.Z()); // v = (pos - O) * V
+
+    setSpu(state, spu);
 
   }
 
-  //
-  // Track parameters in last point
-  //
-  R[0] += (A2+A3+A4)*S3;   A[0] += (SA[0]=((A0+2.*A3)+(A5+A6))*P3-A[0]);  // R  = R0 + S3*[(A2, B2, C2) +   (A3, B3, C3) + (A4, B4, C4)]
-  R[1] += (B2+B3+B4)*S3;   A[1] += (SA[1]=((B0+2.*B3)+(B5+B6))*P3-A[1]);  // A  =     1/3*[(A0, B0, C0) + 2*(A3, B3, C3) + (A5, B5, C5) + (A6, B6, C6)]
-  R[2] += (C2+C3+C4)*S3;   A[2] += (SA[2]=((C0+2.*C3)+(C5+C6))*P3-A[2]);  // SA = A_new - A_old
+  void RKTrackRep::calcJ_pM_5x7(M5x7& J_pM, const TVector3& U, const TVector3& V, const M1x3& pTilde, double spu) const
+  {
+    /*if (debugLvl_ > 1) {
+      debugOut << "RKTrackRep::calcJ_pM_5x7 \n";
+      debugOut << "  U = "; U.Print();
+      debugOut << "  V = "; V.Print();
+      debugOut << "  pTilde = "; RKTools::printDim(pTilde, 3,1);
+      debugOut << "  spu = " << spu << "\n";
+    }*/
 
-  // normalize A
-  double CBA ( 1./sqrt(A[0]*A[0]+A[1]*A[1]+A[2]*A[2]) ); // 1/|A|
-  A[0] *= CBA; A[1] *= CBA; A[2] *= CBA;
+    std::fill(J_pM.begin(), J_pM.end(), 0);
 
+    const double pTildeMag = sqrt(pTilde[0] * pTilde[0] + pTilde[1] * pTilde[1] + pTilde[2] * pTilde[2]);
+    const double pTildeMag2 = pTildeMag * pTildeMag;
 
-  // Test approximation quality on given step
-  double EST ( fabs((A1+A6)-(A3+A4)) +
-               fabs((B1+B6)-(B3+B4)) +
-               fabs((C1+C6)-(C3+C4))  );  // EST = ||(ABC1+ABC6)-(ABC3+ABC4)||_1  =  ||(axzy x H0 + ABC5 x H2) - (ABC2 x H1 + ABC3 x H1)||_1
-  if (debugLvl_ > 0) {
-    debugOut << "    RKTrackRep::RKPropagate. Step = "<< S << "; quality EST = " << EST  << " \n";
+    const double utpTildeOverpTildeMag2 = (U.X() * pTilde[0] + U.Y() * pTilde[1] + U.Z() * pTilde[2]) / pTildeMag2;
+    const double vtpTildeOverpTildeMag2 = (V.X() * pTilde[0] + V.Y() * pTilde[1] + V.Z() * pTilde[2]) / pTildeMag2;
+
+    //J_pM matrix is d(x,y,z,ax,ay,az,q/p) / d(q/p,u',v',u,v)   (out is 7x7)
+
+    // d(x,y,z)/d(u)
+    J_pM[21] = U.X(); // [3][0]
+    J_pM[22] = U.Y(); // [3][1]
+    J_pM[23] = U.Z(); // [3][2]
+    // d(x,y,z)/d(v)
+    J_pM[28] = V.X(); // [4][0]
+    J_pM[29] = V.Y(); // [4][1]
+    J_pM[30] = V.Z(); // [4][2]
+    // d(q/p)/d(q/p)
+    J_pM[6] = 1.; // not needed for array matrix multiplication
+    // d(ax,ay,az)/d(u')
+    double fact = spu / pTildeMag;
+    J_pM[10] = fact * (U.X() - pTilde[0] * utpTildeOverpTildeMag2); // [1][3]
+    J_pM[11] = fact * (U.Y() - pTilde[1] * utpTildeOverpTildeMag2); // [1][4]
+    J_pM[12] = fact * (U.Z() - pTilde[2] * utpTildeOverpTildeMag2); // [1][5]
+    // d(ax,ay,az)/d(v')
+    J_pM[17] = fact * (V.X() - pTilde[0] * vtpTildeOverpTildeMag2); // [2][3]
+    J_pM[18] = fact * (V.Y() - pTilde[1] * vtpTildeOverpTildeMag2); // [2][4]
+    J_pM[19] = fact * (V.Z() - pTilde[2] * vtpTildeOverpTildeMag2); // [2][5]
+
+    /*if (debugLvl_ > 1) {
+      debugOut << "  J_pM_5x7_ = "; RKTools::printDim(J_pM_5x7_, 5,7);
+    }*/
   }
 
-  // Prevent the step length increase from getting too large, this is
-  // just the point where it becomes 10.
-  if (EST < DLT*1e-5)
-    return 10;
 
-  // Step length increase for a fifth order Runge-Kutta, see e.g. 17.2
-  // in Numerical Recipes.  FIXME: move to caller.
-  return pow(DLT/EST, 1./5.);
-}
+  void RKTrackRep::transformPM6(const MeasuredStateOnPlane& state,
+                                M6x6& out6x6) const
+  {
+
+    // get vectors and aux variables
+    const TVector3& U(state.getPlane()->getU());
+    const TVector3& V(state.getPlane()->getV());
+    const TVector3& W(state.getPlane()->getNormal());
+
+    const TVectorD& state5(state.getState());
+    double spu(getSpu(state));
+
+    M1x3 pTilde;
+    pTilde[0] = spu * (W.X() + state5(1) * U.X() + state5(2) * V.X()); // a_x
+    pTilde[1] = spu * (W.Y() + state5(1) * U.Y() + state5(2) * V.Y()); // a_y
+    pTilde[2] = spu * (W.Z() + state5(1) * U.Z() + state5(2) * V.Z()); // a_z
+
+    const double pTildeMag = sqrt(pTilde[0] * pTilde[0] + pTilde[1] * pTilde[1] + pTilde[2] * pTilde[2]);
+    const double pTildeMag2 = pTildeMag * pTildeMag;
+
+    const double utpTildeOverpTildeMag2 = (U.X() * pTilde[0] + U.Y() * pTilde[1] + U.Z() * pTilde[2]) / pTildeMag2;
+    const double vtpTildeOverpTildeMag2 = (V.X() * pTilde[0] + V.Y() * pTilde[1] + V.Z() * pTilde[2]) / pTildeMag2;
+
+    //J_pM matrix is d(x,y,z,px,py,pz) / d(q/p,u',v',u,v)       (out is 6x6)
+
+    const double qop = state5(0);
+    const double p = getCharge(state) / qop; // momentum
+
+    M5x6 J_pM_5x6;
+    std::fill(J_pM_5x6.begin(), J_pM_5x6.end(), 0);
+
+    // d(px,py,pz)/d(q/p)
+    double fact = -1. * p / (pTildeMag * qop);
+    J_pM_5x6[3] = fact * pTilde[0]; // [0][3]
+    J_pM_5x6[4] = fact * pTilde[1]; // [0][4]
+    J_pM_5x6[5] = fact * pTilde[2]; // [0][5]
+    // d(px,py,pz)/d(u')
+    fact = p * spu / pTildeMag;
+    J_pM_5x6[9]  = fact * (U.X() - pTilde[0] * utpTildeOverpTildeMag2); // [1][3]
+    J_pM_5x6[10] = fact * (U.Y() - pTilde[1] * utpTildeOverpTildeMag2); // [1][4]
+    J_pM_5x6[11] = fact * (U.Z() - pTilde[2] * utpTildeOverpTildeMag2); // [1][5]
+    // d(px,py,pz)/d(v')
+    J_pM_5x6[15] = fact * (V.X() - pTilde[0] * vtpTildeOverpTildeMag2); // [2][3]
+    J_pM_5x6[16] = fact * (V.Y() - pTilde[1] * vtpTildeOverpTildeMag2); // [2][4]
+    J_pM_5x6[17] = fact * (V.Z() - pTilde[2] * vtpTildeOverpTildeMag2); // [2][5]
+    // d(x,y,z)/d(u)
+    J_pM_5x6[18] = U.X(); // [3][0]
+    J_pM_5x6[19] = U.Y(); // [3][1]
+    J_pM_5x6[20] = U.Z(); // [3][2]
+    // d(x,y,z)/d(v)
+    J_pM_5x6[24] = V.X(); // [4][0]
+    J_pM_5x6[25] = V.Y(); // [4][1]
+    J_pM_5x6[26] = V.Z(); // [4][2]
 
 
+    // do the transformation
+    // out = J_pM^T * in5x5 * J_pM
+    const M5x5& in5x5_ = *((M5x5*) state.getCov().GetMatrixArray());
+    RKTools::J_pMTxcov5xJ_pM(J_pM_5x6, in5x5_, out6x6);
 
-void RKTrackRep::initArrays() const {
-  std::fill(noiseArray_.begin(), noiseArray_.end(), 0);
-  std::fill(noiseProjection_.begin(), noiseProjection_.end(), 0);
-  for (unsigned int i=0; i<7; ++i) // initialize as diagonal matrix
-    noiseProjection_[i*8] = 1;
-  std::fill(J_MMT_.begin(), J_MMT_.end(), 0);
-
-  fJacobian_.UnitMatrix();
-  fNoise_.Zero();
-  limits_.reset();
-
-  RKSteps_.reserve(100);
-  ExtrapSteps_.reserve(100);
-
-  lastStartState_.getAuxInfo().ResizeTo(2);
-  lastEndState_.getAuxInfo().ResizeTo(2);
-}
-
-
-void RKTrackRep::getState7(const StateOnPlane& state, M1x7& state7) const {
-
-  if (dynamic_cast<const MeasurementOnPlane*>(&state) != nullptr) {
-    Exception exc("RKTrackRep::getState7 - cannot get pos or mom from a MeasurementOnPlane",__LINE__,__FILE__);
-    exc.setFatal();
-    throw exc;
   }
 
-  const TVector3& U(state.getPlane()->getU());
-  const TVector3& V(state.getPlane()->getV());
-  const TVector3& O(state.getPlane()->getO());
-  const TVector3& W(state.getPlane()->getNormal());
+  void RKTrackRep::calcJ_Mp_7x5(M7x5& J_Mp, const TVector3& U, const TVector3& V, const TVector3& W, const M1x3& A) const
+  {
 
-  assert(state.getState().GetNrows() == 5);
-  const double* state5 = state.getState().GetMatrixArray();
+    /*if (debugLvl_ > 1) {
+      debugOut << "RKTrackRep::calcJ_Mp_7x5 \n";
+      debugOut << "  U = "; U.Print();
+      debugOut << "  V = "; V.Print();
+      debugOut << "  W = "; W.Print();
+      debugOut << "  A = "; RKTools::printDim(A, 3,1);
+    }*/
 
-  double spu = getSpu(state);
+    std::fill(J_Mp.begin(), J_Mp.end(), 0);
 
-  state7[0] = O.X() + state5[3]*U.X() + state5[4]*V.X(); // x
-  state7[1] = O.Y() + state5[3]*U.Y() + state5[4]*V.Y(); // y
-  state7[2] = O.Z() + state5[3]*U.Z() + state5[4]*V.Z(); // z
+    const double AtU = A[0] * U.X() + A[1] * U.Y() + A[2] * U.Z();
+    const double AtV = A[0] * V.X() + A[1] * V.Y() + A[2] * V.Z();
+    const double AtW = A[0] * W.X() + A[1] * W.Y() + A[2] * W.Z();
 
-  state7[3] = spu * (W.X() + state5[1]*U.X() + state5[2]*V.X()); // a_x
-  state7[4] = spu * (W.Y() + state5[1]*U.Y() + state5[2]*V.Y()); // a_y
-  state7[5] = spu * (W.Z() + state5[1]*U.Z() + state5[2]*V.Z()); // a_z
+    // J_Mp matrix is d(q/p,u',v',u,v) / d(x,y,z,ax,ay,az,q/p)   (in is 7x7)
 
-  // normalize dir
-  double norm = 1. / sqrt(state7[3]*state7[3] + state7[4]*state7[4] + state7[5]*state7[5]);
-  for (unsigned int i=3; i<6; ++i) state7[i] *= norm;
+    // d(u')/d(ax,ay,az)
+    double fact = 1. / (AtW * AtW);
+    J_Mp[16] = fact * (U.X() * AtW - W.X() * AtU); // [3][1]
+    J_Mp[21] = fact * (U.Y() * AtW - W.Y() * AtU); // [4][1]
+    J_Mp[26] = fact * (U.Z() * AtW - W.Z() * AtU); // [5][1]
+    // d(v')/d(ax,ay,az)
+    J_Mp[17] = fact * (V.X() * AtW - W.X() * AtV); // [3][2]
+    J_Mp[22] = fact * (V.Y() * AtW - W.Y() * AtV); // [4][2]
+    J_Mp[27] = fact * (V.Z() * AtW - W.Z() * AtV); // [5][2]
+    // d(q/p)/d(q/p)
+    J_Mp[30] = 1.; // [6][0]  - not needed for array matrix multiplication
+    //d(u)/d(x,y,z)
+    J_Mp[3]  = U.X(); // [0][3]
+    J_Mp[8]  = U.Y(); // [1][3]
+    J_Mp[13] = U.Z(); // [2][3]
+    //d(v)/d(x,y,z)
+    J_Mp[4]  = V.X(); // [0][4]
+    J_Mp[9]  = V.Y(); // [1][4]
+    J_Mp[14] = V.Z(); // [2][4]
 
-  state7[6] = state5[0]; // q/p
-}
+    /*if (debugLvl_ > 1) {
+      debugOut << "  J_Mp_7x5_ = "; RKTools::printDim(J_Mp, 7,5);
+    }*/
 
-
-void RKTrackRep::getState5(StateOnPlane& state, const M1x7& state7) const {
-
-  // state5: (q/p, u', v'. u, v)
-
-  double spu(1.);
-
-  const TVector3& O(state.getPlane()->getO());
-  const TVector3& U(state.getPlane()->getU());
-  const TVector3& V(state.getPlane()->getV());
-  const TVector3& W(state.getPlane()->getNormal());
-
-  // force A to be in normal direction and set spu accordingly
-  double AtW( state7[3]*W.X() + state7[4]*W.Y() + state7[5]*W.Z() );
-  if (AtW < 0.) {
-    //fDir *= -1.;
-    //AtW *= -1.;
-    spu = -1.;
   }
 
-  double* state5 = state.getState().GetMatrixArray();
 
-  state5[0] = state7[6]; // q/p
-  state5[1] = (state7[3]*U.X() + state7[4]*U.Y() + state7[5]*U.Z()) / AtW; // u' = (A * U) / (A * W)
-  state5[2] = (state7[3]*V.X() + state7[4]*V.Y() + state7[5]*V.Z()) / AtW; // v' = (A * V) / (A * W)
-  state5[3] = ((state7[0]-O.X())*U.X() +
-               (state7[1]-O.Y())*U.Y() +
-               (state7[2]-O.Z())*U.Z()); // u = (pos - O) * U
-  state5[4] = ((state7[0]-O.X())*V.X() +
-               (state7[1]-O.Y())*V.Y() +
-               (state7[2]-O.Z())*V.Z()); // v = (pos - O) * V
+  void RKTrackRep::transformM6P(const M6x6& in6x6,
+                                const M1x7& state7,
+                                MeasuredStateOnPlane& state) const   // plane and charge must already be set!
+  {
 
-  setSpu(state, spu);
+    // get vectors and aux variables
+    const TVector3& U(state.getPlane()->getU());
+    const TVector3& V(state.getPlane()->getV());
+    const TVector3& W(state.getPlane()->getNormal());
 
-}
+    const double AtU = state7[3] * U.X() + state7[4] * U.Y() + state7[5] * U.Z();
+    const double AtV = state7[3] * V.X() + state7[4] * V.Y() + state7[5] * V.Z();
+    const double AtW = state7[3] * W.X() + state7[4] * W.Y() + state7[5] * W.Z();
 
-void RKTrackRep::calcJ_pM_5x7(M5x7& J_pM, const TVector3& U, const TVector3& V, const M1x3& pTilde, double spu) const {
-  /*if (debugLvl_ > 1) {
-    debugOut << "RKTrackRep::calcJ_pM_5x7 \n";
-    debugOut << "  U = "; U.Print();
-    debugOut << "  V = "; V.Print();
-    debugOut << "  pTilde = "; RKTools::printDim(pTilde, 3,1);
-    debugOut << "  spu = " << spu << "\n";
-  }*/
+    // J_Mp matrix is d(q/p,u',v',u,v) / d(x,y,z,px,py,pz)       (in is 6x6)
 
-  std::fill(J_pM.begin(), J_pM.end(), 0);
+    const double qop = state7[6];
+    const double p = getCharge(state) / qop; // momentum
 
-  const double pTildeMag = sqrt(pTilde[0]*pTilde[0] + pTilde[1]*pTilde[1] + pTilde[2]*pTilde[2]);
-  const double pTildeMag2 = pTildeMag*pTildeMag;
+    M6x5 J_Mp_6x5;
+    std::fill(J_Mp_6x5.begin(), J_Mp_6x5.end(), 0);
 
-  const double utpTildeOverpTildeMag2 = (U.X()*pTilde[0] + U.Y()*pTilde[1] + U.Z()*pTilde[2]) / pTildeMag2;
-  const double vtpTildeOverpTildeMag2 = (V.X()*pTilde[0] + V.Y()*pTilde[1] + V.Z()*pTilde[2]) / pTildeMag2;
+    //d(u)/d(x,y,z)
+    J_Mp_6x5[3]  = U.X(); // [0][3]
+    J_Mp_6x5[8]  = U.Y(); // [1][3]
+    J_Mp_6x5[13] = U.Z(); // [2][3]
+    //d(v)/d(x,y,z)
+    J_Mp_6x5[4]  = V.X(); // [0][4]
+    J_Mp_6x5[9]  = V.Y(); // [1][4]
+    J_Mp_6x5[14] = V.Z(); // [2][4]
+    // d(q/p)/d(px,py,pz)
+    double fact = (-1.) * qop / p;
+    J_Mp_6x5[15] = fact * state7[3]; // [3][0]
+    J_Mp_6x5[20] = fact * state7[4]; // [4][0]
+    J_Mp_6x5[25] = fact * state7[5]; // [5][0]
+    // d(u')/d(px,py,pz)
+    fact = 1. / (p * AtW * AtW);
+    J_Mp_6x5[16] = fact * (U.X() * AtW - W.X() * AtU); // [3][1]
+    J_Mp_6x5[21] = fact * (U.Y() * AtW - W.Y() * AtU); // [4][1]
+    J_Mp_6x5[26] = fact * (U.Z() * AtW - W.Z() * AtU); // [5][1]
+    // d(v')/d(px,py,pz)
+    J_Mp_6x5[17] = fact * (V.X() * AtW - W.X() * AtV); // [3][2]
+    J_Mp_6x5[22] = fact * (V.Y() * AtW - W.Y() * AtV); // [4][2]
+    J_Mp_6x5[27] = fact * (V.Z() * AtW - W.Z() * AtV); // [5][2]
 
-  //J_pM matrix is d(x,y,z,ax,ay,az,q/p) / d(q/p,u',v',u,v)   (out is 7x7)
+    // do the transformation
+    // out5x5 = J_Mp^T * in * J_Mp
+    M5x5& out5x5_ = *((M5x5*) state.getCov().GetMatrixArray());
+    RKTools::J_MpTxcov6xJ_Mp(J_Mp_6x5, in6x6, out5x5_);
 
-   // d(x,y,z)/d(u)
-  J_pM[21] = U.X(); // [3][0]
-  J_pM[22] = U.Y(); // [3][1]
-  J_pM[23] = U.Z(); // [3][2]
-  // d(x,y,z)/d(v)
-  J_pM[28] = V.X(); // [4][0]
-  J_pM[29] = V.Y(); // [4][1]
-  J_pM[30] = V.Z(); // [4][2]
-  // d(q/p)/d(q/p)
-  J_pM[6] = 1.; // not needed for array matrix multiplication
-  // d(ax,ay,az)/d(u')
-  double fact = spu / pTildeMag;
-  J_pM[10] = fact * ( U.X() - pTilde[0]*utpTildeOverpTildeMag2 ); // [1][3]
-  J_pM[11] = fact * ( U.Y() - pTilde[1]*utpTildeOverpTildeMag2 ); // [1][4]
-  J_pM[12] = fact * ( U.Z() - pTilde[2]*utpTildeOverpTildeMag2 ); // [1][5]
-  // d(ax,ay,az)/d(v')
-  J_pM[17] = fact * ( V.X() - pTilde[0]*vtpTildeOverpTildeMag2 ); // [2][3]
-  J_pM[18] = fact * ( V.Y() - pTilde[1]*vtpTildeOverpTildeMag2 ); // [2][4]
-  J_pM[19] = fact * ( V.Z() - pTilde[2]*vtpTildeOverpTildeMag2 ); // [2][5]
-
-  /*if (debugLvl_ > 1) {
-    debugOut << "  J_pM_5x7_ = "; RKTools::printDim(J_pM_5x7_, 5,7);
-  }*/
-}
-
-
-void RKTrackRep::transformPM6(const MeasuredStateOnPlane& state,
-                              M6x6& out6x6) const {
-
-  // get vectors and aux variables
-  const TVector3& U(state.getPlane()->getU());
-  const TVector3& V(state.getPlane()->getV());
-  const TVector3& W(state.getPlane()->getNormal());
-
-  const TVectorD& state5(state.getState());
-  double spu(getSpu(state));
-
-  M1x3 pTilde;
-  pTilde[0] = spu * (W.X() + state5(1)*U.X() + state5(2)*V.X()); // a_x
-  pTilde[1] = spu * (W.Y() + state5(1)*U.Y() + state5(2)*V.Y()); // a_y
-  pTilde[2] = spu * (W.Z() + state5(1)*U.Z() + state5(2)*V.Z()); // a_z
-
-  const double pTildeMag = sqrt(pTilde[0]*pTilde[0] + pTilde[1]*pTilde[1] + pTilde[2]*pTilde[2]);
-  const double pTildeMag2 = pTildeMag*pTildeMag;
-
-  const double utpTildeOverpTildeMag2 = (U.X()*pTilde[0] + U.Y()*pTilde[1] + U.Z()*pTilde[2]) / pTildeMag2;
-  const double vtpTildeOverpTildeMag2 = (V.X()*pTilde[0] + V.Y()*pTilde[1] + V.Z()*pTilde[2]) / pTildeMag2;
-
-  //J_pM matrix is d(x,y,z,px,py,pz) / d(q/p,u',v',u,v)       (out is 6x6)
-
-  const double qop = state5(0);
-  const double p = getCharge(state)/qop; // momentum
-
-  M5x6 J_pM_5x6;
-  std::fill(J_pM_5x6.begin(), J_pM_5x6.end(), 0);
-
-  // d(px,py,pz)/d(q/p)
-  double fact = -1. * p / (pTildeMag * qop);
-  J_pM_5x6[3] = fact * pTilde[0]; // [0][3]
-  J_pM_5x6[4] = fact * pTilde[1]; // [0][4]
-  J_pM_5x6[5] = fact * pTilde[2]; // [0][5]
-  // d(px,py,pz)/d(u')
-  fact = p * spu / pTildeMag;
-  J_pM_5x6[9]  = fact * ( U.X() - pTilde[0]*utpTildeOverpTildeMag2 ); // [1][3]
-  J_pM_5x6[10] = fact * ( U.Y() - pTilde[1]*utpTildeOverpTildeMag2 ); // [1][4]
-  J_pM_5x6[11] = fact * ( U.Z() - pTilde[2]*utpTildeOverpTildeMag2 ); // [1][5]
-  // d(px,py,pz)/d(v')
-  J_pM_5x6[15] = fact * ( V.X() - pTilde[0]*vtpTildeOverpTildeMag2 ); // [2][3]
-  J_pM_5x6[16] = fact * ( V.Y() - pTilde[1]*vtpTildeOverpTildeMag2 ); // [2][4]
-  J_pM_5x6[17] = fact * ( V.Z() - pTilde[2]*vtpTildeOverpTildeMag2 ); // [2][5]
-  // d(x,y,z)/d(u)
-  J_pM_5x6[18] = U.X(); // [3][0]
-  J_pM_5x6[19] = U.Y(); // [3][1]
-  J_pM_5x6[20] = U.Z(); // [3][2]
-  // d(x,y,z)/d(v)
-  J_pM_5x6[24] = V.X(); // [4][0]
-  J_pM_5x6[25] = V.Y(); // [4][1]
-  J_pM_5x6[26] = V.Z(); // [4][2]
-
-
-  // do the transformation
-  // out = J_pM^T * in5x5 * J_pM
-  const M5x5& in5x5_ = *((M5x5*) state.getCov().GetMatrixArray());
-  RKTools::J_pMTxcov5xJ_pM(J_pM_5x6, in5x5_, out6x6);
-
-}
-
-void RKTrackRep::calcJ_Mp_7x5(M7x5& J_Mp, const TVector3& U, const TVector3& V, const TVector3& W, const M1x3& A) const {
-
-  /*if (debugLvl_ > 1) {
-    debugOut << "RKTrackRep::calcJ_Mp_7x5 \n";
-    debugOut << "  U = "; U.Print();
-    debugOut << "  V = "; V.Print();
-    debugOut << "  W = "; W.Print();
-    debugOut << "  A = "; RKTools::printDim(A, 3,1);
-  }*/
-
-  std::fill(J_Mp.begin(), J_Mp.end(), 0);
-
-  const double AtU = A[0]*U.X() + A[1]*U.Y() + A[2]*U.Z();
-  const double AtV = A[0]*V.X() + A[1]*V.Y() + A[2]*V.Z();
-  const double AtW = A[0]*W.X() + A[1]*W.Y() + A[2]*W.Z();
-
-  // J_Mp matrix is d(q/p,u',v',u,v) / d(x,y,z,ax,ay,az,q/p)   (in is 7x7)
-
-  // d(u')/d(ax,ay,az)
-  double fact = 1./(AtW*AtW);
-  J_Mp[16] = fact * (U.X()*AtW - W.X()*AtU); // [3][1]
-  J_Mp[21] = fact * (U.Y()*AtW - W.Y()*AtU); // [4][1]
-  J_Mp[26] = fact * (U.Z()*AtW - W.Z()*AtU); // [5][1]
-  // d(v')/d(ax,ay,az)
-  J_Mp[17] = fact * (V.X()*AtW - W.X()*AtV); // [3][2]
-  J_Mp[22] = fact * (V.Y()*AtW - W.Y()*AtV); // [4][2]
-  J_Mp[27] = fact * (V.Z()*AtW - W.Z()*AtV); // [5][2]
-  // d(q/p)/d(q/p)
-  J_Mp[30] = 1.; // [6][0]  - not needed for array matrix multiplication
-  //d(u)/d(x,y,z)
-  J_Mp[3]  = U.X(); // [0][3]
-  J_Mp[8]  = U.Y(); // [1][3]
-  J_Mp[13] = U.Z(); // [2][3]
-  //d(v)/d(x,y,z)
-  J_Mp[4]  = V.X(); // [0][4]
-  J_Mp[9]  = V.Y(); // [1][4]
-  J_Mp[14] = V.Z(); // [2][4]
-
-  /*if (debugLvl_ > 1) {
-    debugOut << "  J_Mp_7x5_ = "; RKTools::printDim(J_Mp, 7,5);
-  }*/
-
-}
-
-
-void RKTrackRep::transformM6P(const M6x6& in6x6,
-                              const M1x7& state7,
-                              MeasuredStateOnPlane& state) const { // plane and charge must already be set!
-
-  // get vectors and aux variables
-  const TVector3& U(state.getPlane()->getU());
-  const TVector3& V(state.getPlane()->getV());
-  const TVector3& W(state.getPlane()->getNormal());
-
-  const double AtU = state7[3]*U.X() + state7[4]*U.Y() + state7[5]*U.Z();
-  const double AtV = state7[3]*V.X() + state7[4]*V.Y() + state7[5]*V.Z();
-  const double AtW = state7[3]*W.X() + state7[4]*W.Y() + state7[5]*W.Z();
-
-  // J_Mp matrix is d(q/p,u',v',u,v) / d(x,y,z,px,py,pz)       (in is 6x6)
-
-  const double qop = state7[6];
-  const double p = getCharge(state)/qop; // momentum
-
-  M6x5 J_Mp_6x5;
-  std::fill(J_Mp_6x5.begin(), J_Mp_6x5.end(), 0);
-
-  //d(u)/d(x,y,z)
-  J_Mp_6x5[3]  = U.X(); // [0][3]
-  J_Mp_6x5[8]  = U.Y(); // [1][3]
-  J_Mp_6x5[13] = U.Z(); // [2][3]
-  //d(v)/d(x,y,z)
-  J_Mp_6x5[4]  = V.X(); // [0][4]
-  J_Mp_6x5[9]  = V.Y(); // [1][4]
-  J_Mp_6x5[14] = V.Z(); // [2][4]
-  // d(q/p)/d(px,py,pz)
-  double fact = (-1.) * qop / p;
-  J_Mp_6x5[15] = fact * state7[3]; // [3][0]
-  J_Mp_6x5[20] = fact * state7[4]; // [4][0]
-  J_Mp_6x5[25] = fact * state7[5]; // [5][0]
-  // d(u')/d(px,py,pz)
-  fact = 1./(p*AtW*AtW);
-  J_Mp_6x5[16] = fact * (U.X()*AtW - W.X()*AtU); // [3][1]
-  J_Mp_6x5[21] = fact * (U.Y()*AtW - W.Y()*AtU); // [4][1]
-  J_Mp_6x5[26] = fact * (U.Z()*AtW - W.Z()*AtU); // [5][1]
-  // d(v')/d(px,py,pz)
-  J_Mp_6x5[17] = fact * (V.X()*AtW - W.X()*AtV); // [3][2]
-  J_Mp_6x5[22] = fact * (V.Y()*AtW - W.Y()*AtV); // [4][2]
-  J_Mp_6x5[27] = fact * (V.Z()*AtW - W.Z()*AtV); // [5][2]
-
-  // do the transformation
-  // out5x5 = J_Mp^T * in * J_Mp
-  M5x5& out5x5_ = *((M5x5*) state.getCov().GetMatrixArray());
-  RKTools::J_MpTxcov6xJ_Mp(J_Mp_6x5, in6x6, out5x5_);
-
-}
+  }
 
 
 //
@@ -1798,903 +1843,907 @@ void RKTrackRep::transformM6P(const M6x6& in6x6,
 //
 // Authors: R.Brun, M.Hansroul, V.Perevoztchikov (Geant3)
 //
-bool RKTrackRep::RKutta(const M1x4& SU,
-                        const DetPlane& plane,
-                        double charge,
-                        double mass,
-                        M1x7& state7,
-                        M7x7* jacobianT,
-                        M1x7* J_MMT_unprojected_lastRow,
-                        double& coveredDistance,
-                        double& flightTime,
-                        bool& checkJacProj,
-                        M7x7& noiseProjection,
-                        StepLimits& limits,
-                        bool onlyOneStep,
-                        bool calcOnlyLastRowOfJ) const {
+  bool RKTrackRep::RKutta(const M1x4& SU,
+                          const DetPlane& plane,
+                          double charge,
+                          double mass,
+                          M1x7& state7,
+                          M7x7* jacobianT,
+                          M1x7* J_MMT_unprojected_lastRow,
+                          double& coveredDistance,
+                          double& flightTime,
+                          bool& checkJacProj,
+                          M7x7& noiseProjection,
+                          StepLimits& limits,
+                          bool onlyOneStep,
+                          bool calcOnlyLastRowOfJ) const
+  {
 
-  // limits, check-values, etc. Can be tuned!
-  static const double Wmax           ( 3000. );           // max. way allowed [cm]
-  static const double AngleMax       ( 6.3 );           // max. total angle change of momentum. Prevents extrapolating a curler round and round if no active plane is found.
-  static const double Pmin           ( 4.E-3 );           // minimum momentum for propagation [GeV]
-  static const unsigned int maxNumIt ( 1000 );    // maximum number of iterations in main loop
-  // Aux parameters
-  M1x3&   R          ( *((M1x3*) &state7[0]) );  // Start coordinates  [cm]  (x,  y,  z)
-  M1x3&   A          ( *((M1x3*) &state7[3]) );  // Start directions         (ax, ay, az);   ax^2+ay^2+az^2=1
-  M1x3    SA         = {{0.,0.,0.}};             // Start directions derivatives dA/S
-  double  Way        ( 0. );                     // Sum of absolute values of all extrapolation steps [cm]
-  double  momentum   ( fabs(charge/state7[6]) ); // momentum [GeV]
-  double  relMomLoss ( 0 );                      // relative momentum loss in RKutta
-  double  deltaAngle ( 0. );                     // total angle by which the momentum has changed during extrapolation
-  // cppcheck-suppress unreadVariable
-  double  An(0), S(0), Sl(0), CBA(0);
+    // limits, check-values, etc. Can be tuned!
+    static const double Wmax(3000.);                        // max. way allowed [cm]
+    static const double AngleMax(
+      6.3);                    // max. total angle change of momentum. Prevents extrapolating a curler round and round if no active plane is found.
+    static const double Pmin(4.E-3);                        // minimum momentum for propagation [GeV]
+    static const unsigned int maxNumIt(1000);       // maximum number of iterations in main loop
+    // Aux parameters
+    M1x3&   R(*((M1x3*) &state7[0]));              // Start coordinates  [cm]  (x,  y,  z)
+    M1x3&   A(*((M1x3*) &state7[3]));              // Start directions         (ax, ay, az);   ax^2+ay^2+az^2=1
+    M1x3    SA         = {{0., 0., 0.}};           // Start directions derivatives dA/S
+    double  Way(0.);                               // Sum of absolute values of all extrapolation steps [cm]
+    double  momentum(fabs(charge / state7[6]));    // momentum [GeV]
+    double  relMomLoss(0);                         // relative momentum loss in RKutta
+    double  deltaAngle(0.);                        // total angle by which the momentum has changed during extrapolation
+    // cppcheck-suppress unreadVariable
+    double  An(0), S(0), Sl(0), CBA(0);
 
-
-  if (debugLvl_ > 0) {
-    debugOut << "RKTrackRep::RKutta \n";
-    debugOut << "position: "; TVector3(R[0], R[1], R[2]).Print();
-    debugOut << "direction: "; TVector3(A[0], A[1], A[2]).Print();
-    debugOut << "momentum: " << momentum << " GeV\n";
-    debugOut << "destination: "; plane.Print();
-  }
-
-  checkJacProj = false;
-
-  // check momentum
-  if(momentum < Pmin){
-    std::ostringstream sstream;
-    sstream << "RKTrackRep::RKutta ==> momentum too low: " << momentum*1000. << " MeV";
-    Exception exc(sstream.str(),__LINE__,__FILE__);
-    exc.setFatal();
-    throw exc;
-  }
-
-  unsigned int counter(0);
-
-  // Step estimation (signed)
-  S = estimateStep(state7, SU, plane, charge, relMomLoss, limits);
-
-  //
-  // Main loop of Runge-Kutta method
-  //
-  while (fabs(S) >= MINSTEP || counter == 0) {
-
-    if(++counter > maxNumIt){
-      Exception exc("RKTrackRep::RKutta ==> maximum number of iterations exceeded",__LINE__,__FILE__);
-      exc.setFatal();
-      throw exc;
-    }
 
     if (debugLvl_ > 0) {
-      debugOut << "------ RKutta main loop nr. " << counter-1 << " ------\n";
+      debugOut << "RKTrackRep::RKutta \n";
+      debugOut << "position: "; TVector3(R[0], R[1], R[2]).Print();
+      debugOut << "direction: "; TVector3(A[0], A[1], A[2]).Print();
+      debugOut << "momentum: " << momentum << " GeV\n";
+      debugOut << "destination: "; plane.Print();
     }
 
-    M1x3 ABefore = {{ A[0], A[1], A[2] }};
-    RKPropagate(state7, jacobianT, SA, S, true, calcOnlyLastRowOfJ); // the actual Runge Kutta propagation
+    checkJacProj = false;
 
-    // update paths
-    coveredDistance += S;       // add stepsize to way (signed)
-    Way  += fabs(S);
-
-    double beta = 1/hypot(1, mass*state7[6]/charge);
-    flightTime += S / beta / 29.9792458; // in ns
-
-    // check way limit
-    if(Way > Wmax){
+    // check momentum
+    if (momentum < Pmin) {
       std::ostringstream sstream;
-      sstream << "RKTrackRep::RKutta ==> Total extrapolation length is longer than length limit : " << Way << " cm !";
-      Exception exc(sstream.str(),__LINE__,__FILE__);
+      sstream << "RKTrackRep::RKutta ==> momentum too low: " << momentum * 1000. << " MeV";
+      Exception exc(sstream.str(), __LINE__, __FILE__);
       exc.setFatal();
       throw exc;
     }
 
-    if (onlyOneStep) return(true);
+    unsigned int counter(0);
 
-    // if stepsize has been limited by material, break the loop and return. No linear extrapolation!
-    if (limits.getLowestLimit().first == stp_momLoss) {
-      if (debugLvl_ > 0) {
-        debugOut<<" momLossExceeded -> return(true); \n";
-      }
-      return(true);
-    }
-
-    // if stepsize has been limited by material boundary, break the loop and return. No linear extrapolation!
-    if (limits.getLowestLimit().first == stp_boundary) {
-      if (debugLvl_ > 0) {
-        debugOut<<" at boundary -> return(true); \n";
-      }
-      return(true);
-    }
-
-
-    // estimate Step for next loop or linear extrapolation
-    Sl = S; // last S used
-    limits.removeLimit(stp_fieldCurv);
-    limits.removeLimit(stp_momLoss);
-    limits.removeLimit(stp_boundary);
-    limits.removeLimit(stp_plane);
+    // Step estimation (signed)
     S = estimateStep(state7, SU, plane, charge, relMomLoss, limits);
 
-    if (limits.getLowestLimit().first == stp_plane &&
-        fabs(S) < MINSTEP) {
-      if (debugLvl_ > 0) {
-        debugOut<<" (at Plane && fabs(S) < MINSTEP) -> break and do linear extrapolation \n";
-      }
-      break;
-    }
-    if (limits.getLowestLimit().first == stp_momLoss &&
-        fabs(S) < MINSTEP) {
-      if (debugLvl_ > 0) {
-        debugOut<<" (momLossExceeded && fabs(S) < MINSTEP) -> return(true), no linear extrapolation; \n";
-      }
-      RKSteps_.erase(RKSteps_.end()-1);
-      --RKStepsFXStop_;
-      return(true); // no linear extrapolation!
-    }
+    //
+    // Main loop of Runge-Kutta method
+    //
+    while (fabs(S) >= MINSTEP || counter == 0) {
 
-    // check if total angle is bigger than AngleMax. Can happen if a curler should be fitted and it does not hit the active area of the next plane.
-    double arg = ABefore[0]*A[0] + ABefore[1]*A[1] + ABefore[2]*A[2];
-    arg = arg > 1 ? 1 : arg;
-    arg = arg < -1 ? -1 : arg;
-    deltaAngle += acos(arg);
-    if (fabs(deltaAngle) > AngleMax){
-      std::ostringstream sstream;
-      sstream << "RKTrackRep::RKutta ==> Do not get to an active plane! Already extrapolated " << deltaAngle * 180 / TMath::Pi() << "°.";
-      Exception exc(sstream.str(),__LINE__,__FILE__);
-      exc.setFatal();
-      throw exc;
-    }
-
-    // check if we went back and forth multiple times -> we don't come closer to the plane!
-    if (counter > 3){
-      if (S                            *RKSteps_.at(counter-1).matStep_.stepSize_ < 0 &&
-          RKSteps_.at(counter-1).matStep_.stepSize_*RKSteps_.at(counter-2).matStep_.stepSize_ < 0 &&
-          RKSteps_.at(counter-2).matStep_.stepSize_*RKSteps_.at(counter-3).matStep_.stepSize_ < 0){
-        Exception exc("RKTrackRep::RKutta ==> Do not get closer to plane!",__LINE__,__FILE__);
+      if (++counter > maxNumIt) {
+        Exception exc("RKTrackRep::RKutta ==> maximum number of iterations exceeded", __LINE__, __FILE__);
         exc.setFatal();
         throw exc;
       }
-    }
 
-  } //end of main loop
-
-
-  //
-  // linear extrapolation to plane
-  //
-  if (limits.getLowestLimit().first == stp_plane) {
-
-    if (fabs(Sl) > 0.001*MINSTEP){
       if (debugLvl_ > 0) {
-        debugOut << " RKutta - linear extrapolation to surface\n";
+        debugOut << "------ RKutta main loop nr. " << counter - 1 << " ------\n";
       }
-      Sl = 1./Sl;        // Sl = inverted last Stepsize Sl
 
-      // normalize SA
-      SA[0]*=Sl;  SA[1]*=Sl;  SA[2]*=Sl; // SA/Sl = delta A / delta way; local derivative of A with respect to the length of the way
+      M1x3 ABefore = {{ A[0], A[1], A[2] }};
+      RKPropagate(state7, jacobianT, SA, S, true, calcOnlyLastRowOfJ); // the actual Runge Kutta propagation
 
-      // calculate A
-      A[0] += SA[0]*S;    // S  = distance to surface
-      A[1] += SA[1]*S;    // A = A + S * SA*Sl
-      A[2] += SA[2]*S;
-
-      // normalize A
-      CBA = 1./sqrt(A[0]*A[0]+A[1]*A[1]+A[2]*A[2]);  // 1/|A|
-      A[0] *= CBA; A[1] *= CBA; A[2] *= CBA;
-
-      R[0] += S*(A[0]-0.5*S*SA[0]);    // R = R + S*(A - 0.5*S*SA); approximation for final point on surface
-      R[1] += S*(A[1]-0.5*S*SA[1]);
-      R[2] += S*(A[2]-0.5*S*SA[2]);
-
-
-      coveredDistance += S;
-      // cppcheck-suppress unreadVariable
+      // update paths
+      coveredDistance += S;       // add stepsize to way (signed)
       Way  += fabs(S);
 
-      double beta = 1/hypot(1, mass*state7[6]/charge);
-      flightTime += S / beta / 29.9792458; // in ns;
-    }
-    else if (debugLvl_ > 0)  {
-      debugOut << " RKutta - last stepsize too small -> can't do linear extrapolation! \n";
-    }
+      double beta = 1 / hypot(1, mass * state7[6] / charge);
+      flightTime += S / beta / 29.9792458; // in ns
 
-    //
-    // Project Jacobian of extrapolation onto destination plane
-    //
-    if (jacobianT != nullptr) {
-
-      // projected jacobianT
-      // x x x x x x 0
-      // x x x x x x 0
-      // x x x x x x 0
-      // x x x x x x 0
-      // x x x x x x 0
-      // x x x x x x 0
-      // x x x x x x 1
-
-      if (checkJacProj && RKSteps_.size()>0){
-        Exception exc("RKTrackRep::Extrap ==> covariance is projected onto destination plane again",__LINE__,__FILE__);
+      // check way limit
+      if (Way > Wmax) {
+        std::ostringstream sstream;
+        sstream << "RKTrackRep::RKutta ==> Total extrapolation length is longer than length limit : " << Way << " cm !";
+        Exception exc(sstream.str(), __LINE__, __FILE__);
+        exc.setFatal();
         throw exc;
       }
 
-      if (debugLvl_ > 0) {
-        //debugOut << "  Jacobian^T of extrapolation before Projection:\n";
-        //RKTools::printDim(*jacobianT, 7,7);
-        debugOut << "  Project Jacobian of extrapolation onto destination plane\n";
-      }
-      An = A[0]*SU[0] + A[1]*SU[1] + A[2]*SU[2];
-      An = (fabs(An) > 1.E-7 ? 1./An : 0); // 1/A_normal
-      double norm;
-      int i=0;
-      if (calcOnlyLastRowOfJ)
-        i = 42;
+      if (onlyOneStep) return (true);
 
-      double* jacPtr = jacobianT->begin();
-
-      for(unsigned int j=42; j<49; j+=7) {
-        (*J_MMT_unprojected_lastRow)[j-42] = jacPtr[j];
+      // if stepsize has been limited by material, break the loop and return. No linear extrapolation!
+      if (limits.getLowestLimit().first == stp_momLoss) {
+        if (debugLvl_ > 0) {
+          debugOut << " momLossExceeded -> return(true); \n";
+        }
+        return (true);
       }
 
-      for(; i<49; i+=7) {
-        norm = (jacPtr[i]*SU[0] + jacPtr[i+1]*SU[1] + jacPtr[i+2]*SU[2]) * An;  // dR_normal / A_normal
-        jacPtr[i]   -= norm*A [0];   jacPtr[i+1] -= norm*A [1];   jacPtr[i+2] -= norm*A [2];
-        jacPtr[i+3] -= norm*SA[0];   jacPtr[i+4] -= norm*SA[1];   jacPtr[i+5] -= norm*SA[2];
-      }
-      checkJacProj = true;
-
-
-      if (debugLvl_ > 0) {
-        //debugOut << "  Jacobian^T of extrapolation after Projection:\n";
-        //RKTools::printDim(*jacobianT, 7,7);
+      // if stepsize has been limited by material boundary, break the loop and return. No linear extrapolation!
+      if (limits.getLowestLimit().first == stp_boundary) {
+        if (debugLvl_ > 0) {
+          debugOut << " at boundary -> return(true); \n";
+        }
+        return (true);
       }
 
-      if (!calcOnlyLastRowOfJ) {
-        for (int iRow = 0; iRow < 3; ++iRow) {
-          for (int iCol = 0; iCol < 3; ++iCol) {
-            noiseProjection[iRow*7 + iCol]       = (iRow == iCol) - An * SU[iCol] * A[iRow];
-            noiseProjection[(iRow + 3)*7 + iCol] =                - An * SU[iCol] * SA[iRow];
-          }
+
+      // estimate Step for next loop or linear extrapolation
+      Sl = S; // last S used
+      limits.removeLimit(stp_fieldCurv);
+      limits.removeLimit(stp_momLoss);
+      limits.removeLimit(stp_boundary);
+      limits.removeLimit(stp_plane);
+      S = estimateStep(state7, SU, plane, charge, relMomLoss, limits);
+
+      if (limits.getLowestLimit().first == stp_plane &&
+          fabs(S) < MINSTEP) {
+        if (debugLvl_ > 0) {
+          debugOut << " (at Plane && fabs(S) < MINSTEP) -> break and do linear extrapolation \n";
+        }
+        break;
+      }
+      if (limits.getLowestLimit().first == stp_momLoss &&
+          fabs(S) < MINSTEP) {
+        if (debugLvl_ > 0) {
+          debugOut << " (momLossExceeded && fabs(S) < MINSTEP) -> return(true), no linear extrapolation; \n";
+        }
+        RKSteps_.erase(RKSteps_.end() - 1);
+        --RKStepsFXStop_;
+        return (true); // no linear extrapolation!
+      }
+
+      // check if total angle is bigger than AngleMax. Can happen if a curler should be fitted and it does not hit the active area of the next plane.
+      double arg = ABefore[0] * A[0] + ABefore[1] * A[1] + ABefore[2] * A[2];
+      arg = arg > 1 ? 1 : arg;
+      arg = arg < -1 ? -1 : arg;
+      deltaAngle += acos(arg);
+      if (fabs(deltaAngle) > AngleMax) {
+        std::ostringstream sstream;
+        sstream << "RKTrackRep::RKutta ==> Do not get to an active plane! Already extrapolated " << deltaAngle * 180 / TMath::Pi() << "°.";
+        Exception exc(sstream.str(), __LINE__, __FILE__);
+        exc.setFatal();
+        throw exc;
+      }
+
+      // check if we went back and forth multiple times -> we don't come closer to the plane!
+      if (counter > 3) {
+        if (S                            * RKSteps_.at(counter - 1).matStep_.stepSize_ < 0 &&
+            RKSteps_.at(counter - 1).matStep_.stepSize_ * RKSteps_.at(counter - 2).matStep_.stepSize_ < 0 &&
+            RKSteps_.at(counter - 2).matStep_.stepSize_ * RKSteps_.at(counter - 3).matStep_.stepSize_ < 0) {
+          Exception exc("RKTrackRep::RKutta ==> Do not get closer to plane!", __LINE__, __FILE__);
+          exc.setFatal();
+          throw exc;
+        }
+      }
+
+    } //end of main loop
+
+
+    //
+    // linear extrapolation to plane
+    //
+    if (limits.getLowestLimit().first == stp_plane) {
+
+      if (fabs(Sl) > 0.001 * MINSTEP) {
+        if (debugLvl_ > 0) {
+          debugOut << " RKutta - linear extrapolation to surface\n";
+        }
+        Sl = 1. / Sl;      // Sl = inverted last Stepsize Sl
+
+        // normalize SA
+        SA[0] *= Sl;  SA[1] *= Sl;  SA[2] *= Sl; // SA/Sl = delta A / delta way; local derivative of A with respect to the length of the way
+
+        // calculate A
+        A[0] += SA[0] * S;  // S  = distance to surface
+        A[1] += SA[1] * S;  // A = A + S * SA*Sl
+        A[2] += SA[2] * S;
+
+        // normalize A
+        CBA = 1. / sqrt(A[0] * A[0] + A[1] * A[1] + A[2] * A[2]); // 1/|A|
+        A[0] *= CBA; A[1] *= CBA; A[2] *= CBA;
+
+        R[0] += S * (A[0] - 0.5 * S * SA[0]); // R = R + S*(A - 0.5*S*SA); approximation for final point on surface
+        R[1] += S * (A[1] - 0.5 * S * SA[1]);
+        R[2] += S * (A[2] - 0.5 * S * SA[2]);
+
+
+        coveredDistance += S;
+        // cppcheck-suppress unreadVariable
+        Way  += fabs(S);
+
+        double beta = 1 / hypot(1, mass * state7[6] / charge);
+        flightTime += S / beta / 29.9792458; // in ns;
+      } else if (debugLvl_ > 0)  {
+        debugOut << " RKutta - last stepsize too small -> can't do linear extrapolation! \n";
+      }
+
+      //
+      // Project Jacobian of extrapolation onto destination plane
+      //
+      if (jacobianT != nullptr) {
+
+        // projected jacobianT
+        // x x x x x x 0
+        // x x x x x x 0
+        // x x x x x x 0
+        // x x x x x x 0
+        // x x x x x x 0
+        // x x x x x x 0
+        // x x x x x x 1
+
+        if (checkJacProj && RKSteps_.size() > 0) {
+          Exception exc("RKTrackRep::Extrap ==> covariance is projected onto destination plane again", __LINE__, __FILE__);
+          throw exc;
         }
 
-        // noiseProjection will look like this:
-        // x x x 0 0 0 0
-        // x x x 0 0 0 0
-        // x x x 0 0 0 0
-        // x x x 1 0 0 0
-        // x x x 0 1 0 0
-        // x x x 0 0 1 0
-        // 0 0 0 0 0 0 1
+        if (debugLvl_ > 0) {
+          //debugOut << "  Jacobian^T of extrapolation before Projection:\n";
+          //RKTools::printDim(*jacobianT, 7,7);
+          debugOut << "  Project Jacobian of extrapolation onto destination plane\n";
+        }
+        An = A[0] * SU[0] + A[1] * SU[1] + A[2] * SU[2];
+        An = (fabs(An) > 1.E-7 ? 1. / An : 0); // 1/A_normal
+        double norm;
+        int i = 0;
+        if (calcOnlyLastRowOfJ)
+          i = 42;
+
+        double* jacPtr = jacobianT->begin();
+
+        for (unsigned int j = 42; j < 49; j += 7) {
+          (*J_MMT_unprojected_lastRow)[j - 42] = jacPtr[j];
+        }
+
+        for (; i < 49; i += 7) {
+          norm = (jacPtr[i] * SU[0] + jacPtr[i + 1] * SU[1] + jacPtr[i + 2] * SU[2]) * An; // dR_normal / A_normal
+          jacPtr[i]   -= norm * A [0];   jacPtr[i + 1] -= norm * A [1];   jacPtr[i + 2] -= norm * A [2];
+          jacPtr[i + 3] -= norm * SA[0];   jacPtr[i + 4] -= norm * SA[1];   jacPtr[i + 5] -= norm * SA[2];
+        }
+        checkJacProj = true;
+
+
+        if (debugLvl_ > 0) {
+          //debugOut << "  Jacobian^T of extrapolation after Projection:\n";
+          //RKTools::printDim(*jacobianT, 7,7);
+        }
+
+        if (!calcOnlyLastRowOfJ) {
+          for (int iRow = 0; iRow < 3; ++iRow) {
+            for (int iCol = 0; iCol < 3; ++iCol) {
+              noiseProjection[iRow * 7 + iCol]       = (iRow == iCol) - An * SU[iCol] * A[iRow];
+              noiseProjection[(iRow + 3) * 7 + iCol] =                - An * SU[iCol] * SA[iRow];
+            }
+          }
+
+          // noiseProjection will look like this:
+          // x x x 0 0 0 0
+          // x x x 0 0 0 0
+          // x x x 0 0 0 0
+          // x x x 1 0 0 0
+          // x x x 0 1 0 0
+          // x x x 0 0 1 0
+          // 0 0 0 0 0 0 1
+        }
+
       }
+    } // end of linear extrapolation to surface
 
-    }
-  } // end of linear extrapolation to surface
+    return (true);
 
-  return(true);
-
-}
+  }
 
 
-double RKTrackRep::estimateStep(const M1x7& state7,
-                                const M1x4& SU,
-                                const DetPlane& plane,
-                                const double& charge,
-                                double& relMomLoss,
-                                StepLimits& limits) const {
+  double RKTrackRep::estimateStep(const M1x7& state7,
+                                  const M1x4& SU,
+                                  const DetPlane& plane,
+                                  const double& charge,
+                                  double& relMomLoss,
+                                  StepLimits& limits) const
+  {
 
-  if (useCache_) {
-    if (cachePos_ >= RKSteps_.size()) {
-      useCache_ = false;
-    }
-    else {
-      if (RKSteps_.at(cachePos_).limits_.getLowestLimit().first == stp_plane) {
-        // we need to step exactly to the plane, so don't use the cache!
+    if (useCache_) {
+      if (cachePos_ >= RKSteps_.size()) {
         useCache_ = false;
-        RKSteps_.erase(RKSteps_.begin() + cachePos_, RKSteps_.end());
-      }
-      else {
-        if (debugLvl_ > 0) {
-          debugOut << " RKTrackRep::estimateStep: use stepSize " << cachePos_ << " from cache: " << RKSteps_.at(cachePos_).matStep_.stepSize_ << "\n";
+      } else {
+        if (RKSteps_.at(cachePos_).limits_.getLowestLimit().first == stp_plane) {
+          // we need to step exactly to the plane, so don't use the cache!
+          useCache_ = false;
+          RKSteps_.erase(RKSteps_.begin() + cachePos_, RKSteps_.end());
+        } else {
+          if (debugLvl_ > 0) {
+            debugOut << " RKTrackRep::estimateStep: use stepSize " << cachePos_ << " from cache: " << RKSteps_.at(
+                       cachePos_).matStep_.stepSize_ << "\n";
+          }
+          //for(int n = 0; n < 1*7; ++n) RKSteps_[cachePos_].state7_[n] = state7[n];
+          ++RKStepsFXStop_;
+          limits = RKSteps_.at(cachePos_).limits_;
+          return RKSteps_.at(cachePos_++).matStep_.stepSize_;
         }
-        //for(int n = 0; n < 1*7; ++n) RKSteps_[cachePos_].state7_[n] = state7[n];
-        ++RKStepsFXStop_;
-        limits = RKSteps_.at(cachePos_).limits_;
-        return RKSteps_.at(cachePos_++).matStep_.stepSize_;
       }
     }
-  }
 
-  limits.setLimit(stp_sMax, 25.); // max. step allowed [cm]
+    limits.setLimit(stp_sMax, 25.); // max. step allowed [cm]
 
-  if (debugLvl_ > 0) {
-    debugOut << " RKTrackRep::estimateStep \n";
-    debugOut << "  position:  "; TVector3(state7[0], state7[1], state7[2]).Print();
-    debugOut << "  direction: "; TVector3(state7[3], state7[4], state7[5]).Print();
-  }
+    if (debugLvl_ > 0) {
+      debugOut << " RKTrackRep::estimateStep \n";
+      debugOut << "  position:  "; TVector3(state7[0], state7[1], state7[2]).Print();
+      debugOut << "  direction: "; TVector3(state7[3], state7[4], state7[5]).Print();
+    }
 
-  // calculate SL distance to surface
-  double Dist ( SU[3] - (state7[0]*SU[0] +
+    // calculate SL distance to surface
+    double Dist(SU[3] - (state7[0]*SU[0] +
                          state7[1]*SU[1] +
-                         state7[2]*SU[2])  );  // Distance between start coordinates and surface
-  double An ( state7[3]*SU[0] +
+                         state7[2]*SU[2]));    // Distance between start coordinates and surface
+    double An(state7[3]*SU[0] +
               state7[4]*SU[1] +
-              state7[5]*SU[2]   );              // An = dir * N;  component of dir normal to surface
+              state7[5]*SU[2]);                 // An = dir * N;  component of dir normal to surface
 
-  double SLDist; // signed
-  if (fabs(An) > 1.E-10)
-    SLDist = Dist/An;
-  else {
-    SLDist = Dist*1.E10;
-    if (An<0) SLDist *= -1.;
-  }
-
-  limits.setLimit(stp_plane, SLDist);
-  limits.setStepSign(SLDist);
-
-  if (debugLvl_ > 0) {
-    debugOut << "  Distance to plane: " << Dist << "\n";
-    debugOut << "  SL distance to plane: " << SLDist << "\n";
-    if (limits.getStepSign()>0) 
-      debugOut << "  Direction is  pointing towards surface.\n";
-    else  
-      debugOut << "  Direction is pointing away from surface.\n";
-  }
-  // DONE calculate SL distance to surface
-
-  //
-  // Limit according to curvature and magnetic field inhomogenities
-  // and improve stepsize estimation to reach plane
-  //
-  double fieldCurvLimit( limits.getLowestLimitSignedVal() ); // signed
-  std::pair<double, double> distVsStep (9.E99, 9.E99); // first: smallest straight line distances to plane; second: RK steps
-
-  static const unsigned int maxNumIt = 10;
-  unsigned int counter(0);
-
-  while (fabs(fieldCurvLimit) > MINSTEP) {
-
-    if(++counter > maxNumIt){
-      // if max iterations are reached, take a safe value
-      // (in previous iteration, fieldCurvLimit has been not more than doubled)
-      // and break.
-      fieldCurvLimit *= 0.5;
-      break;
-    }
-
-    M1x7 state7_temp = state7;
-    M1x3 SA = {{0, 0, 0}};
-
-    double q ( RKPropagate(state7_temp, nullptr, SA, fieldCurvLimit, true) );
-    if (debugLvl_ > 0) {
-      debugOut << "  maxStepArg = " << fieldCurvLimit << "; q = " << q  << " \n";
-    }
-
-    // remember steps and resulting SL distances to plane for stepsize improvement
-    // calculate distance to surface
-    Dist = SU[3] - (state7_temp[0] * SU[0] +
-                    state7_temp[1] * SU[1] +
-                    state7_temp[2] * SU[2]); // Distance between position and surface
-
-    An = state7_temp[3] * SU[0] +
-         state7_temp[4] * SU[1] +
-         state7_temp[5] * SU[2];    // An = dir * N;  component of dir normal to surface
-
-    if (fabs(Dist/An) < fabs(distVsStep.first)) {
-      distVsStep.first = Dist/An;
-      distVsStep.second = fieldCurvLimit;
-    }
-
-    // resize limit according to q never grow step size more than
-    // two-fold to avoid infinite grow-shrink loops with strongly
-    // inhomogeneous fields.
-    if (q>2) {
-      fieldCurvLimit *= 2;
-      break;
-    }
-
-    fieldCurvLimit *= q * 0.95;
-
-    if (fabs(q-1) < 0.25 || // good enough!
-        fabs(fieldCurvLimit) > limits.getLowestLimitVal()) // other limits are lower!
-      break;
-  }
-  if (fabs(fieldCurvLimit) < MINSTEP)
-    limits.setLimit(stp_fieldCurv, MINSTEP);
-  else
-    limits.setLimit(stp_fieldCurv, fieldCurvLimit);
-
-  double stepToPlane(limits.getLimitSigned(stp_plane));
-  if (fabs(distVsStep.first) < 8.E99) {
-    stepToPlane = distVsStep.first + distVsStep.second;
-  }
-  limits.setLimit(stp_plane, stepToPlane);
-
-
-  //
-  // Select direction
-  //
-  // auto select
-  if (propDir_ == 0 || !plane.isFinite()){
-    if (debugLvl_ > 0) {
-      debugOut << "  auto select direction";
-      if (!plane.isFinite()) debugOut << ", plane is not finite";
-      debugOut << ".\n";
-    }
-  }
-  // see if straight line approximation is ok
-  else if ( limits.getLimit(stp_plane) < 0.2*limits.getLimit(stp_fieldCurv) ){
-    if (debugLvl_ > 0) {
-      debugOut << "  straight line approximation is fine.\n";
-    }
-
-    // if direction is pointing to active part of surface
-    if( plane.isInActive(state7[0], state7[1], state7[2],  state7[3], state7[4], state7[5]) ) {
-      if (debugLvl_ > 0) {
-        debugOut << "  direction is pointing to active part of surface. \n";
-      }
-    }
-    // if we are near the plane, but not pointing to the active area, make a big step!
+    double SLDist; // signed
+    if (fabs(An) > 1.E-10)
+      SLDist = Dist / An;
     else {
-      limits.removeLimit(stp_plane);
-      limits.setStepSign(propDir_);
-      if (debugLvl_ > 0) {
-        debugOut << "  we are near the plane, but not pointing to the active area. make a big step! \n";
-      }
+      SLDist = Dist * 1.E10;
+      if (An < 0) SLDist *= -1.;
     }
-  }
-  // propDir_ is set and we are not pointing to an active part of a plane -> propDir_ decides!
-  else {
-    if (limits.getStepSign() * propDir_ < 0){
-      limits.removeLimit(stp_plane);
-      limits.setStepSign(propDir_);
-      if (debugLvl_ > 0) {
-        debugOut << "  invert Step according to propDir_ and make a big step. \n";
-      }
-    }
-  }
 
-
-  // call stepper and reduce stepsize if step not too small
-  static const RKStep defaultRKStep;
-  RKSteps_.push_back( defaultRKStep );
-  std::vector<RKStep>::iterator lastStep = RKSteps_.end() - 1;
-  lastStep->state7_ = state7;
-  ++RKStepsFXStop_;
-
-  if(limits.getLowestLimitVal() > MINSTEP){ // only call stepper if step estimation big enough
-    M1x7 state7_temp = {{ state7[0], state7[1], state7[2], state7[3], state7[4], state7[5], state7[6] }};
-
-    MaterialEffects::getInstance()->stepper(this,
-                                            state7_temp,
-                                            charge/state7[6], // |p|
-                                            relMomLoss,
-                                            pdgCode_,
-                                            lastStep->matStep_.material_,
-                                            limits,
-                                            true);
-  } else { //assume material has not changed
-    if  (RKSteps_.size()>1) {
-      lastStep->matStep_.material_ = (lastStep - 1)->matStep_.material_;
-    }
-  }
-
-  if (debugLvl_ > 0) {
-    debugOut << "   final limits:\n";
-    limits.Print();
-  }
-
-  double finalStep = limits.getLowestLimitSignedVal();
-
-  lastStep->matStep_.stepSize_ = finalStep;
-  lastStep->limits_ = limits;
-
-  if (debugLvl_ > 0) {
-    debugOut << "  --> Step to be used: " << finalStep << "\n";
-  }
-
-  return finalStep;
-
-}
-
-
-TVector3 RKTrackRep::pocaOnLine(const TVector3& linePoint, const TVector3& lineDirection, const TVector3& point) const {
-
-  TVector3 retVal(lineDirection);
-
-  double t = 1./(retVal.Mag2()) * ((point*retVal) - (linePoint*retVal));
-  retVal *= t;
-  retVal += linePoint;
-  return retVal; // = linePoint + t*lineDirection
-
-}
-
-
-double RKTrackRep::Extrap(const DetPlane& startPlane,
-                          const DetPlane& destPlane,
-                          double charge,
-                          double mass,
-                          bool& isAtBoundary,
-                          M1x7& state7,
-                          double& flightTime,
-                          bool fillExtrapSteps,
-                          TMatrixDSym* cov, // 5D
-                          bool onlyOneStep,
-                          bool stopAtBoundary,
-                          double maxStep) const
-{
-
-  static const unsigned int maxNumIt(500);
-  unsigned int numIt(0);
-
-  double coveredDistance(0.);
-  // cppcheck-suppress unreadVariable
-  double dqop(0.);
-
-  const TVector3 W(destPlane.getNormal());
-  M1x4 SU = {{W.X(), W.Y(), W.Z(), destPlane.distance(0., 0., 0.)}};
-
-  // make SU vector point away from origin
-  if (W*destPlane.getO() < 0) {
-    SU[0] *= -1;
-    SU[1] *= -1;
-    SU[2] *= -1;
-  }
-
-
-  M1x7 startState7 = state7;
-
-  while(true){
+    limits.setLimit(stp_plane, SLDist);
+    limits.setStepSign(SLDist);
 
     if (debugLvl_ > 0) {
-      debugOut << "\n============ RKTrackRep::Extrap loop nr. " << numIt << " ============\n";
-      debugOut << "Start plane: "; startPlane.Print();
-      debugOut << "fillExtrapSteps " << fillExtrapSteps << "\n";
+      debugOut << "  Distance to plane: " << Dist << "\n";
+      debugOut << "  SL distance to plane: " << SLDist << "\n";
+      if (limits.getStepSign() > 0)
+        debugOut << "  Direction is  pointing towards surface.\n";
+      else
+        debugOut << "  Direction is pointing away from surface.\n";
     }
+    // DONE calculate SL distance to surface
 
-    if(++numIt > maxNumIt){
-      Exception exc("RKTrackRep::Extrap ==> maximum number of iterations exceeded",__LINE__,__FILE__);
-      exc.setFatal();
-      throw exc;
-    }
+    //
+    // Limit according to curvature and magnetic field inhomogenities
+    // and improve stepsize estimation to reach plane
+    //
+    double fieldCurvLimit(limits.getLowestLimitSignedVal());   // signed
+    std::pair<double, double> distVsStep(9.E99, 9.E99);  // first: smallest straight line distances to plane; second: RK steps
 
-    // initialize jacobianT with unit matrix
-    for(int i = 0; i < 7*7; ++i) J_MMT_[i] = 0;
-    for(int i=0; i<7; ++i) J_MMT_[8*i] = 1.;
+    static const unsigned int maxNumIt = 10;
+    unsigned int counter(0);
 
-    M7x7* noise = nullptr;
-    isAtBoundary = false;
+    while (fabs(fieldCurvLimit) > MINSTEP) {
 
-    // propagation
-    bool checkJacProj = false;
-    limits_.reset();
-    limits_.setLimit(stp_sMaxArg, maxStep-fabs(coveredDistance));
-
-    M1x7 J_MMT_unprojected_lastRow = {{0, 0, 0, 0, 0, 0, 1}};
-
-    if( ! RKutta(SU, destPlane, charge, mass, state7, &J_MMT_, &J_MMT_unprojected_lastRow,
-		 coveredDistance, flightTime, checkJacProj, noiseProjection_,
-		 limits_, onlyOneStep, !fillExtrapSteps) ) {
-      Exception exc("RKTrackRep::Extrap ==> Runge Kutta propagation failed",__LINE__,__FILE__);
-      exc.setFatal();
-      throw exc;
-    }
-
-    bool atPlane(limits_.getLowestLimit().first == stp_plane);
-    if (limits_.getLowestLimit().first == stp_boundary)
-      isAtBoundary = true;
-
-
-    if (debugLvl_ > 0) {
-      debugOut<<"RKSteps \n";
-      for (std::vector<RKStep>::iterator it = RKSteps_.begin(); it != RKSteps_.end(); ++it){
-        debugOut << "stepSize = " << it->matStep_.stepSize_ << "\t";
-        it->matStep_.material_.Print();
+      if (++counter > maxNumIt) {
+        // if max iterations are reached, take a safe value
+        // (in previous iteration, fieldCurvLimit has been not more than doubled)
+        // and break.
+        fieldCurvLimit *= 0.5;
+        break;
       }
-      debugOut<<"\n";
-    }
 
+      M1x7 state7_temp = state7;
+      M1x3 SA = {{0, 0, 0}};
 
-
-    // call MatFX
-    if(fillExtrapSteps) {
-      noise = &noiseArray_;
-      for(int i = 0; i < 7*7; ++i) noiseArray_[i] = 0; // set noiseArray_ to 0
-    }
-
-    unsigned int nPoints(RKStepsFXStop_ - RKStepsFXStart_);
-    if (/*!fNoMaterial &&*/ nPoints>0){
-      // momLoss has a sign - negative loss means momentum gain
-      double momLoss = MaterialEffects::getInstance()->effects(RKSteps_,
-                                                               RKStepsFXStart_,
-                                                               RKStepsFXStop_,
-                                                               fabs(charge/state7[6]), // momentum
-                                                               pdgCode_,
-                                                               noise);
-
-      RKStepsFXStart_ = RKStepsFXStop_;
-
+      double q(RKPropagate(state7_temp, nullptr, SA, fieldCurvLimit, true));
       if (debugLvl_ > 0) {
-        debugOut << "momLoss: " << momLoss << " GeV; relative: " << momLoss/fabs(charge/state7[6])
-            << "; coveredDistance = " << coveredDistance << "\n";
-        if (debugLvl_ > 1 && noise != nullptr) {
-          debugOut << "7D noise: \n";
-          RKTools::printDim(noise->begin(), 7, 7);
+        debugOut << "  maxStepArg = " << fieldCurvLimit << "; q = " << q  << " \n";
+      }
+
+      // remember steps and resulting SL distances to plane for stepsize improvement
+      // calculate distance to surface
+      Dist = SU[3] - (state7_temp[0] * SU[0] +
+                      state7_temp[1] * SU[1] +
+                      state7_temp[2] * SU[2]); // Distance between position and surface
+
+      An = state7_temp[3] * SU[0] +
+           state7_temp[4] * SU[1] +
+           state7_temp[5] * SU[2];    // An = dir * N;  component of dir normal to surface
+
+      if (fabs(Dist / An) < fabs(distVsStep.first)) {
+        distVsStep.first = Dist / An;
+        distVsStep.second = fieldCurvLimit;
+      }
+
+      // resize limit according to q never grow step size more than
+      // two-fold to avoid infinite grow-shrink loops with strongly
+      // inhomogeneous fields.
+      if (q > 2) {
+        fieldCurvLimit *= 2;
+        break;
+      }
+
+      fieldCurvLimit *= q * 0.95;
+
+      if (fabs(q - 1) < 0.25 || // good enough!
+          fabs(fieldCurvLimit) > limits.getLowestLimitVal()) // other limits are lower!
+        break;
+    }
+    if (fabs(fieldCurvLimit) < MINSTEP)
+      limits.setLimit(stp_fieldCurv, MINSTEP);
+    else
+      limits.setLimit(stp_fieldCurv, fieldCurvLimit);
+
+    double stepToPlane(limits.getLimitSigned(stp_plane));
+    if (fabs(distVsStep.first) < 8.E99) {
+      stepToPlane = distVsStep.first + distVsStep.second;
+    }
+    limits.setLimit(stp_plane, stepToPlane);
+
+
+    //
+    // Select direction
+    //
+    // auto select
+    if (propDir_ == 0 || !plane.isFinite()) {
+      if (debugLvl_ > 0) {
+        debugOut << "  auto select direction";
+        if (!plane.isFinite()) debugOut << ", plane is not finite";
+        debugOut << ".\n";
+      }
+    }
+    // see if straight line approximation is ok
+    else if (limits.getLimit(stp_plane) < 0.2 * limits.getLimit(stp_fieldCurv)) {
+      if (debugLvl_ > 0) {
+        debugOut << "  straight line approximation is fine.\n";
+      }
+
+      // if direction is pointing to active part of surface
+      if (plane.isInActive(state7[0], state7[1], state7[2],  state7[3], state7[4], state7[5])) {
+        if (debugLvl_ > 0) {
+          debugOut << "  direction is pointing to active part of surface. \n";
         }
       }
+      // if we are near the plane, but not pointing to the active area, make a big step!
+      else {
+        limits.removeLimit(stp_plane);
+        limits.setStepSign(propDir_);
+        if (debugLvl_ > 0) {
+          debugOut << "  we are near the plane, but not pointing to the active area. make a big step! \n";
+        }
+      }
+    }
+    // propDir_ is set and we are not pointing to an active part of a plane -> propDir_ decides!
+    else {
+      if (limits.getStepSign() * propDir_ < 0) {
+        limits.removeLimit(stp_plane);
+        limits.setStepSign(propDir_);
+        if (debugLvl_ > 0) {
+          debugOut << "  invert Step according to propDir_ and make a big step. \n";
+        }
+      }
+    }
 
-      // do momLoss only for defined 1/momentum .ne.0
-      if(fabs(state7[6])>1.E-10) {
+
+    // call stepper and reduce stepsize if step not too small
+    static const RKStep defaultRKStep;
+    RKSteps_.push_back(defaultRKStep);
+    std::vector<RKStep>::iterator lastStep = RKSteps_.end() - 1;
+    lastStep->state7_ = state7;
+    ++RKStepsFXStop_;
+
+    if (limits.getLowestLimitVal() > MINSTEP) { // only call stepper if step estimation big enough
+      M1x7 state7_temp = {{ state7[0], state7[1], state7[2], state7[3], state7[4], state7[5], state7[6] }};
+
+      MaterialEffects::getInstance()->stepper(this,
+                                              state7_temp,
+                                              charge / state7[6], // |p|
+                                              relMomLoss,
+                                              pdgCode_,
+                                              lastStep->matStep_.material_,
+                                              limits,
+                                              true);
+    } else { //assume material has not changed
+      if (RKSteps_.size() > 1) {
+        lastStep->matStep_.material_ = (lastStep - 1)->matStep_.material_;
+      }
+    }
+
+    if (debugLvl_ > 0) {
+      debugOut << "   final limits:\n";
+      limits.Print();
+    }
+
+    double finalStep = limits.getLowestLimitSignedVal();
+
+    lastStep->matStep_.stepSize_ = finalStep;
+    lastStep->limits_ = limits;
+
+    if (debugLvl_ > 0) {
+      debugOut << "  --> Step to be used: " << finalStep << "\n";
+    }
+
+    return finalStep;
+
+  }
+
+
+  TVector3 RKTrackRep::pocaOnLine(const TVector3& linePoint, const TVector3& lineDirection, const TVector3& point) const
+  {
+
+    TVector3 retVal(lineDirection);
+
+    double t = 1. / (retVal.Mag2()) * ((point * retVal) - (linePoint * retVal));
+    retVal *= t;
+    retVal += linePoint;
+    return retVal; // = linePoint + t*lineDirection
+
+  }
+
+
+  double RKTrackRep::Extrap(const DetPlane& startPlane,
+                            const DetPlane& destPlane,
+                            double charge,
+                            double mass,
+                            bool& isAtBoundary,
+                            M1x7& state7,
+                            double& flightTime,
+                            bool fillExtrapSteps,
+                            TMatrixDSym* cov, // 5D
+                            bool onlyOneStep,
+                            bool stopAtBoundary,
+                            double maxStep) const
+  {
+
+    static const unsigned int maxNumIt(500);
+    unsigned int numIt(0);
+
+    double coveredDistance(0.);
+    // cppcheck-suppress unreadVariable
+    double dqop(0.);
+
+    const TVector3 W(destPlane.getNormal());
+    M1x4 SU = {{W.X(), W.Y(), W.Z(), destPlane.distance(0., 0., 0.)}};
+
+    // make SU vector point away from origin
+    if (W * destPlane.getO() < 0) {
+      SU[0] *= -1;
+      SU[1] *= -1;
+      SU[2] *= -1;
+    }
+
+
+    M1x7 startState7 = state7;
+
+    while (true) {
+
+      if (debugLvl_ > 0) {
+        debugOut << "\n============ RKTrackRep::Extrap loop nr. " << numIt << " ============\n";
+        debugOut << "Start plane: "; startPlane.Print();
+        debugOut << "fillExtrapSteps " << fillExtrapSteps << "\n";
+      }
+
+      if (++numIt > maxNumIt) {
+        Exception exc("RKTrackRep::Extrap ==> maximum number of iterations exceeded", __LINE__, __FILE__);
+        exc.setFatal();
+        throw exc;
+      }
+
+      // initialize jacobianT with unit matrix
+      for (int i = 0; i < 7 * 7; ++i) J_MMT_[i] = 0;
+      for (int i = 0; i < 7; ++i) J_MMT_[8 * i] = 1.;
+
+      M7x7* noise = nullptr;
+      isAtBoundary = false;
+
+      // propagation
+      bool checkJacProj = false;
+      limits_.reset();
+      limits_.setLimit(stp_sMaxArg, maxStep - fabs(coveredDistance));
+
+      M1x7 J_MMT_unprojected_lastRow = {{0, 0, 0, 0, 0, 0, 1}};
+
+      if (! RKutta(SU, destPlane, charge, mass, state7, &J_MMT_, &J_MMT_unprojected_lastRow,
+                   coveredDistance, flightTime, checkJacProj, noiseProjection_,
+                   limits_, onlyOneStep, !fillExtrapSteps)) {
+        Exception exc("RKTrackRep::Extrap ==> Runge Kutta propagation failed", __LINE__, __FILE__);
+        exc.setFatal();
+        throw exc;
+      }
+
+      bool atPlane(limits_.getLowestLimit().first == stp_plane);
+      if (limits_.getLowestLimit().first == stp_boundary)
+        isAtBoundary = true;
+
+
+      if (debugLvl_ > 0) {
+        debugOut << "RKSteps \n";
+        for (std::vector<RKStep>::iterator it = RKSteps_.begin(); it != RKSteps_.end(); ++it) {
+          debugOut << "stepSize = " << it->matStep_.stepSize_ << "\t";
+          it->matStep_.material_.Print();
+        }
+        debugOut << "\n";
+      }
+
+
+
+      // call MatFX
+      if (fillExtrapSteps) {
+        noise = &noiseArray_;
+        for (int i = 0; i < 7 * 7; ++i) noiseArray_[i] = 0; // set noiseArray_ to 0
+      }
+
+      unsigned int nPoints(RKStepsFXStop_ - RKStepsFXStart_);
+      if (/*!fNoMaterial &&*/ nPoints > 0) {
+        // momLoss has a sign - negative loss means momentum gain
+        double momLoss = MaterialEffects::getInstance()->effects(RKSteps_,
+                                                                 RKStepsFXStart_,
+                                                                 RKStepsFXStop_,
+                                                                 fabs(charge / state7[6]), // momentum
+                                                                 pdgCode_,
+                                                                 noise);
+
+        RKStepsFXStart_ = RKStepsFXStop_;
 
         if (debugLvl_ > 0) {
-          debugOut << "correct state7 with dx/dqop, dy/dqop ...\n";
+          debugOut << "momLoss: " << momLoss << " GeV; relative: " << momLoss / fabs(charge / state7[6])
+                   << "; coveredDistance = " << coveredDistance << "\n";
+          if (debugLvl_ > 1 && noise != nullptr) {
+            debugOut << "7D noise: \n";
+            RKTools::printDim(noise->begin(), 7, 7);
+          }
         }
 
-        dqop = charge/(fabs(charge/state7[6])-momLoss) - state7[6];
-
-        // Correct coveredDistance and flightTime and momLoss if checkJacProj == true
-        // The idea is to calculate the state correction (based on the mometum loss) twice:
-        // Once with the unprojected Jacobian (which preserves coveredDistance),
-        // and once with the projected Jacobian (which is constrained to the plane and does NOT preserve coveredDistance).
-        // The difference of these two corrections can then be used to calculate a correction factor.
-        if (checkJacProj && fabs(coveredDistance) > MINSTEP) {
-          M1x3 state7_correction_unprojected = {{0, 0, 0}};
-          for (unsigned int i=0; i<3; ++i) {
-            state7_correction_unprojected[i] = 0.5 * dqop * J_MMT_unprojected_lastRow[i];
-            //debugOut << "J_MMT_unprojected_lastRow[i] " << J_MMT_unprojected_lastRow[i] << "\n";
-            //debugOut << "state7_correction_unprojected[i] " << state7_correction_unprojected[i] << "\n";
-          }
-
-          M1x3 state7_correction_projected = {{0, 0, 0}};
-          for (unsigned int i=0; i<3; ++i) {
-            state7_correction_projected[i] = 0.5 * dqop * J_MMT_[6*7 + i];
-            //debugOut << "J_MMT_[6*7 + i] " << J_MMT_[6*7 + i] << "\n";
-            //debugOut << "state7_correction_projected[i] " << state7_correction_projected[i] << "\n";
-          }
-
-          // delta distance
-          M1x3 delta_state = {{0, 0, 0}};
-          for (unsigned int i=0; i<3; ++i) {
-            delta_state[i] = state7_correction_unprojected[i] - state7_correction_projected[i];
-          }
-
-          double Dist( sqrt(delta_state[0]*delta_state[0]
-              + delta_state[1]*delta_state[1]
-              + delta_state[2]*delta_state[2] )  );
-
-          // sign: delta * a
-          if (delta_state[0]*state7[3] + delta_state[1]*state7[4] + delta_state[2]*state7[5] > 0)
-            Dist *= -1.;
-
-          double correctionFactor( 1. + Dist / coveredDistance );
-          flightTime *= correctionFactor;
-          momLoss *= correctionFactor;
-          coveredDistance = coveredDistance + Dist;
+        // do momLoss only for defined 1/momentum .ne.0
+        if (fabs(state7[6]) > 1.E-10) {
 
           if (debugLvl_ > 0) {
-            debugOut << "correctionFactor-1 = " << correctionFactor-1. << "; Dist = " << Dist << "\n";
-            debugOut << "corrected momLoss: " << momLoss << " GeV; relative: " << momLoss/fabs(charge/state7[6])
-                << "; corrected coveredDistance = " << coveredDistance << "\n";
+            debugOut << "correct state7 with dx/dqop, dy/dqop ...\n";
+          }
+
+          dqop = charge / (fabs(charge / state7[6]) - momLoss) - state7[6];
+
+          // Correct coveredDistance and flightTime and momLoss if checkJacProj == true
+          // The idea is to calculate the state correction (based on the mometum loss) twice:
+          // Once with the unprojected Jacobian (which preserves coveredDistance),
+          // and once with the projected Jacobian (which is constrained to the plane and does NOT preserve coveredDistance).
+          // The difference of these two corrections can then be used to calculate a correction factor.
+          if (checkJacProj && fabs(coveredDistance) > MINSTEP) {
+            M1x3 state7_correction_unprojected = {{0, 0, 0}};
+            for (unsigned int i = 0; i < 3; ++i) {
+              state7_correction_unprojected[i] = 0.5 * dqop * J_MMT_unprojected_lastRow[i];
+              //debugOut << "J_MMT_unprojected_lastRow[i] " << J_MMT_unprojected_lastRow[i] << "\n";
+              //debugOut << "state7_correction_unprojected[i] " << state7_correction_unprojected[i] << "\n";
+            }
+
+            M1x3 state7_correction_projected = {{0, 0, 0}};
+            for (unsigned int i = 0; i < 3; ++i) {
+              state7_correction_projected[i] = 0.5 * dqop * J_MMT_[6 * 7 + i];
+              //debugOut << "J_MMT_[6*7 + i] " << J_MMT_[6*7 + i] << "\n";
+              //debugOut << "state7_correction_projected[i] " << state7_correction_projected[i] << "\n";
+            }
+
+            // delta distance
+            M1x3 delta_state = {{0, 0, 0}};
+            for (unsigned int i = 0; i < 3; ++i) {
+              delta_state[i] = state7_correction_unprojected[i] - state7_correction_projected[i];
+            }
+
+            double Dist(sqrt(delta_state[0]*delta_state[0]
+                             + delta_state[1]*delta_state[1]
+                             + delta_state[2]*delta_state[2]));
+
+            // sign: delta * a
+            if (delta_state[0]*state7[3] + delta_state[1]*state7[4] + delta_state[2]*state7[5] > 0)
+              Dist *= -1.;
+
+            double correctionFactor(1. + Dist / coveredDistance);
+            flightTime *= correctionFactor;
+            momLoss *= correctionFactor;
+            coveredDistance = coveredDistance + Dist;
+
+            if (debugLvl_ > 0) {
+              debugOut << "correctionFactor-1 = " << correctionFactor - 1. << "; Dist = " << Dist << "\n";
+              debugOut << "corrected momLoss: " << momLoss << " GeV; relative: " << momLoss / fabs(charge / state7[6])
+                       << "; corrected coveredDistance = " << coveredDistance << "\n";
+            }
+          }
+
+          // correct state7 with dx/dqop, dy/dqop ... Greatly improves extrapolation accuracy!
+          double qop(charge / (fabs(charge / state7[6]) - momLoss));
+          dqop = qop - state7[6];
+          state7[6] = qop;
+
+          for (unsigned int i = 0; i < 6; ++i) {
+            state7[i] += 0.5 * dqop * J_MMT_[6 * 7 + i];
+          }
+          // normalize direction, just to make sure
+          double norm(1. / sqrt(state7[3]*state7[3] + state7[4]*state7[4] + state7[5]*state7[5]));
+          for (unsigned int i = 3; i < 6; ++i)
+            state7[i] *= norm;
+
+        }
+      } // finished MatFX
+
+
+      // fill ExtrapSteps_
+      if (fillExtrapSteps) {
+        static const ExtrapStep defaultExtrapStep;
+        ExtrapSteps_.push_back(defaultExtrapStep);
+        std::vector<ExtrapStep>::iterator lastStep = ExtrapSteps_.end() - 1;
+
+        // Store Jacobian of this step for final calculation.
+        lastStep->jac7_ = J_MMT_;
+
+        if (checkJacProj == true) {
+          //project the noise onto the destPlane
+          RKTools::Np_N_NpT(noiseProjection_, noiseArray_);
+
+          if (debugLvl_ > 1) {
+            debugOut << "7D noise projected onto plane: \n";
+            RKTools::printDim(noiseArray_.begin(), 7, 7);
           }
         }
 
-        // correct state7 with dx/dqop, dy/dqop ... Greatly improves extrapolation accuracy!
-        double qop( charge/(fabs(charge/state7[6])-momLoss) );
-        dqop = qop - state7[6];
-        state7[6] = qop;
+        // Store this step's noise for final calculation.
+        lastStep->noise7_ = noiseArray_;
 
-        for (unsigned int i=0; i<6; ++i) {
-          state7[i] += 0.5 * dqop * J_MMT_[6*7 + i];
+        if (debugLvl_ > 2) {
+          debugOut << "ExtrapSteps \n";
+          for (std::vector<ExtrapStep>::iterator it = ExtrapSteps_.begin(); it != ExtrapSteps_.end(); ++it) {
+            debugOut << "7D Jacobian: "; RKTools::printDim((it->jac7_.begin()), 5, 5);
+            debugOut << "7D noise:    "; RKTools::printDim((it->noise7_.begin()), 5, 5);
+          }
+          debugOut << "\n";
         }
-        // normalize direction, just to make sure
-        double norm( 1. / sqrt(state7[3]*state7[3] + state7[4]*state7[4] + state7[5]*state7[5]) );
-        for (unsigned int i=3; i<6; ++i)
-          state7[i] *= norm;
-
       }
-    } // finished MatFX
 
 
-    // fill ExtrapSteps_
+
+      // check if at boundary
+      if (stopAtBoundary and isAtBoundary) {
+        if (debugLvl_ > 0) {
+          debugOut << "stopAtBoundary -> break; \n ";
+        }
+        break;
+      }
+
+      if (onlyOneStep) {
+        if (debugLvl_ > 0) {
+          debugOut << "onlyOneStep -> break; \n ";
+        }
+        break;
+      }
+
+      //break if we arrived at destPlane
+      if (atPlane) {
+        if (debugLvl_ > 0) {
+          debugOut << "arrived at destPlane with a distance of  " << destPlane.distance(state7[0], state7[1], state7[2]) << " cm left. ";
+          if (destPlane.isInActive(state7[0], state7[1], state7[2],  state7[3], state7[4], state7[5]))
+            debugOut << "In active area of destPlane. \n";
+          else
+            debugOut << "NOT in active area of plane. \n";
+
+          debugOut << "  position:  "; TVector3(state7[0], state7[1], state7[2]).Print();
+          debugOut << "  direction: "; TVector3(state7[3], state7[4], state7[5]).Print();
+        }
+        break;
+      }
+
+    }
+
     if (fillExtrapSteps) {
-      static const ExtrapStep defaultExtrapStep;
-      ExtrapSteps_.push_back(defaultExtrapStep);
-      std::vector<ExtrapStep>::iterator lastStep = ExtrapSteps_.end() - 1;
+      // propagate cov and add noise
+      calcForwardJacobianAndNoise(startState7, startPlane, state7, destPlane);
 
-      // Store Jacobian of this step for final calculation.
-      lastStep->jac7_ = J_MMT_;
-
-      if( checkJacProj == true ){
-        //project the noise onto the destPlane
-        RKTools::Np_N_NpT(noiseProjection_, noiseArray_);
-
-        if (debugLvl_ > 1) {
-          debugOut << "7D noise projected onto plane: \n";
-          RKTools::printDim(noiseArray_.begin(), 7, 7);
-        }
-      }
-
-      // Store this step's noise for final calculation.
-      lastStep->noise7_ = noiseArray_;
-
-      if (debugLvl_ > 2) {
-        debugOut<<"ExtrapSteps \n";
-        for (std::vector<ExtrapStep>::iterator it = ExtrapSteps_.begin(); it != ExtrapSteps_.end(); ++it){
-          debugOut << "7D Jacobian: "; RKTools::printDim((it->jac7_.begin()), 5,5);
-          debugOut << "7D noise:    "; RKTools::printDim((it->noise7_.begin()), 5,5);
-        }
-        debugOut<<"\n";
-      }
-    }
-
-
-
-    // check if at boundary
-    if (stopAtBoundary and isAtBoundary) {
-      if (debugLvl_ > 0) {
-        debugOut << "stopAtBoundary -> break; \n ";
-      }
-      break;
-    }
-
-    if (onlyOneStep) {
-      if (debugLvl_ > 0) {
-        debugOut << "onlyOneStep -> break; \n ";
-      }
-      break;
-    }
-
-    //break if we arrived at destPlane
-    if(atPlane) {
-      if (debugLvl_ > 0) {
-        debugOut << "arrived at destPlane with a distance of  " << destPlane.distance(state7[0], state7[1], state7[2]) << " cm left. ";
-        if (destPlane.isInActive(state7[0], state7[1], state7[2],  state7[3], state7[4], state7[5]))
-          debugOut << "In active area of destPlane. \n";
-        else
-          debugOut << "NOT in active area of plane. \n";
-
-        debugOut << "  position:  "; TVector3(state7[0], state7[1], state7[2]).Print();
-        debugOut << "  direction: "; TVector3(state7[3], state7[4], state7[5]).Print();
-      }
-      break;
-    }
-
-  }
-
-  if (fillExtrapSteps) {
-    // propagate cov and add noise
-    calcForwardJacobianAndNoise(startState7, startPlane, state7, destPlane);
-
-    if (cov != nullptr) {
-      cov->Similarity(fJacobian_);
-      *cov += fNoise_;
-    }
-
-    if (debugLvl_ > 0) {
       if (cov != nullptr) {
-        debugOut << "final covariance matrix after Extrap: "; cov->Print();
+        cov->Similarity(fJacobian_);
+        *cov += fNoise_;
       }
-    }
-  }
 
-  return coveredDistance;
-}
-
-
-void RKTrackRep::checkCache(const StateOnPlane& state, const SharedPlanePtr* plane) const {
-
-  if (state.getRep() != this){
-    Exception exc("RKTrackRep::checkCache ==> state is defined wrt. another TrackRep",__LINE__,__FILE__);
-    exc.setFatal();
-    throw exc;
-  }
-
-  if (dynamic_cast<const MeasurementOnPlane*>(&state) != nullptr) {
-    Exception exc("RKTrackRep::checkCache - cannot extrapolate MeasurementOnPlane",__LINE__,__FILE__);
-    exc.setFatal();
-    throw exc;
-  }
-
-  cachePos_ = 0;
-  RKStepsFXStart_ = 0;
-  RKStepsFXStop_ = 0;
-  ExtrapSteps_.clear();
-  initArrays();
-
-
-  if (plane &&
-      lastStartState_.getPlane() &&
-      lastEndState_.getPlane() &&
-      state.getPlane() == lastStartState_.getPlane() &&
-      state.getState() == lastStartState_.getState() &&
-      (*plane)->distance(getPos(lastEndState_)) <= MINSTEP) {
-    useCache_ = true;
-
-    // clean up cache. Only use steps with same sign.
-    double firstStep(0);
-    for (unsigned int i=0; i<RKSteps_.size(); ++i) {
-      if (i == 0) {
-        firstStep = RKSteps_.at(0).matStep_.stepSize_;
-        continue;
-      }
-      if (RKSteps_.at(i).matStep_.stepSize_ * firstStep < 0) {
-        if (RKSteps_.at(i-1).matStep_.material_ == RKSteps_.at(i).matStep_.material_) {
-          RKSteps_.at(i-1).matStep_.stepSize_ += RKSteps_.at(i).matStep_.stepSize_;
+      if (debugLvl_ > 0) {
+        if (cov != nullptr) {
+          debugOut << "final covariance matrix after Extrap: "; cov->Print();
         }
-        RKSteps_.erase(RKSteps_.begin()+i, RKSteps_.end());
       }
     }
 
-    if (debugLvl_ > 0) {
+    return coveredDistance;
+  }
+
+
+  void RKTrackRep::checkCache(const StateOnPlane& state, const SharedPlanePtr* plane) const
+  {
+
+    if (state.getRep() != this) {
+      Exception exc("RKTrackRep::checkCache ==> state is defined wrt. another TrackRep", __LINE__, __FILE__);
+      exc.setFatal();
+      throw exc;
+    }
+
+    if (dynamic_cast<const MeasurementOnPlane*>(&state) != nullptr) {
+      Exception exc("RKTrackRep::checkCache - cannot extrapolate MeasurementOnPlane", __LINE__, __FILE__);
+      exc.setFatal();
+      throw exc;
+    }
+
+    cachePos_ = 0;
+    RKStepsFXStart_ = 0;
+    RKStepsFXStop_ = 0;
+    ExtrapSteps_.clear();
+    initArrays();
+
+
+    if (plane &&
+        lastStartState_.getPlane() &&
+        lastEndState_.getPlane() &&
+        state.getPlane() == lastStartState_.getPlane() &&
+        state.getState() == lastStartState_.getState() &&
+        (*plane)->distance(getPos(lastEndState_)) <= MINSTEP) {
+      useCache_ = true;
+
+      // clean up cache. Only use steps with same sign.
+      double firstStep(0);
+      for (unsigned int i = 0; i < RKSteps_.size(); ++i) {
+        if (i == 0) {
+          firstStep = RKSteps_.at(0).matStep_.stepSize_;
+          continue;
+        }
+        if (RKSteps_.at(i).matStep_.stepSize_ * firstStep < 0) {
+          if (RKSteps_.at(i - 1).matStep_.material_ == RKSteps_.at(i).matStep_.material_) {
+            RKSteps_.at(i - 1).matStep_.stepSize_ += RKSteps_.at(i).matStep_.stepSize_;
+          }
+          RKSteps_.erase(RKSteps_.begin() + i, RKSteps_.end());
+        }
+      }
+
+      if (debugLvl_ > 0) {
         debugOut << "RKTrackRep::checkCache: use cached material and step values.\n";
-    }
-  }
-  else {
+      }
+    } else {
 
-    if (debugLvl_ > 0) {
-      debugOut << "RKTrackRep::checkCache: can NOT use cached material and step values.\n";
+      if (debugLvl_ > 0) {
+        debugOut << "RKTrackRep::checkCache: can NOT use cached material and step values.\n";
 
-      if (plane != nullptr) {
-        if (state.getPlane() != lastStartState_.getPlane()) {
-          debugOut << "state.getPlane() != lastStartState_.getPlane()\n";
-        }
-        else {
-          if (! (state.getState() == lastStartState_.getState())) {
-            debugOut << "state.getState() != lastStartState_.getState()\n";
-          }
-          else if (lastEndState_.getPlane().get() != nullptr) {
-            debugOut << "distance " << (*plane)->distance(getPos(lastEndState_)) << "\n";
+        if (plane != nullptr) {
+          if (state.getPlane() != lastStartState_.getPlane()) {
+            debugOut << "state.getPlane() != lastStartState_.getPlane()\n";
+          } else {
+            if (!(state.getState() == lastStartState_.getState())) {
+              debugOut << "state.getState() != lastStartState_.getState()\n";
+            } else if (lastEndState_.getPlane().get() != nullptr) {
+              debugOut << "distance " << (*plane)->distance(getPos(lastEndState_)) << "\n";
+            }
           }
         }
       }
+
+      useCache_ = false;
+      RKSteps_.clear();
+
+      lastStartState_.setStatePlane(state.getState(), state.getPlane());
     }
-
-    useCache_ = false;
-    RKSteps_.clear();
-
-    lastStartState_.setStatePlane(state.getState(), state.getPlane());
   }
-}
 
 
-double RKTrackRep::momMag(const M1x7& state7) const {
-  // FIXME given this interface this function cannot work for charge =/= +-1
-  return fabs(1/state7[6]);
-}
+  double RKTrackRep::momMag(const M1x7& state7) const
+  {
+    // FIXME given this interface this function cannot work for charge =/= +-1
+    return fabs(1 / state7[6]);
+  }
 
 
-bool RKTrackRep::isSameType(const AbsTrackRep* other) {
-  if (dynamic_cast<const RKTrackRep*>(other) == nullptr)
-    return false;
+  bool RKTrackRep::isSameType(const AbsTrackRep* other)
+  {
+    if (dynamic_cast<const RKTrackRep*>(other) == nullptr)
+      return false;
 
-  return true;
-}
-
-
-bool RKTrackRep::isSame(const AbsTrackRep* other) {
-  if (getPDG() != other->getPDG())
-    return false;
-
-  return isSameType(other);
-}
+    return true;
+  }
 
 
-void RKTrackRep::Streamer(TBuffer &R__b)
-{
-   // Stream an object of class genfit::RKTrackRep.
+  bool RKTrackRep::isSame(const AbsTrackRep* other)
+  {
+    if (getPDG() != other->getPDG())
+      return false;
 
-   //This works around a msvc bug and should be harmless on other platforms
-   typedef ::genfit::RKTrackRep thisClass;
-   UInt_t R__s, R__c;
-   if (R__b.IsReading()) {
+    return isSameType(other);
+  }
+
+
+  void RKTrackRep::Streamer(TBuffer& R__b)
+  {
+    // Stream an object of class genfit::RKTrackRep.
+
+    //This works around a msvc bug and should be harmless on other platforms
+    typedef ::genfit::RKTrackRep thisClass;
+    UInt_t R__s, R__c;
+    if (R__b.IsReading()) {
       ::genfit::AbsTrackRep::Streamer(R__b);
-      Version_t R__v = R__b.ReadVersion(&R__s, &R__c); if (R__v) { }
+      Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+      if (R__v) { }
       R__b.CheckByteCount(R__s, R__c, thisClass::IsA());
       lastStartState_.setRep(this);
       lastEndState_.setRep(this);
-   } else {
+    } else {
       ::genfit::AbsTrackRep::Streamer(R__b);
       R__c = R__b.WriteVersion(thisClass::IsA(), kTRUE);
       R__b.SetByteCount(R__c, kTRUE);
-   }
-}
+    }
+  }
 
 } /* End of namespace genfit */

--- a/trackReps/src/StepLimits.cc
+++ b/trackReps/src/StepLimits.cc
@@ -27,125 +27,133 @@
 
 namespace genfit {
 
-const double StepLimits::maxLimit_ = 99.E99;
+  const double StepLimits::maxLimit_ = 99.E99;
 
 
-StepLimits& StepLimits::operator=(const StepLimits& other) {
-  for (unsigned int i=1; i<ENUM_NR_ITEMS; ++i) {
-    limits_[i] = other.limits_[i];
-  }
-
-  stepSign_ = other.stepSign_;
-
-  return *this;
-}
-
-
-std::pair<StepLimitType, double> StepLimits::getLowestLimit(double margin) const {
-
-  double lowest(maxLimit_);
-  unsigned int iLowest(0);
-
-  for (unsigned int i=1; i<ENUM_NR_ITEMS; ++i) {
-
-    // lowest hard limit may exceed lowest soft limit by up to #margin
-    if (i == int(stp_sMaxArg))
-      lowest *= (1+margin);
-
-    if (limits_[i] < lowest) {
-      lowest = limits_[i];
-      iLowest = i;
+  StepLimits& StepLimits::operator=(const StepLimits& other)
+  {
+    for (unsigned int i = 1; i < ENUM_NR_ITEMS; ++i) {
+      limits_[i] = other.limits_[i];
     }
+
+    stepSign_ = other.stepSign_;
+
+    return *this;
   }
 
-  return std::pair<StepLimitType, double>(static_cast<StepLimitType>(iLowest), lowest);
-}
 
+  std::pair<StepLimitType, double> StepLimits::getLowestLimit(double margin) const
+  {
 
-double StepLimits::getLowestLimitVal(double margin) const {
+    double lowest(maxLimit_);
+    unsigned int iLowest(0);
 
-  double lowest(maxLimit_);
+    for (unsigned int i = 1; i < ENUM_NR_ITEMS; ++i) {
 
-  for (unsigned int i=1; i<ENUM_NR_ITEMS; ++i) {
+      // lowest hard limit may exceed lowest soft limit by up to #margin
+      if (i == int(stp_sMaxArg))
+        lowest *= (1 + margin);
 
-    // lowest hard limit may exceed lowest soft limit by up to #margin
-    if (i == int(stp_sMaxArg))
-      lowest *= (1+margin);
-
-    if (limits_[i] < lowest) {
-      lowest = limits_[i];
+      if (limits_[i] < lowest) {
+        lowest = limits_[i];
+        iLowest = i;
+      }
     }
+
+    return std::pair<StepLimitType, double>(static_cast<StepLimitType>(iLowest), lowest);
   }
 
-  return lowest;
-}
 
+  double StepLimits::getLowestLimitVal(double margin) const
+  {
 
-void StepLimits::reduceLimit(StepLimitType type, double value) {
-  assert (type != stp_noLimit);
-  value = fabs(value);
+    double lowest(maxLimit_);
 
-  if (limits_[type] > value)
-    limits_[type] = value;
-}
+    for (unsigned int i = 1; i < ENUM_NR_ITEMS; ++i) {
 
+      // lowest hard limit may exceed lowest soft limit by up to #margin
+      if (i == int(stp_sMaxArg))
+        lowest *= (1 + margin);
 
-void StepLimits::setStepSign(char signedVal) {
-  if (signedVal < 0)
-    stepSign_ = -1;
-  else
-    stepSign_ = 1;
-}
+      if (limits_[i] < lowest) {
+        lowest = limits_[i];
+      }
+    }
 
-void StepLimits::setStepSign(double signedVal) {
-  if (signedVal < 0.)
-    stepSign_ = -1;
-  else
-    stepSign_ = 1;
-}
-
-
-void StepLimits::reset() {
-  for (unsigned int i=1; i<ENUM_NR_ITEMS; ++i) {
-    limits_[i] = maxLimit_;
+    return lowest;
   }
-  stepSign_ = 1;
-}
 
 
-void StepLimits::Print() {
-  for (unsigned int i=0; i<ENUM_NR_ITEMS; ++i) {
-    if (limits_[i] >= maxLimit_)
-      continue;
+  void StepLimits::reduceLimit(StepLimitType type, double value)
+  {
+    assert(type != stp_noLimit);
+    value = fabs(value);
 
-    printOut << "   | " << limits_[i] << " cm due to ";
-    switch (static_cast<StepLimitType>(i)) {
-    case stp_noLimit:
-      break;
-    case stp_fieldCurv:
-      printOut << "stp_fieldCurv (medium limit): stepsize limited by curvature and magnetic field inhomogenities";
-      break;
-    case stp_momLoss:
-      printOut << "stp_momLoss (medium limit): stepsize limited by stepper because maximum momLoss is reached";
-      break;
-    case stp_sMax:
-      printOut << "stp_sMax (medium limit): stepsize limited by SMax defined in #estimateStep()";
-      break;
-    case stp_sMaxArg:
-      printOut << "stp_sMaxArg (hard limit): stepsize limited by argument maxStepArg passed to #estimateStep()";
-      break;
-    case stp_boundary:
-      printOut << "stp_boundary (hard limit): stepsize limited by stepper because material boundary is encountered";
-      break;
-    case stp_plane:
-      printOut << "stp_plane (hard limit):  stepsize limited because destination plane is reached";
-      break;
-    case ENUM_NR_ITEMS:
-      break;
+    if (limits_[type] > value)
+      limits_[type] = value;
+  }
+
+
+  void StepLimits::setStepSign(char signedVal)
+  {
+    if (signedVal < 0)
+      stepSign_ = -1;
+    else
+      stepSign_ = 1;
+  }
+
+  void StepLimits::setStepSign(double signedVal)
+  {
+    if (signedVal < 0.)
+      stepSign_ = -1;
+    else
+      stepSign_ = 1;
+  }
+
+
+  void StepLimits::reset()
+  {
+    for (unsigned int i = 1; i < ENUM_NR_ITEMS; ++i) {
+      limits_[i] = maxLimit_;
+    }
+    stepSign_ = 1;
+  }
+
+
+  void StepLimits::Print()
+  {
+    for (unsigned int i = 0; i < ENUM_NR_ITEMS; ++i) {
+      if (limits_[i] >= maxLimit_)
+        continue;
+
+      printOut << "   | " << limits_[i] << " cm due to ";
+      switch (static_cast<StepLimitType>(i)) {
+        case stp_noLimit:
+          break;
+        case stp_fieldCurv:
+          printOut << "stp_fieldCurv (medium limit): stepsize limited by curvature and magnetic field inhomogenities";
+          break;
+        case stp_momLoss:
+          printOut << "stp_momLoss (medium limit): stepsize limited by stepper because maximum momLoss is reached";
+          break;
+        case stp_sMax:
+          printOut << "stp_sMax (medium limit): stepsize limited by SMax defined in #estimateStep()";
+          break;
+        case stp_sMaxArg:
+          printOut << "stp_sMaxArg (hard limit): stepsize limited by argument maxStepArg passed to #estimateStep()";
+          break;
+        case stp_boundary:
+          printOut << "stp_boundary (hard limit): stepsize limited by stepper because material boundary is encountered";
+          break;
+        case stp_plane:
+          printOut << "stp_plane (hard limit):  stepsize limited because destination plane is reached";
+          break;
+        case ENUM_NR_ITEMS:
+          break;
+      }
+      printOut << "\n";
     }
     printOut << "\n";
   }
-  printOut << "\n";
-}
 
 } /* End of namespace genfit */

--- a/trackReps/src/TGeoMaterialInterface.cc
+++ b/trackReps/src/TGeoMaterialInterface.cc
@@ -30,249 +30,255 @@
 
 namespace genfit {
 
-double MeanExcEnergy_get(int Z);
-double MeanExcEnergy_get(TGeoMaterial*);
+  double MeanExcEnergy_get(int Z);
+  double MeanExcEnergy_get(TGeoMaterial*);
 
 
-bool
-TGeoMaterialInterface::initTrack(double posX, double posY, double posZ,
-                                   double dirX, double dirY, double dirZ){
-  #ifdef DEBUG
-  debugOut << "TGeoMaterialInterface::initTrack. \n";
-  debugOut << "Pos    "; TVector3(posX, posY, posZ).Print();
-  debugOut << "Dir    "; TVector3(dirX, dirY, dirZ).Print();
-  #endif
+  bool
+  TGeoMaterialInterface::initTrack(double posX, double posY, double posZ,
+                                   double dirX, double dirY, double dirZ)
+  {
+#ifdef DEBUG
+    debugOut << "TGeoMaterialInterface::initTrack. \n";
+    debugOut << "Pos    "; TVector3(posX, posY, posZ).Print();
+    debugOut << "Dir    "; TVector3(dirX, dirY, dirZ).Print();
+#endif
 
-  // Move to the new point.
-  bool result = !gGeoManager->IsSameLocation(posX, posY, posZ, kTRUE);
-  // Set the intended direction.
-  gGeoManager->SetCurrentDirection(dirX, dirY, dirZ);
+    // Move to the new point.
+    bool result = !gGeoManager->IsSameLocation(posX, posY, posZ, kTRUE);
+    // Set the intended direction.
+    gGeoManager->SetCurrentDirection(dirX, dirY, dirZ);
 
-  if (debugLvl_ > 0) {
-    debugOut << "      TGeoMaterialInterface::initTrack at \n";
-    debugOut << "      position:  "; TVector3(posX, posY, posZ).Print();
-    debugOut << "      direction: "; TVector3(dirX, dirY, dirZ).Print();
+    if (debugLvl_ > 0) {
+      debugOut << "      TGeoMaterialInterface::initTrack at \n";
+      debugOut << "      position:  "; TVector3(posX, posY, posZ).Print();
+      debugOut << "      direction: "; TVector3(dirX, dirY, dirZ).Print();
+    }
+
+    return result;
   }
 
-  return result;
-}
+
+  Material TGeoMaterialInterface::getMaterialParameters()
+  {
+
+    TGeoMaterial* mat = gGeoManager->GetCurrentVolume()->GetMedium()->GetMaterial();
+    return Material(mat->GetDensity(), mat->GetZ(), mat->GetA(), mat->GetRadLen(), MeanExcEnergy_get(mat));
+
+  }
 
 
-Material TGeoMaterialInterface::getMaterialParameters() {
-
-  TGeoMaterial* mat = gGeoManager->GetCurrentVolume()->GetMedium()->GetMaterial();
-  return Material(mat->GetDensity(), mat->GetZ(), mat->GetA(), mat->GetRadLen(), MeanExcEnergy_get(mat));
-
-}
-
-
-double
-TGeoMaterialInterface::findNextBoundary(const RKTrackRep* rep,
+  double
+  TGeoMaterialInterface::findNextBoundary(const RKTrackRep* rep,
                                           const M1x7& stateOrig,
                                           double sMax, // signed
                                           bool varField)
-{
-  const double delta(1.E-2); // cm, distance limit beneath which straight-line steps are taken.
-  const double epsilon(1.E-1); // cm, allowed upper bound on arch
-  // deviation from straight line
+  {
+    const double delta(1.E-2); // cm, distance limit beneath which straight-line steps are taken.
+    const double epsilon(1.E-1); // cm, allowed upper bound on arch
+    // deviation from straight line
 
-  M1x3 SA;
-  M1x7 state7, oldState7;
-  oldState7 = stateOrig;
+    M1x3 SA;
+    M1x7 state7, oldState7;
+    oldState7 = stateOrig;
 
-  int stepSign(sMax < 0 ? -1 : 1);
+    int stepSign(sMax < 0 ? -1 : 1);
 
-  double s = 0;  // trajectory length to boundary
+    double s = 0;  // trajectory length to boundary
 
-  const unsigned maxIt = 300;
-  unsigned it = 0;
+    const unsigned maxIt = 300;
+    unsigned it = 0;
 
-  // Initialize the geometry to the current location (set by caller).
-  gGeoManager->FindNextBoundary(fabs(sMax) - s);
-  double safety = gGeoManager->GetSafeDistance(); // >= 0
-  double slDist = gGeoManager->GetStep();
+    // Initialize the geometry to the current location (set by caller).
+    gGeoManager->FindNextBoundary(fabs(sMax) - s);
+    double safety = gGeoManager->GetSafeDistance(); // >= 0
+    double slDist = gGeoManager->GetStep();
 
-  // this should not happen, but it happens sometimes.
-  // The reason are probably overlaps in the geometry.
-  // Without this "hack" many small steps with size of minStep will be made,
-  // until eventually the maximum number of iterations are exceeded and the extrapolation fails
-  if (slDist < safety) 
-    slDist = safety;
-  double step = slDist;
+    // this should not happen, but it happens sometimes.
+    // The reason are probably overlaps in the geometry.
+    // Without this "hack" many small steps with size of minStep will be made,
+    // until eventually the maximum number of iterations are exceeded and the extrapolation fails
+    if (slDist < safety)
+      slDist = safety;
+    double step = slDist;
 
-  if (debugLvl_ > 0)
-    debugOut << "   safety = " << safety << "; step, slDist = " << step << "\n";
+    if (debugLvl_ > 0)
+      debugOut << "   safety = " << safety << "; step, slDist = " << step << "\n";
 
-  while (1) {
-    if (++it > maxIt){
-      Exception exc("TGeoMaterialInterface::findNextBoundary ==> maximum number of iterations exceeded",__LINE__,__FILE__);
-      exc.setFatal();
-      throw exc;
-    }
+    while (1) {
+      if (++it > maxIt) {
+        Exception exc("TGeoMaterialInterface::findNextBoundary ==> maximum number of iterations exceeded", __LINE__, __FILE__);
+        exc.setFatal();
+        throw exc;
+      }
 
-    // No boundary in sight?
-    if (s + safety > fabs(sMax)) {
-      if (debugLvl_ > 0)
-        debugOut << "   next boundary is further away than sMax \n";
-      return stepSign*(s + safety); //sMax;
-    }
-
-    // Are we at the boundary?
-    if (slDist < delta) {
-      if (debugLvl_ > 0)
-        debugOut << "   very close to the boundary -> return"
-        << " stepSign*(s + slDist) = "
-        << stepSign << "*(" << s + slDist << ")\n";
-      return stepSign*(s + slDist);
-    }
-
-    // We have to find whether there's any boundary on our path.
-
-    // Follow curved arch, then see if we may have missed a boundary.
-    // Always propagate complete way from original start to avoid
-    // inconsistent extrapolations.
-    state7 = stateOrig;
-    rep->RKPropagate(state7, nullptr, SA, stepSign*(s + step), varField);
-
-    // Straight line distance² between extrapolation finish and
-    // the end of the previously determined safe segment.
-    double dist2 = (pow(state7[0] - oldState7[0], 2)
-        + pow(state7[1] - oldState7[1], 2)
-        + pow(state7[2] - oldState7[2], 2));
-    // Maximal lateral deviation².
-    double maxDeviation2 = 0.25*(step*step - dist2);
-
-    if (step > safety
-        && maxDeviation2 > epsilon*epsilon) {
-      // Need to take a shorter step to reliably estimate material,
-      // but only if we didn't move by safety.  In order to avoid
-      // issues with roundoff we check 'step > safety' instead of
-      // 'step != safety'.  If we moved by safety, there couldn't have
-      // been a boundary that we missed along the path, but we could
-      // be on the boundary.
-
-      // Take a shorter step, but never shorter than safety.
-      step = std::max(step / 2, safety);
-    } else {
-      gGeoManager->PushPoint();
-      bool volChanged = initTrack(state7[0], state7[1], state7[2],
-          stepSign*state7[3], stepSign*state7[4],
-          stepSign*state7[5]);
-
-      if (volChanged) {
+      // No boundary in sight?
+      if (s + safety > fabs(sMax)) {
         if (debugLvl_ > 0)
-          debugOut << "   volChanged\n";
-        // Move back to start.
-        gGeoManager->PopPoint();
+          debugOut << "   next boundary is further away than sMax \n";
+        return stepSign * (s + safety); //sMax;
+      }
 
-        // Extrapolation may not take the exact step length we asked
-        // for, so it can happen that a requested step < safety takes
-        // us across the boundary.  This is then the best estimate we
-        // can get of the distance to the boundary with the stepper.
-        if (step <= safety) {
-          if (debugLvl_ > 0)
-            debugOut << "   step <= safety, return stepSign*(s + step) = " << stepSign*(s + step) << "\n";
-          return stepSign*(s + step);
-        }
+      // Are we at the boundary?
+      if (slDist < delta) {
+        if (debugLvl_ > 0)
+          debugOut << "   very close to the boundary -> return"
+                   << " stepSign*(s + slDist) = "
+                   << stepSign << "*(" << s + slDist << ")\n";
+        return stepSign * (s + slDist);
+      }
 
-        // Volume changed during the extrapolation.  Take a shorter
-        // step, but never shorter than safety.
+      // We have to find whether there's any boundary on our path.
+
+      // Follow curved arch, then see if we may have missed a boundary.
+      // Always propagate complete way from original start to avoid
+      // inconsistent extrapolations.
+      state7 = stateOrig;
+      rep->RKPropagate(state7, nullptr, SA, stepSign * (s + step), varField);
+
+      // Straight line distance² between extrapolation finish and
+      // the end of the previously determined safe segment.
+      double dist2 = (pow(state7[0] - oldState7[0], 2)
+                      + pow(state7[1] - oldState7[1], 2)
+                      + pow(state7[2] - oldState7[2], 2));
+      // Maximal lateral deviation².
+      double maxDeviation2 = 0.25 * (step * step - dist2);
+
+      if (step > safety
+          && maxDeviation2 > epsilon * epsilon) {
+        // Need to take a shorter step to reliably estimate material,
+        // but only if we didn't move by safety.  In order to avoid
+        // issues with roundoff we check 'step > safety' instead of
+        // 'step != safety'.  If we moved by safety, there couldn't have
+        // been a boundary that we missed along the path, but we could
+        // be on the boundary.
+
+        // Take a shorter step, but never shorter than safety.
         step = std::max(step / 2, safety);
       } else {
-        // we're in the new place, the step was safe, advance
-        s += step;
+        gGeoManager->PushPoint();
+        bool volChanged = initTrack(state7[0], state7[1], state7[2],
+                                    stepSign * state7[3], stepSign * state7[4],
+                                    stepSign * state7[5]);
 
-        oldState7 = state7;
-        gGeoManager->PopDummy();  // Pop stack, but stay in place.
+        if (volChanged) {
+          if (debugLvl_ > 0)
+            debugOut << "   volChanged\n";
+          // Move back to start.
+          gGeoManager->PopPoint();
 
-        gGeoManager->FindNextBoundary(fabs(sMax) - s);
-        safety = gGeoManager->GetSafeDistance();
-        slDist = gGeoManager->GetStep();
+          // Extrapolation may not take the exact step length we asked
+          // for, so it can happen that a requested step < safety takes
+          // us across the boundary.  This is then the best estimate we
+          // can get of the distance to the boundary with the stepper.
+          if (step <= safety) {
+            if (debugLvl_ > 0)
+              debugOut << "   step <= safety, return stepSign*(s + step) = " << stepSign*(s + step) << "\n";
+            return stepSign * (s + step);
+          }
 
-        // this should not happen, but it happens sometimes.
-        // The reason are probably overlaps in the geometry.
-        // Without this "hack" many small steps with size of minStep will be made,
-        // until eventually the maximum number of iterations are exceeded and the extrapolation fails
-        if (slDist < safety)
-          slDist = safety;
-        step = slDist;
-        if (debugLvl_ > 0)
-          debugOut << "   safety = " << safety << "; step, slDist = " << step << "\n";
+          // Volume changed during the extrapolation.  Take a shorter
+          // step, but never shorter than safety.
+          step = std::max(step / 2, safety);
+        } else {
+          // we're in the new place, the step was safe, advance
+          s += step;
+
+          oldState7 = state7;
+          gGeoManager->PopDummy();  // Pop stack, but stay in place.
+
+          gGeoManager->FindNextBoundary(fabs(sMax) - s);
+          safety = gGeoManager->GetSafeDistance();
+          slDist = gGeoManager->GetStep();
+
+          // this should not happen, but it happens sometimes.
+          // The reason are probably overlaps in the geometry.
+          // Without this "hack" many small steps with size of minStep will be made,
+          // until eventually the maximum number of iterations are exceeded and the extrapolation fails
+          if (slDist < safety)
+            slDist = safety;
+          step = slDist;
+          if (debugLvl_ > 0)
+            debugOut << "   safety = " << safety << "; step, slDist = " << step << "\n";
+        }
       }
     }
   }
-}
 
 
-/*
-Reference for elemental mean excitation energies at:
-http://physics.nist.gov/PhysRefData/XrayMassCoef/tab1.html
+  /*
+  Reference for elemental mean excitation energies at:
+  http://physics.nist.gov/PhysRefData/XrayMassCoef/tab1.html
 
-Code ported from GEANT 3
-*/
+  Code ported from GEANT 3
+  */
 
-const int MeanExcEnergy_NELEMENTS = 93; // 0 = vacuum, 1 = hydrogen, 92 = uranium
-const double MeanExcEnergy_vals[MeanExcEnergy_NELEMENTS] = {
-  1.e15, 19.2, 41.8, 40.0, 63.7, 76.0, 78., 82.0,
-  95.0, 115.0, 137.0, 149.0, 156.0, 166.0, 173.0, 173.0,
-  180.0, 174.0, 188.0, 190.0, 191.0, 216.0, 233.0, 245.0,
-  257.0, 272.0, 286.0, 297.0, 311.0, 322.0, 330.0, 334.0,
-  350.0, 347.0, 348.0, 343.0, 352.0, 363.0, 366.0, 379.0,
-  393.0, 417.0, 424.0, 428.0, 441.0, 449.0, 470.0, 470.0,
-  469.0, 488.0, 488.0, 487.0, 485.0, 491.0, 482.0, 488.0,
-  491.0, 501.0, 523.0, 535.0, 546.0, 560.0, 574.0, 580.0,
-  591.0, 614.0, 628.0, 650.0, 658.0, 674.0, 684.0, 694.0,
-  705.0, 718.0, 727.0, 736.0, 746.0, 757.0, 790.0, 790.0,
-  800.0, 810.0, 823.0, 823.0, 830.0, 825.0, 794.0, 827.0,
-  826.0, 841.0, 847.0, 878.0, 890.0, };
+  const int MeanExcEnergy_NELEMENTS = 93; // 0 = vacuum, 1 = hydrogen, 92 = uranium
+  const double MeanExcEnergy_vals[MeanExcEnergy_NELEMENTS] = {
+    1.e15, 19.2, 41.8, 40.0, 63.7, 76.0, 78., 82.0,
+    95.0, 115.0, 137.0, 149.0, 156.0, 166.0, 173.0, 173.0,
+    180.0, 174.0, 188.0, 190.0, 191.0, 216.0, 233.0, 245.0,
+    257.0, 272.0, 286.0, 297.0, 311.0, 322.0, 330.0, 334.0,
+    350.0, 347.0, 348.0, 343.0, 352.0, 363.0, 366.0, 379.0,
+    393.0, 417.0, 424.0, 428.0, 441.0, 449.0, 470.0, 470.0,
+    469.0, 488.0, 488.0, 487.0, 485.0, 491.0, 482.0, 488.0,
+    491.0, 501.0, 523.0, 535.0, 546.0, 560.0, 574.0, 580.0,
+    591.0, 614.0, 628.0, 650.0, 658.0, 674.0, 684.0, 694.0,
+    705.0, 718.0, 727.0, 736.0, 746.0, 757.0, 790.0, 790.0,
+    800.0, 810.0, 823.0, 823.0, 830.0, 825.0, 794.0, 827.0,
+    826.0, 841.0, 847.0, 878.0, 890.0,
+  };
 // Logarithms of the previous table, used to calculate mixtures.
-const double MeanExcEnergy_logs[MeanExcEnergy_NELEMENTS] = {
-  34.5388, 2.95491, 3.7329, 3.68888, 4.15418, 4.33073, 4.35671, 4.40672, 
-  4.55388, 4.74493, 4.91998, 5.00395, 5.04986, 5.11199, 5.15329, 5.15329, 
-  5.19296, 5.15906, 5.23644, 5.24702, 5.25227, 5.37528, 5.45104, 5.50126, 
-  5.54908, 5.6058, 5.65599, 5.69373, 5.73979, 5.77455, 5.79909, 5.81114, 
-  5.85793, 5.84932, 5.8522, 5.83773, 5.86363, 5.8944, 5.90263, 5.93754, 
-  5.97381, 6.03309, 6.04973, 6.05912, 6.08904, 6.10702, 6.15273, 6.15273, 
-  6.1506, 6.19032, 6.19032, 6.18826, 6.18415, 6.19644, 6.17794, 6.19032, 
-  6.19644, 6.21661, 6.25958, 6.28227, 6.30262, 6.32794, 6.35263, 6.36303, 
-  6.38182, 6.41999, 6.44254, 6.47697, 6.4892, 6.51323, 6.52796, 6.54247, 
-  6.5582, 6.57647, 6.58893, 6.60123, 6.61473, 6.62936, 6.67203, 6.67203, 
-  6.68461, 6.69703, 6.71296, 6.71296, 6.72143, 6.71538, 6.67708, 6.7178, 
-  6.71659, 6.73459, 6.7417, 6.77765, 6.79122, };
+  const double MeanExcEnergy_logs[MeanExcEnergy_NELEMENTS] = {
+    34.5388, 2.95491, 3.7329, 3.68888, 4.15418, 4.33073, 4.35671, 4.40672,
+    4.55388, 4.74493, 4.91998, 5.00395, 5.04986, 5.11199, 5.15329, 5.15329,
+    5.19296, 5.15906, 5.23644, 5.24702, 5.25227, 5.37528, 5.45104, 5.50126,
+    5.54908, 5.6058, 5.65599, 5.69373, 5.73979, 5.77455, 5.79909, 5.81114,
+    5.85793, 5.84932, 5.8522, 5.83773, 5.86363, 5.8944, 5.90263, 5.93754,
+    5.97381, 6.03309, 6.04973, 6.05912, 6.08904, 6.10702, 6.15273, 6.15273,
+    6.1506, 6.19032, 6.19032, 6.18826, 6.18415, 6.19644, 6.17794, 6.19032,
+    6.19644, 6.21661, 6.25958, 6.28227, 6.30262, 6.32794, 6.35263, 6.36303,
+    6.38182, 6.41999, 6.44254, 6.47697, 6.4892, 6.51323, 6.52796, 6.54247,
+    6.5582, 6.57647, 6.58893, 6.60123, 6.61473, 6.62936, 6.67203, 6.67203,
+    6.68461, 6.69703, 6.71296, 6.71296, 6.72143, 6.71538, 6.67708, 6.7178,
+    6.71659, 6.73459, 6.7417, 6.77765, 6.79122,
+  };
 
 
-double
-MeanExcEnergy_get(int Z, bool logs = false) {
-  assert(Z >= 0 && Z < MeanExcEnergy_NELEMENTS);
-  if (logs)
-    return MeanExcEnergy_logs[Z];
-  else
-    return MeanExcEnergy_vals[Z];
-}
+  double
+  MeanExcEnergy_get(int Z, bool logs = false)
+  {
+    assert(Z >= 0 && Z < MeanExcEnergy_NELEMENTS);
+    if (logs)
+      return MeanExcEnergy_logs[Z];
+    else
+      return MeanExcEnergy_vals[Z];
+  }
 
 
-double
-MeanExcEnergy_get(TGeoMaterial* mat) {
-  if (mat->IsMixture()) {
-    // The mean excitation energy is calculated as the geometric mean
-    // of the mEEs of the components, weighted for abundance.
-    double logMEE = 0.;
-    double denom  = 0.;
-    TGeoMixture* mix = (TGeoMixture*)mat;
-    for (int i = 0; i < mix->GetNelements(); ++i) {
-      int index = int(mix->GetZmixt()[i]);
-      double weight = mix->GetWmixt()[i] * mix->GetZmixt()[i] / mix->GetAmixt()[i];
-      logMEE += weight * MeanExcEnergy_get(index, true);
-      denom  += weight;
+  double
+  MeanExcEnergy_get(TGeoMaterial* mat)
+  {
+    if (mat->IsMixture()) {
+      // The mean excitation energy is calculated as the geometric mean
+      // of the mEEs of the components, weighted for abundance.
+      double logMEE = 0.;
+      double denom  = 0.;
+      TGeoMixture* mix = (TGeoMixture*)mat;
+      for (int i = 0; i < mix->GetNelements(); ++i) {
+        int index = int(mix->GetZmixt()[i]);
+        double weight = mix->GetWmixt()[i] * mix->GetZmixt()[i] / mix->GetAmixt()[i];
+        logMEE += weight * MeanExcEnergy_get(index, true);
+        denom  += weight;
+      }
+      logMEE /= denom;
+      return exp(logMEE);
     }
-    logMEE /= denom;
-    return exp(logMEE);
-  } 
 
-  // not a mixture
-  int index = int(mat->GetZ());
-  return MeanExcEnergy_get(index, false);
-}
+    // not a mixture
+    int index = int(mat->GetZ());
+    return MeanExcEnergy_get(index, false);
+  }
 
 
 } /* End of namespace genfit */

--- a/utilities/include/HelixTrackModel.h
+++ b/utilities/include/HelixTrackModel.h
@@ -35,38 +35,39 @@
 
 namespace genfit {
 
-/**
- * @brief Helix track model for testing purposes
- */
-class HelixTrackModel : public TObject {
+  /**
+   * @brief Helix track model for testing purposes
+   */
+  class HelixTrackModel : public TObject {
 
- public:
+  public:
 
-  // Constructors/Destructors ---------
-  HelixTrackModel(const TVector3& pos, const TVector3& mom, double charge);
+    // Constructors/Destructors ---------
+    HelixTrackModel(const TVector3& pos, const TVector3& mom, double charge);
 
-  TVector3 getPos(double tracklength) const;
-  void getPosMom(double tracklength, TVector3& pos, TVector3& mom) const;
-  void getPosDir(double tracklength, TVector3& pos, TVector3& dir) const {
-    getPosMom(tracklength, pos, dir);
-    dir.SetMag(1);
-  }
-
-
- private:
-
-  double sgn_;
-  double mom_;
-  double R_; // radius
-  TVector3 center_;
-  double alpha0_;
-  double theta_;
+    TVector3 getPos(double tracklength) const;
+    void getPosMom(double tracklength, TVector3& pos, TVector3& mom) const;
+    void getPosDir(double tracklength, TVector3& pos, TVector3& dir) const
+    {
+      getPosMom(tracklength, pos, dir);
+      dir.SetMag(1);
+    }
 
 
- public:
-  ClassDef(HelixTrackModel,1)
+  private:
 
-};
+    double sgn_;
+    double mom_;
+    double R_; // radius
+    TVector3 center_;
+    double alpha0_;
+    double theta_;
+
+
+  public:
+    ClassDef(HelixTrackModel, 1)
+
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/utilities/include/MeasurementCreator.h
+++ b/utilities/include/MeasurementCreator.h
@@ -39,91 +39,92 @@
 namespace genfit {
 
 
-enum eMeasurementType { Pixel = 0,
-        Spacepoint,
-        ProlateSpacepoint,
-        StripU,
-        StripV,
-        StripUV,
-	Wire,
-	WirePoint,
-	nMeasurementTypes
-        };
+  enum eMeasurementType { Pixel = 0,
+                          Spacepoint,
+                          ProlateSpacepoint,
+                          StripU,
+                          StripV,
+                          StripUV,
+                          Wire,
+                          WirePoint,
+                          nMeasurementTypes
+                        };
 
 
-/**
- * @brief Create different measurement types along a HelixTrackModel for testing purposes.
- */
-class MeasurementCreator : public TObject {
+  /**
+   * @brief Create different measurement types along a HelixTrackModel for testing purposes.
+   */
+  class MeasurementCreator : public TObject {
 
 
- public:
+  public:
 
-  // Constructors/Destructors ---------
-  MeasurementCreator();
+    // Constructors/Destructors ---------
+    MeasurementCreator();
 
-  ~MeasurementCreator() {delete trackModel_;}
+    ~MeasurementCreator() {delete trackModel_;}
 
-  //! Takes ownership!
-  void setTrackModel(const HelixTrackModel* model) {delete trackModel_; trackModel_ = model;}
-  void setResolution(double resolution) {resolution_ = resolution;}
-  void setResolutionWire(double resolutionWire) {resolutionWire_ = resolutionWire;}
-  void setOutlierProb(double outlierProb) {outlierProb_ = outlierProb;}
-  void setOutlierRange(double outlierRange) {outlierRange_ = outlierRange;}
-  void setThetaDetPlane(double thetaDetPlane) {thetaDetPlane_ = thetaDetPlane;}
-  void setPhiDetPlane(double phiDetPlane) {phiDetPlane_ = phiDetPlane;}
-  void setWireDir(const TVector3 wireDir) {wireDir_ = wireDir; wireDir_.SetMag(1.);}
-  void setMinDrift(double minDrift) {minDrift_ = minDrift;}
-  void setMaxDrift(double maxDrift) {maxDrift_ = maxDrift;}
-  void setIdealLRResolution(bool idealLRResolution) {idealLRResolution_ = idealLRResolution;}
-  void setUseSkew(bool useSkew) {useSkew_ = useSkew;}
-  void setSkewAngle(double skewAngle) {skewAngle_ = skewAngle;}
-  void setNSuperLayer(int nSuperLayer) {nSuperLayer_ = nSuperLayer;}
-  void setDebug(bool debug) {debug_ = debug;}
-
-
-  std::vector<genfit::AbsMeasurement*> create(eMeasurementType, double tracklength, bool& outlier, int& lr);
-  std::vector<genfit::AbsMeasurement*> create(eMeasurementType type, double tracklength) {
-    bool dummy1;
-    int dummy2;
-    return create(type, tracklength, dummy1, dummy2);
-  }
-
-  void reset();
-
- private:
-
-  const HelixTrackModel* trackModel_; // ownership
-
-  double resolution_;  // cm; resolution of generated measurements
-  double resolutionWire_;  // cm; resolution in wire direction of generated measurements (wire and prolate sp measurements)
-
-  double outlierProb_;
-  double outlierRange_;
-
-  // planarMeasurement specific
-  double thetaDetPlane_; // degree
-  double phiDetPlane_; // degree
-
-  // WireMeasurement specific
-  int wireCounter_;
-  TVector3 wireDir_;
-  double minDrift_;
-  double maxDrift_;
-  bool idealLRResolution_; // resolve the l/r ambiguities of the wire measurements
-  bool useSkew_;
-  double skewAngle_;
-  int nSuperLayer_;
-
-  // misc
-  int measurementCounter_;
-  bool debug_;
+    //! Takes ownership!
+    void setTrackModel(const HelixTrackModel* model) {delete trackModel_; trackModel_ = model;}
+    void setResolution(double resolution) {resolution_ = resolution;}
+    void setResolutionWire(double resolutionWire) {resolutionWire_ = resolutionWire;}
+    void setOutlierProb(double outlierProb) {outlierProb_ = outlierProb;}
+    void setOutlierRange(double outlierRange) {outlierRange_ = outlierRange;}
+    void setThetaDetPlane(double thetaDetPlane) {thetaDetPlane_ = thetaDetPlane;}
+    void setPhiDetPlane(double phiDetPlane) {phiDetPlane_ = phiDetPlane;}
+    void setWireDir(const TVector3 wireDir) {wireDir_ = wireDir; wireDir_.SetMag(1.);}
+    void setMinDrift(double minDrift) {minDrift_ = minDrift;}
+    void setMaxDrift(double maxDrift) {maxDrift_ = maxDrift;}
+    void setIdealLRResolution(bool idealLRResolution) {idealLRResolution_ = idealLRResolution;}
+    void setUseSkew(bool useSkew) {useSkew_ = useSkew;}
+    void setSkewAngle(double skewAngle) {skewAngle_ = skewAngle;}
+    void setNSuperLayer(int nSuperLayer) {nSuperLayer_ = nSuperLayer;}
+    void setDebug(bool debug) {debug_ = debug;}
 
 
- public:
-  ClassDef(MeasurementCreator,1)
+    std::vector<genfit::AbsMeasurement*> create(eMeasurementType, double tracklength, bool& outlier, int& lr);
+    std::vector<genfit::AbsMeasurement*> create(eMeasurementType type, double tracklength)
+    {
+      bool dummy1;
+      int dummy2;
+      return create(type, tracklength, dummy1, dummy2);
+    }
 
-};
+    void reset();
+
+  private:
+
+    const HelixTrackModel* trackModel_; // ownership
+
+    double resolution_;  // cm; resolution of generated measurements
+    double resolutionWire_;  // cm; resolution in wire direction of generated measurements (wire and prolate sp measurements)
+
+    double outlierProb_;
+    double outlierRange_;
+
+    // planarMeasurement specific
+    double thetaDetPlane_; // degree
+    double phiDetPlane_; // degree
+
+    // WireMeasurement specific
+    int wireCounter_;
+    TVector3 wireDir_;
+    double minDrift_;
+    double maxDrift_;
+    bool idealLRResolution_; // resolve the l/r ambiguities of the wire measurements
+    bool useSkew_;
+    double skewAngle_;
+    int nSuperLayer_;
+
+    // misc
+    int measurementCounter_;
+    bool debug_;
+
+
+  public:
+    ClassDef(MeasurementCreator, 1)
+
+  };
 
 } /* End of namespace genfit */
 /** @} */

--- a/utilities/include/mySpacepointDetectorHit.h
+++ b/utilities/include/mySpacepointDetectorHit.h
@@ -25,30 +25,30 @@
 
 namespace genfit {
 
-/** @brief Example class for a spacepoint detector hit.
- *
- *  @author Johannes Rauch  (Technische Universit&auml;t M&uuml;nchen, original author)
- *
- */
-class mySpacepointDetectorHit : public TObject {
+  /** @brief Example class for a spacepoint detector hit.
+   *
+   *  @author Johannes Rauch  (Technische Universit&auml;t M&uuml;nchen, original author)
+   *
+   */
+  class mySpacepointDetectorHit : public TObject {
 
- public:
-  mySpacepointDetectorHit() {;}
+  public:
+    mySpacepointDetectorHit() {;}
 
-  mySpacepointDetectorHit(const TVector3& pos, const TMatrixDSym cov)
-  : pos_(pos), cov_(cov) {;}
+    mySpacepointDetectorHit(const TVector3& pos, const TMatrixDSym cov)
+      : pos_(pos), cov_(cov) {;}
 
-  const TVector3 getPos() const {return pos_;}
-  const TMatrixDSym getCov() const {return cov_;}
+    const TVector3 getPos() const {return pos_;}
+    const TMatrixDSym getCov() const {return cov_;}
 
- private:
+  private:
 
-  TVector3 pos_;
-  TMatrixDSym cov_;
+    TVector3 pos_;
+    TMatrixDSym cov_;
 
-  ClassDef(mySpacepointDetectorHit,1)
-};
-/** @} */
+    ClassDef(mySpacepointDetectorHit, 1)
+  };
+  /** @} */
 
 } /* End of namespace genfit */
 

--- a/utilities/include/mySpacepointMeasurement.h
+++ b/utilities/include/mySpacepointMeasurement.h
@@ -27,38 +27,38 @@
 
 namespace genfit {
 
-/** @brief Example class for a spacepoint measurement which can be created
- * from mySpacepointDetectorHit via the MeasurementFactory.
- *
- *  @author Johannes Rauch  (Technische Universit&auml;t M&uuml;nchen, original author)
- *
- */
-class mySpacepointMeasurement : public SpacepointMeasurement {
+  /** @brief Example class for a spacepoint measurement which can be created
+   * from mySpacepointDetectorHit via the MeasurementFactory.
+   *
+   *  @author Johannes Rauch  (Technische Universit&auml;t M&uuml;nchen, original author)
+   *
+   */
+  class mySpacepointMeasurement : public SpacepointMeasurement {
 
- public:
+  public:
 
-  /** Default constructor for ROOT IO. */
-  mySpacepointMeasurement() :
-     SpacepointMeasurement() {;}
+    /** Default constructor for ROOT IO. */
+    mySpacepointMeasurement() :
+      SpacepointMeasurement() {;}
 
-  mySpacepointMeasurement(const mySpacepointDetectorHit* detHit, const TrackCandHit* hit) :
-    SpacepointMeasurement()
-  {
-    rawHitCoords_(0) = detHit->getPos()(0);
-    rawHitCoords_(1) = detHit->getPos()(1);
-    rawHitCoords_(2) = detHit->getPos()(2);
-    rawHitCov_ = detHit->getCov();
-    detId_ = hit->getDetId();
-    hitId_ = hit->getHitId();
+    mySpacepointMeasurement(const mySpacepointDetectorHit* detHit, const TrackCandHit* hit) :
+      SpacepointMeasurement()
+    {
+      rawHitCoords_(0) = detHit->getPos()(0);
+      rawHitCoords_(1) = detHit->getPos()(1);
+      rawHitCoords_(2) = detHit->getPos()(2);
+      rawHitCov_ = detHit->getCov();
+      detId_ = hit->getDetId();
+      hitId_ = hit->getHitId();
 
-    this -> initG();
-  }
+      this -> initG();
+    }
 
-  virtual mySpacepointMeasurement* clone() const {return new mySpacepointMeasurement(*this);}
+    virtual mySpacepointMeasurement* clone() const {return new mySpacepointMeasurement(*this);}
 
-  ClassDef(mySpacepointMeasurement,1)
-};
-/** @} */
+    ClassDef(mySpacepointMeasurement, 1)
+  };
+  /** @} */
 
 } /* End of namespace genfit */
 

--- a/utilities/src/HelixTrackModel.cc
+++ b/utilities/src/HelixTrackModel.cc
@@ -25,71 +25,74 @@
 
 namespace genfit {
 
-HelixTrackModel::HelixTrackModel(const TVector3& pos, const TVector3& mom, double charge) {
+  HelixTrackModel::HelixTrackModel(const TVector3& pos, const TVector3& mom, double charge)
+  {
 
-  mom_ = mom.Mag();
+    mom_ = mom.Mag();
 
-  TVector3 B = genfit::FieldManager::getInstance()->getFieldVal(pos);
+    TVector3 B = genfit::FieldManager::getInstance()->getFieldVal(pos);
 
-  // B must point in Z direction
-  assert(B.X() == 0);
-  assert(B.Y() == 0);
+    // B must point in Z direction
+    assert(B.X() == 0);
+    assert(B.Y() == 0);
 
-  double Bz = B.Z();
+    double Bz = B.Z();
 
-  // calc helix parameters
-  TVector3 dir2D(mom);
-  dir2D.SetZ(0);
-  dir2D.SetMag(1.);
-  R_ = 100.*mom.Perp()/(0.0299792458*Bz) / fabs(charge);
-  sgn_ = 1;
-  if (charge<0) sgn_=-1.;
-  center_ = pos + sgn_ * R_ * dir2D.Orthogonal();
-  alpha0_ = (pos-center_).Phi();
+    // calc helix parameters
+    TVector3 dir2D(mom);
+    dir2D.SetZ(0);
+    dir2D.SetMag(1.);
+    R_ = 100.*mom.Perp() / (0.0299792458 * Bz) / fabs(charge);
+    sgn_ = 1;
+    if (charge < 0) sgn_ = -1.;
+    center_ = pos + sgn_ * R_ * dir2D.Orthogonal();
+    alpha0_ = (pos - center_).Phi();
 
-  theta_ = mom.Theta();
+    theta_ = mom.Theta();
 
-  //std::cout<<"radius " << R_ << "  center ";
-  //center_.Print();
+    //std::cout<<"radius " << R_ << "  center ";
+    //center_.Print();
 
-}
+  }
 
 
-TVector3 HelixTrackModel::getPos(double tracklength) const {
+  TVector3 HelixTrackModel::getPos(double tracklength) const
+  {
 
-  TVector3 pos;
+    TVector3 pos;
 
-  double angle = alpha0_ - sgn_ * tracklength / R_ * sin(theta_);
+    double angle = alpha0_ - sgn_ * tracklength / R_ * sin(theta_);
 
-  TVector3 radius(R_,0,0);
-  radius.SetPhi(angle);
-  pos = center_ + radius;
-  pos.SetZ(center_.Z() - sgn_ * ((alpha0_-angle)*R_ * tan(theta_-M_PI/2.)) );
+    TVector3 radius(R_, 0, 0);
+    radius.SetPhi(angle);
+    pos = center_ + radius;
+    pos.SetZ(center_.Z() - sgn_ * ((alpha0_ - angle)*R_ * tan(theta_ - M_PI / 2.)));
 
-  return pos;
-}
+    return pos;
+  }
 
-void HelixTrackModel::getPosMom(double tracklength, TVector3& pos, TVector3& mom) const {
+  void HelixTrackModel::getPosMom(double tracklength, TVector3& pos, TVector3& mom) const
+  {
 
-  double angle = alpha0_ - sgn_ * tracklength / R_ * sin(theta_);
+    double angle = alpha0_ - sgn_ * tracklength / R_ * sin(theta_);
 
-  TVector3 radius(R_,0,0);
-  radius.SetPhi(angle);
-  pos = center_ + radius;
-  pos.SetZ(center_.Z() - sgn_ * ((alpha0_-angle)*R_ * tan(theta_-M_PI/2.)) );
+    TVector3 radius(R_, 0, 0);
+    radius.SetPhi(angle);
+    pos = center_ + radius;
+    pos.SetZ(center_.Z() - sgn_ * ((alpha0_ - angle)*R_ * tan(theta_ - M_PI / 2.)));
 
-  mom.SetXYZ(1,1,1);
-  mom.SetTheta(theta_);
-  mom.SetPhi(angle - sgn_*M_PI/2.);
-  mom.SetMag(mom_);
+    mom.SetXYZ(1, 1, 1);
+    mom.SetTheta(theta_);
+    mom.SetPhi(angle - sgn_ * M_PI / 2.);
+    mom.SetMag(mom_);
 
-  /*std::cout<<"tracklength " << tracklength << "\n";
-  std::cout<<"angle " << angle << "\n";
-  std::cout<<"radius vector "; radius.Print();
-  std::cout<<"pos "; pos.Print();
-  std::cout<<"mom "; mom.Print();*/
+    /*std::cout<<"tracklength " << tracklength << "\n";
+    std::cout<<"angle " << angle << "\n";
+    std::cout<<"radius vector "; radius.Print();
+    std::cout<<"pos "; pos.Print();
+    std::cout<<"mom "; mom.Print();*/
 
-}
+  }
 
 
 } /* End of namespace genfit */

--- a/utilities/src/MeasurementCreator.cc
+++ b/utilities/src/MeasurementCreator.cc
@@ -35,7 +35,7 @@
 
 namespace genfit {
 
-MeasurementCreator::MeasurementCreator() :
+  MeasurementCreator::MeasurementCreator() :
     trackModel_(nullptr),
     resolution_(0.01),
     resolutionWire_(0.1),
@@ -44,7 +44,7 @@ MeasurementCreator::MeasurementCreator() :
     thetaDetPlane_(90),
     phiDetPlane_(0),
     wireCounter_(0),
-    wireDir_(0.,0.,1.),
+    wireDir_(0., 0., 1.),
     minDrift_(0),
     maxDrift_(2),
     idealLRResolution_(true),
@@ -53,292 +53,289 @@ MeasurementCreator::MeasurementCreator() :
     nSuperLayer_(5),
     measurementCounter_(0),
     debug_(false)
-{
-  ;
-}
-
-
-std::vector<genfit::AbsMeasurement*> MeasurementCreator::create(eMeasurementType type, double tracklength, bool& outlier, int& lr) {
-
-  outlier = false;
-  lr = 0;
-  std::vector<AbsMeasurement*> retVal;
-  genfit::AbsMeasurement* measurement;
-
-  TVector3 point, dir;
-  trackModel_->getPosDir(tracklength, point, dir);
-
-
-  TVector3 planeNorm(dir);
-  planeNorm.SetTheta(thetaDetPlane_*TMath::Pi()/180);
-  planeNorm.SetPhi(planeNorm.Phi()+phiDetPlane_);
-  static const TVector3 z(0,0,1);
-  static const TVector3 x(1,0,0);
-
-
-  TVector3 currentWireDir(wireDir_);
-  TVector3 wirePerp;
-
-  if (type == Wire ||
-      type == WirePoint){
-
-    // skew layers
-    if (useSkew_ && (int)((double)wireCounter_/(double)nSuperLayer_)%2 == 1) {
-      TVector3 perp(wireDir_.Cross(dir));
-      if ((int)((double)wireCounter_/(double)nSuperLayer_)%4 == 1){
-        currentWireDir.Rotate(skewAngle_*TMath::Pi()/180, wireDir_.Cross(perp));
-      }
-      else currentWireDir.Rotate(-skewAngle_*TMath::Pi()/180, wireDir_.Cross(perp));
-    }
-    currentWireDir.SetMag(1.);
-
-    // left/right
-    lr = 1;
-    wirePerp = dir.Cross(currentWireDir);
-    if (gRandom->Uniform(-1,1) >= 0) {
-      wirePerp *= -1.;
-      lr = -1;
-    }
-    wirePerp.SetMag(gRandom->Uniform(minDrift_, maxDrift_));
-  }
-
-  if (outlierProb_ > gRandom->Uniform(1.)) {
-    outlier = true;
-    if(debug_)  std::cerr << "create outlier" << std::endl;
+  {
+    ;
   }
 
 
-  switch(type){
-    case Pixel: {
-      if (debug_) std::cerr << "create PixHit" << std::endl;
+  std::vector<genfit::AbsMeasurement*> MeasurementCreator::create(eMeasurementType type, double tracklength, bool& outlier, int& lr)
+  {
 
-      genfit::SharedPlanePtr plane(new genfit::DetPlane(point, planeNorm.Cross(z), (planeNorm.Cross(z)).Cross(planeNorm)));
+    outlier = false;
+    lr = 0;
+    std::vector<AbsMeasurement*> retVal;
+    genfit::AbsMeasurement* measurement;
 
-      TVectorD hitCoords(2);
-      if (outlier) {
-        hitCoords(0) = gRandom->Uniform(-outlierRange_, outlierRange_);
-        hitCoords(1) = gRandom->Uniform(-outlierRange_, outlierRange_);
+    TVector3 point, dir;
+    trackModel_->getPosDir(tracklength, point, dir);
+
+
+    TVector3 planeNorm(dir);
+    planeNorm.SetTheta(thetaDetPlane_ * TMath::Pi() / 180);
+    planeNorm.SetPhi(planeNorm.Phi() + phiDetPlane_);
+    static const TVector3 z(0, 0, 1);
+    static const TVector3 x(1, 0, 0);
+
+
+    TVector3 currentWireDir(wireDir_);
+    TVector3 wirePerp;
+
+    if (type == Wire ||
+        type == WirePoint) {
+
+      // skew layers
+      if (useSkew_ && (int)((double)wireCounter_ / (double)nSuperLayer_) % 2 == 1) {
+        TVector3 perp(wireDir_.Cross(dir));
+        if ((int)((double)wireCounter_ / (double)nSuperLayer_) % 4 == 1) {
+          currentWireDir.Rotate(skewAngle_ * TMath::Pi() / 180, wireDir_.Cross(perp));
+        } else currentWireDir.Rotate(-skewAngle_ * TMath::Pi() / 180, wireDir_.Cross(perp));
       }
-      else {
-        hitCoords(0) = gRandom->Gaus(0,resolution_);
-        hitCoords(1) = gRandom->Gaus(0,resolution_);
+      currentWireDir.SetMag(1.);
+
+      // left/right
+      lr = 1;
+      wirePerp = dir.Cross(currentWireDir);
+      if (gRandom->Uniform(-1, 1) >= 0) {
+        wirePerp *= -1.;
+        lr = -1;
       }
-
-      TMatrixDSym hitCov(2);
-      hitCov(0,0) = resolution_*resolution_;
-      hitCov(1,1) = resolution_*resolution_;
-
-      measurement = new genfit::PlanarMeasurement(hitCoords, hitCov, int(type), measurementCounter_, nullptr);
-      static_cast<genfit::PlanarMeasurement*>(measurement)->setPlane(plane, measurementCounter_);
-      retVal.push_back(measurement);
+      wirePerp.SetMag(gRandom->Uniform(minDrift_, maxDrift_));
     }
-    break;
 
-    case Spacepoint: {
-      if (debug_) std::cerr << "create SpacepointHit" << std::endl;
-
-      TVectorD hitCoords(3);
-      if (outlier) {
-        hitCoords(0) = gRandom->Uniform(point.X()-outlierRange_, point.X()+outlierRange_);
-        hitCoords(1) = gRandom->Uniform(point.Y()-outlierRange_, point.Y()+outlierRange_);
-        hitCoords(2) = gRandom->Uniform(point.Z()-outlierRange_, point.Z()+outlierRange_);
-      }
-      else {
-        hitCoords(0) = gRandom->Gaus(point.X(),resolution_);
-        hitCoords(1) = gRandom->Gaus(point.Y(),resolution_);
-        hitCoords(2) = gRandom->Gaus(point.Z(),resolution_);
-      }
-
-      TMatrixDSym hitCov(3);
-      hitCov(0,0) = resolution_*resolution_;
-      hitCov(1,1) = resolution_*resolution_;
-      hitCov(2,2) = resolution_*resolution_;
-
-      measurement = new genfit::SpacepointMeasurement(hitCoords, hitCov, int(type), measurementCounter_, nullptr);
-      retVal.push_back(measurement);
+    if (outlierProb_ > gRandom->Uniform(1.)) {
+      outlier = true;
+      if (debug_)  std::cerr << "create outlier" << std::endl;
     }
-    break;
-
-    case ProlateSpacepoint: {
-      if (debug_) std::cerr << "create ProlateSpacepointHit" << std::endl;
-
-      TVectorD hitCoords(3);
-      if (outlier) {
-        hitCoords(0) = gRandom->Uniform(point.X()-outlierRange_, point.X()+outlierRange_);
-        hitCoords(1) = gRandom->Uniform(point.Y()-outlierRange_, point.Y()+outlierRange_);
-        hitCoords(2) = gRandom->Uniform(point.Z()-outlierRange_, point.Z()+outlierRange_);
-      }
-      else {
-        hitCoords(0) = point.X();
-        hitCoords(1) = point.Y();
-        hitCoords(2) = point.Z();
-      }
-
-      TMatrixDSym hitCov(3);
-      hitCov(0,0) = resolution_*resolution_;
-      hitCov(1,1) = resolution_*resolution_;
-      hitCov(2,2) = resolutionWire_*resolutionWire_;
-
-      // rotation matrix
-      TVector3 xp = currentWireDir.Orthogonal();
-      xp.SetMag(1);
-      TVector3 yp = currentWireDir.Cross(xp);
-      yp.SetMag(1);
-
-      TMatrixD rot(3,3);
-
-      rot(0,0) = xp.X();  rot(0,1) = yp.X();  rot(0,2) = currentWireDir.X();
-      rot(1,0) = xp.Y();  rot(1,1) = yp.Y();  rot(1,2) = currentWireDir.Y();
-      rot(2,0) = xp.Z();  rot(2,1) = yp.Z();  rot(2,2) = currentWireDir.Z();
-
-      // smear
-      TVectorD smearVec(3);
-      smearVec(0) = resolution_;
-      smearVec(1) = resolution_;
-      smearVec(2) = resolutionWire_;
-      smearVec *= rot;
-      if (!outlier) {
-        hitCoords(0) += gRandom->Gaus(0, smearVec(0));
-        hitCoords(1) += gRandom->Gaus(0, smearVec(1));
-        hitCoords(2) += gRandom->Gaus(0, smearVec(2));
-      }
 
 
-      // rotate cov
-      hitCov.Similarity(rot);
+    switch (type) {
+      case Pixel: {
+        if (debug_) std::cerr << "create PixHit" << std::endl;
 
-      measurement = new genfit::ProlateSpacepointMeasurement(hitCoords, hitCov, int(type), measurementCounter_, nullptr);
-      static_cast<genfit::ProlateSpacepointMeasurement*>(measurement)->setLargestErrorDirection(currentWireDir);
-      retVal.push_back(measurement);
-    }
-    break;
+        genfit::SharedPlanePtr plane(new genfit::DetPlane(point, planeNorm.Cross(z), (planeNorm.Cross(z)).Cross(planeNorm)));
 
-    case StripU: case StripV: case StripUV : {
-      if (debug_) std::cerr << "create StripHit" << std::endl;
-
-      TVector3 vU, vV;
-      vU = planeNorm.Cross(z);
-      vV = (planeNorm.Cross(z)).Cross(planeNorm);
-      genfit::SharedPlanePtr plane(new genfit::DetPlane(point, vU, vV));
-
-      TVectorD hitCoords(1);
-      if (outlier)
-        hitCoords(0) = gRandom->Uniform(-outlierRange_, outlierRange_);
-      else
-        hitCoords(0) = gRandom->Gaus(0,resolution_);
-
-      TMatrixDSym hitCov(1);
-      hitCov(0,0) = resolution_*resolution_;
-
-      measurement = new genfit::PlanarMeasurement(hitCoords, hitCov, int(type), measurementCounter_, nullptr);
-      static_cast<genfit::PlanarMeasurement*>(measurement)->setPlane(plane, measurementCounter_);
-      if (type == StripV)
-        static_cast<genfit::PlanarMeasurement*>(measurement)->setStripV();
-      retVal.push_back(measurement);
-
-
-      if (type == StripUV) {
-        if (outlier)
+        TVectorD hitCoords(2);
+        if (outlier) {
           hitCoords(0) = gRandom->Uniform(-outlierRange_, outlierRange_);
-        else
-          hitCoords(0) = gRandom->Gaus(0,resolution_);
+          hitCoords(1) = gRandom->Uniform(-outlierRange_, outlierRange_);
+        } else {
+          hitCoords(0) = gRandom->Gaus(0, resolution_);
+          hitCoords(1) = gRandom->Gaus(0, resolution_);
+        }
 
-        hitCov(0,0) = resolution_*resolution_;
+        TMatrixDSym hitCov(2);
+        hitCov(0, 0) = resolution_ * resolution_;
+        hitCov(1, 1) = resolution_ * resolution_;
 
         measurement = new genfit::PlanarMeasurement(hitCoords, hitCov, int(type), measurementCounter_, nullptr);
         static_cast<genfit::PlanarMeasurement*>(measurement)->setPlane(plane, measurementCounter_);
-        static_cast<genfit::PlanarMeasurement*>(measurement)->setStripV();
         retVal.push_back(measurement);
       }
+      break;
+
+      case Spacepoint: {
+        if (debug_) std::cerr << "create SpacepointHit" << std::endl;
+
+        TVectorD hitCoords(3);
+        if (outlier) {
+          hitCoords(0) = gRandom->Uniform(point.X() - outlierRange_, point.X() + outlierRange_);
+          hitCoords(1) = gRandom->Uniform(point.Y() - outlierRange_, point.Y() + outlierRange_);
+          hitCoords(2) = gRandom->Uniform(point.Z() - outlierRange_, point.Z() + outlierRange_);
+        } else {
+          hitCoords(0) = gRandom->Gaus(point.X(), resolution_);
+          hitCoords(1) = gRandom->Gaus(point.Y(), resolution_);
+          hitCoords(2) = gRandom->Gaus(point.Z(), resolution_);
+        }
+
+        TMatrixDSym hitCov(3);
+        hitCov(0, 0) = resolution_ * resolution_;
+        hitCov(1, 1) = resolution_ * resolution_;
+        hitCov(2, 2) = resolution_ * resolution_;
+
+        measurement = new genfit::SpacepointMeasurement(hitCoords, hitCov, int(type), measurementCounter_, nullptr);
+        retVal.push_back(measurement);
+      }
+      break;
+
+      case ProlateSpacepoint: {
+        if (debug_) std::cerr << "create ProlateSpacepointHit" << std::endl;
+
+        TVectorD hitCoords(3);
+        if (outlier) {
+          hitCoords(0) = gRandom->Uniform(point.X() - outlierRange_, point.X() + outlierRange_);
+          hitCoords(1) = gRandom->Uniform(point.Y() - outlierRange_, point.Y() + outlierRange_);
+          hitCoords(2) = gRandom->Uniform(point.Z() - outlierRange_, point.Z() + outlierRange_);
+        } else {
+          hitCoords(0) = point.X();
+          hitCoords(1) = point.Y();
+          hitCoords(2) = point.Z();
+        }
+
+        TMatrixDSym hitCov(3);
+        hitCov(0, 0) = resolution_ * resolution_;
+        hitCov(1, 1) = resolution_ * resolution_;
+        hitCov(2, 2) = resolutionWire_ * resolutionWire_;
+
+        // rotation matrix
+        TVector3 xp = currentWireDir.Orthogonal();
+        xp.SetMag(1);
+        TVector3 yp = currentWireDir.Cross(xp);
+        yp.SetMag(1);
+
+        TMatrixD rot(3, 3);
+
+        rot(0, 0) = xp.X();  rot(0, 1) = yp.X();  rot(0, 2) = currentWireDir.X();
+        rot(1, 0) = xp.Y();  rot(1, 1) = yp.Y();  rot(1, 2) = currentWireDir.Y();
+        rot(2, 0) = xp.Z();  rot(2, 1) = yp.Z();  rot(2, 2) = currentWireDir.Z();
+
+        // smear
+        TVectorD smearVec(3);
+        smearVec(0) = resolution_;
+        smearVec(1) = resolution_;
+        smearVec(2) = resolutionWire_;
+        smearVec *= rot;
+        if (!outlier) {
+          hitCoords(0) += gRandom->Gaus(0, smearVec(0));
+          hitCoords(1) += gRandom->Gaus(0, smearVec(1));
+          hitCoords(2) += gRandom->Gaus(0, smearVec(2));
+        }
+
+
+        // rotate cov
+        hitCov.Similarity(rot);
+
+        measurement = new genfit::ProlateSpacepointMeasurement(hitCoords, hitCov, int(type), measurementCounter_, nullptr);
+        static_cast<genfit::ProlateSpacepointMeasurement*>(measurement)->setLargestErrorDirection(currentWireDir);
+        retVal.push_back(measurement);
+      }
+      break;
+
+      case StripU: case StripV: case StripUV : {
+        if (debug_) std::cerr << "create StripHit" << std::endl;
+
+        TVector3 vU, vV;
+        vU = planeNorm.Cross(z);
+        vV = (planeNorm.Cross(z)).Cross(planeNorm);
+        genfit::SharedPlanePtr plane(new genfit::DetPlane(point, vU, vV));
+
+        TVectorD hitCoords(1);
+        if (outlier)
+          hitCoords(0) = gRandom->Uniform(-outlierRange_, outlierRange_);
+        else
+          hitCoords(0) = gRandom->Gaus(0, resolution_);
+
+        TMatrixDSym hitCov(1);
+        hitCov(0, 0) = resolution_ * resolution_;
+
+        measurement = new genfit::PlanarMeasurement(hitCoords, hitCov, int(type), measurementCounter_, nullptr);
+        static_cast<genfit::PlanarMeasurement*>(measurement)->setPlane(plane, measurementCounter_);
+        if (type == StripV)
+          static_cast<genfit::PlanarMeasurement*>(measurement)->setStripV();
+        retVal.push_back(measurement);
+
+
+        if (type == StripUV) {
+          if (outlier)
+            hitCoords(0) = gRandom->Uniform(-outlierRange_, outlierRange_);
+          else
+            hitCoords(0) = gRandom->Gaus(0, resolution_);
+
+          hitCov(0, 0) = resolution_ * resolution_;
+
+          measurement = new genfit::PlanarMeasurement(hitCoords, hitCov, int(type), measurementCounter_, nullptr);
+          static_cast<genfit::PlanarMeasurement*>(measurement)->setPlane(plane, measurementCounter_);
+          static_cast<genfit::PlanarMeasurement*>(measurement)->setStripV();
+          retVal.push_back(measurement);
+        }
+      }
+      break;
+
+      case Wire: {
+        if (debug_) std::cerr << "create WireHit" << std::endl;
+
+        if (outlier) {
+          wirePerp.SetMag(gRandom->Uniform(outlierRange_));
+        }
+
+        TVectorD hitCoords(7);
+        hitCoords(0) = (point - wirePerp - currentWireDir).X();
+        hitCoords(1) = (point - wirePerp - currentWireDir).Y();
+        hitCoords(2) = (point - wirePerp - currentWireDir).Z();
+
+        hitCoords(3) = (point - wirePerp + currentWireDir).X();
+        hitCoords(4) = (point - wirePerp + currentWireDir).Y();
+        hitCoords(5) = (point - wirePerp + currentWireDir).Z();
+
+        if (outlier)
+          hitCoords(6) = gRandom->Uniform(outlierRange_);
+        else
+          hitCoords(6) = gRandom->Gaus(wirePerp.Mag(), resolution_);
+
+        TMatrixDSym hitCov(7);
+        hitCov(6, 6) = resolution_ * resolution_;
+
+
+        measurement = new genfit::WireMeasurement(hitCoords, hitCov, int(type), measurementCounter_, nullptr);
+        if (idealLRResolution_) {
+          static_cast<genfit::WireMeasurement*>(measurement)->setLeftRightResolution(lr);
+        }
+        ++wireCounter_;
+        retVal.push_back(measurement);
+      }
+      break;
+
+      case WirePoint: {
+        if (debug_) std::cerr << "create WirePointHit" << std::endl;
+
+        if (outlier) {
+          wirePerp.SetMag(gRandom->Uniform(outlierRange_));
+        }
+
+        TVectorD hitCoords(8);
+        hitCoords(0) = (point - wirePerp - currentWireDir).X();
+        hitCoords(1) = (point - wirePerp - currentWireDir).Y();
+        hitCoords(2) = (point - wirePerp - currentWireDir).Z();
+
+        hitCoords(3) = (point - wirePerp + currentWireDir).X();
+        hitCoords(4) = (point - wirePerp + currentWireDir).Y();
+        hitCoords(5) = (point - wirePerp + currentWireDir).Z();
+
+        if (outlier) {
+          hitCoords(6) = gRandom->Uniform(outlierRange_);
+          hitCoords(7) = gRandom->Uniform(currentWireDir.Mag() - outlierRange_, currentWireDir.Mag() + outlierRange_);
+        } else {
+          hitCoords(6) = gRandom->Gaus(wirePerp.Mag(), resolution_);
+          hitCoords(7) = gRandom->Gaus(currentWireDir.Mag(), resolutionWire_);
+        }
+
+
+        TMatrixDSym hitCov(8);
+        hitCov(6, 6) = resolution_ * resolution_;
+        hitCov(7, 7) = resolutionWire_ * resolutionWire_;
+
+        measurement = new genfit::WirePointMeasurement(hitCoords, hitCov, int(type), measurementCounter_, nullptr);
+        if (idealLRResolution_) {
+          static_cast<genfit::WirePointMeasurement*>(measurement)->setLeftRightResolution(lr);
+        }
+        ++wireCounter_;
+        retVal.push_back(measurement);
+      }
+      break;
+
+      default:
+        std::cerr << "measurement type not defined!" << std::endl;
+        exit(0);
     }
-    break;
 
-    case Wire: {
-      if (debug_) std::cerr << "create WireHit" << std::endl;
+    return retVal;
 
-      if (outlier) {
-        wirePerp.SetMag(gRandom->Uniform(outlierRange_));
-      }
-
-      TVectorD hitCoords(7);
-      hitCoords(0) = (point-wirePerp-currentWireDir).X();
-      hitCoords(1) = (point-wirePerp-currentWireDir).Y();
-      hitCoords(2) = (point-wirePerp-currentWireDir).Z();
-
-      hitCoords(3) = (point-wirePerp+currentWireDir).X();
-      hitCoords(4) = (point-wirePerp+currentWireDir).Y();
-      hitCoords(5) = (point-wirePerp+currentWireDir).Z();
-
-      if (outlier)
-        hitCoords(6) = gRandom->Uniform(outlierRange_);
-      else
-        hitCoords(6) = gRandom->Gaus(wirePerp.Mag(), resolution_);
-
-      TMatrixDSym hitCov(7);
-      hitCov(6,6) = resolution_*resolution_;
-
-
-      measurement = new genfit::WireMeasurement(hitCoords, hitCov, int(type), measurementCounter_, nullptr);
-      if (idealLRResolution_){
-        static_cast<genfit::WireMeasurement*>(measurement)->setLeftRightResolution(lr);
-      }
-      ++wireCounter_;
-      retVal.push_back(measurement);
-    }
-    break;
-
-    case WirePoint: {
-      if (debug_) std::cerr << "create WirePointHit" << std::endl;
-
-      if (outlier) {
-        wirePerp.SetMag(gRandom->Uniform(outlierRange_));
-      }
-
-      TVectorD hitCoords(8);
-      hitCoords(0) = (point-wirePerp-currentWireDir).X();
-      hitCoords(1) = (point-wirePerp-currentWireDir).Y();
-      hitCoords(2) = (point-wirePerp-currentWireDir).Z();
-
-      hitCoords(3) = (point-wirePerp+currentWireDir).X();
-      hitCoords(4) = (point-wirePerp+currentWireDir).Y();
-      hitCoords(5) = (point-wirePerp+currentWireDir).Z();
-
-      if (outlier) {
-        hitCoords(6) = gRandom->Uniform(outlierRange_);
-        hitCoords(7) = gRandom->Uniform(currentWireDir.Mag()-outlierRange_, currentWireDir.Mag()+outlierRange_);
-      }
-      else {
-        hitCoords(6) = gRandom->Gaus(wirePerp.Mag(), resolution_);
-        hitCoords(7) = gRandom->Gaus(currentWireDir.Mag(), resolutionWire_);
-      }
-
-
-      TMatrixDSym hitCov(8);
-      hitCov(6,6) = resolution_*resolution_;
-      hitCov(7,7) = resolutionWire_*resolutionWire_;
-
-      measurement = new genfit::WirePointMeasurement(hitCoords, hitCov, int(type), measurementCounter_, nullptr);
-      if (idealLRResolution_){
-        static_cast<genfit::WirePointMeasurement*>(measurement)->setLeftRightResolution(lr);
-      }
-      ++wireCounter_;
-      retVal.push_back(measurement);
-    }
-    break;
-
-    default:
-      std::cerr << "measurement type not defined!" << std::endl;
-      exit(0);
   }
 
-  return retVal;
 
-}
-
-
-void MeasurementCreator::reset() {
-  wireCounter_ = 0;
-  measurementCounter_ = 0;
-}
+  void MeasurementCreator::reset()
+  {
+    wireCounter_ = 0;
+    measurementCounter_ = 0;
+  }
 
 } /* End of namespace genfit */


### PR DESCRIPTION
I just run `astyle 3.1` over the whole GenFit codebase. I did not touch anything else.

(Namely, the command I run was `find . -type f -exec b2code-style-fix {} \;`, and the `git add *`.)

The astyle options used are these: https://github.com/belle2/tools/blob/main/b2code-style-fix#L44-L64