### PR TITLE
Test against multiple root versions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,16 +2,13 @@ name: Build and Test
 
 on: [push, pull_request]
 
-env:
-  ROOT_VERSION_1: root_v6.24.06.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
-  ROOT_VERSION_2: root_v6.30.02.Linux-ubuntu20.04-x86_64-gcc9.4.tar.gz
 jobs:
   build:
     runs-on: ubuntu-20.04
 
     strategy:
       matrix:
-        ROOT_VERSION: [env.ROOT_VERSION_1, env.ROOT_VERSION_2]
+        ROOT_VERSION: [root_v6.24.06.Linux-ubuntu20-x86_64-gcc9.3.tar.gz, root_v6.30.02.Linux-ubuntu20.04-x86_64-gcc9.4.tar.gz]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -3,11 +3,15 @@ name: Build and Test
 on: [push, pull_request]
 
 env:
-  ROOT_VERSION: root_v6.24.06.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
-
+  ROOT_VERSION_1: root_v6.24.06.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
+  ROOT_VERSION_2: root_v6.30.02.Linux-ubuntu20.04-x86_64-gcc9.4.tar.gz
 jobs:
   build:
     runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        ROOT_VERSION: [${{ env.ROOT_VERSION_1 }}, ${{ env.ROOT_VERSION_2 }}]
 
     steps:
     - uses: actions/checkout@v3
@@ -23,8 +27,8 @@ jobs:
 
     - name: Install root
       run: |
-        wget https://root.cern.ch/download/${ROOT_VERSION}
-        tar xzf ${ROOT_VERSION}
+        wget https://root.cern.ch/download/${{ matrix.ROOT_VERSION }}
+        tar xzf ${{ matrix.ROOT_VERSION }}
         source root/bin/thisroot.sh
        
     - name: Build GenFit
@@ -39,5 +43,3 @@ jobs:
         source root/bin/thisroot.sh
         cd ${{github.workspace}}/../build
         ctest  --output-on-failure
-        
-

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        ROOT_VERSION: ["${{ env.ROOT_VERSION_1 }}", "${{ env.ROOT_VERSION_2 }}"]
+        ROOT_VERSION: [env.ROOT_VERSION_1, env.ROOT_VERSION_2]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        ROOT_VERSION: [${{ env.ROOT_VERSION_1 }}, ${{ env.ROOT_VERSION_2 }}]
+        ROOT_VERSION: ["${{ env.ROOT_VERSION_1 }}", "${{ env.ROOT_VERSION_2 }}"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
As in https://github.com/GenFit/GenFit/pull/127 a failing build with a new ROOT version was observed, testing now also with this ROOT version.