### PR TITLE
Moving from travis.ci to github-actions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -32,6 +32,7 @@ jobs:
        
     - name: Build GenFit
       run: |
+        source root/bin/thisroot.sh
         cd ${{github.workspace}} && ls
         cd ${{github.workspace}} && cd .. && mkdir build && cd build
         cmake ../GenFit

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Run Tests
       run: |
         source root/bin/thisroot.sh
-        cd build
+        cd ${{github.workspace}} && cd ../build
         ctest
         
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,4 +29,11 @@ jobs:
         wget https://root.cern.ch/download/${ROOT_VERSION}
         tar xzf ${ROOT_VERSION}
         source root/bin/thisroot.sh
+        
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build
+      
+    - name: Build GenFit
+      run: cmake --build ${{github.workspace}}/build
+        
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -34,15 +34,14 @@ jobs:
     - name: Build GenFit
       run: |
         source root/bin/thisroot.sh
-        cd ${{github.workspace}} && ls
-        cd ${{github.workspace}} && cd .. && mkdir build && cd build
+        cd ${{github.workspace}}/.. && mkdir build && cd build
         cmake ../GenFit
         make
     
     - name: Run Tests
       run: |
         source root/bin/thisroot.sh
-        cd ${{github.workspace}} && cd ../build
+        cd ${{github.workspace}}/../build
         ctest
         
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,11 +29,11 @@ jobs:
         wget https://root.cern.ch/download/${ROOT_VERSION}
         tar xzf ${ROOT_VERSION}
         source root/bin/thisroot.sh
-        
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build
-      
+       
     - name: Build GenFit
-      run: cmake --build ${{github.workspace}}/build
+      run: |
+        cd ${{github.workspace}} && mkdir build && cd build
+        cmake ../GenFit
+        make
         
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,6 +38,6 @@ jobs:
       run: |
         source root/bin/thisroot.sh
         cd ${{github.workspace}}/../build
-        ctest
+        ctest  --output-on-failure
         
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,5 +38,8 @@ jobs:
         cd ${{github.workspace}} && cd .. && mkdir build && cd build
         cmake ../GenFit
         make
+    
+    - name: Run Tests
+      run: ctest
         
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,13 +2,12 @@ name: Build and Test
 
 on: [push, pull_request]
 
+env:
+  ROOT_VERSION: root_v6.24.06.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
+
 jobs:
   build:
-    strategy:
-      matrix:
-        ubuntu: [20, 22]
-        
-    runs-on: ubuntu-${{ matrix.ubuntu}}.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3
@@ -24,7 +23,6 @@ jobs:
 
     - name: Install root
       run: |
-        export ROOT_VERSION=root_v6.24.06.Linux-ubuntu${{ matrix.ubuntu }}-x86_64-gcc9.3.tar.gz
         wget https://root.cern.ch/download/${ROOT_VERSION}
         tar xzf ${ROOT_VERSION}
         source root/bin/thisroot.sh

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -40,6 +40,9 @@ jobs:
         make
     
     - name: Run Tests
-      run: ctest
+      run: |
+        source root/bin/thisroot.sh
+        cd build
+        ctest
         
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -32,7 +32,8 @@ jobs:
        
     - name: Build GenFit
       run: |
-        cd ${{github.workspace}} && mkdir build && cd build
+        cd ${{github.workspace}} && ls
+        cd ${{github.workspace}} && cd .. && mkdir build && cd build
         cmake ../GenFit
         make
         

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,10 +1,6 @@
 name: Build and Test
 
-on:
-  push:
-    branches: [ "test-github-actions" ]
-  pull_request:
-    branches: [ "test-github-actions" ]
+on: [push, pull_request]
 
 env:
   ROOT_VERSION: root_v6.24.06.Linux-ubuntu20-x86_64-gcc9.3.tar.gz

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,6 +19,7 @@ jobs:
     - name: Install cmake and gtest
       run: |
         sudo apt-get install cmake libgtest-dev libglu1-mesa
+        sudo apt install libopengl0 -y
         cd /usr/src/gtest
         sudo cmake CMakeLists.txt
         sudo make

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,9 +2,9 @@ name: Build and Test
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "test-github-actions" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "test-github-actions" ]
 
 env:
   ROOT_VERSION: root_v6.24.06.Linux-ubuntu20-x86_64-gcc9.3.tar.gz

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,12 +2,13 @@ name: Build and Test
 
 on: [push, pull_request]
 
-env:
-  ROOT_VERSION: root_v6.24.06.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
-
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        ubuntu: [20, 22]
+        
+    runs-on: ubuntu-${{ matrix.ubuntu}}.04
 
     steps:
     - uses: actions/checkout@v3
@@ -23,6 +24,7 @@ jobs:
 
     - name: Install root
       run: |
+        export ROOT_VERSION=root_v6.24.06.Linux-ubuntu${{ matrix.ubuntu }}-x86_64-gcc9.3.tar.gz
         wget https://root.cern.ch/download/${ROOT_VERSION}
         tar xzf ${ROOT_VERSION}
         source root/bin/thisroot.sh

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,32 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  ROOT_VERSION: root_v6.24.06.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install cmake and gtest
+      run: |
+        sudo apt-get install cmake libgtest-dev libglu1-mesa
+        cd /usr/src/gtest
+        sudo cmake CMakeLists.txt
+        sudo make
+        cd -
+
+    - name: Install root
+      run: |
+        wget https://root.cern.ch/download/${ROOT_VERSION}
+        tar xzf ${ROOT_VERSION}
+        source root/bin/thisroot.sh
+


### PR DESCRIPTION
Since the travis CI stopped working its a good time to transfer the CI to github actions