### PR TITLE
Specify genfit as a c++ project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(POLICY CMP0042)
 endif(POLICY CMP0042)
 
 # declare the project name
-PROJECT(genfit2)
+PROJECT(genfit2 LANGUAGES CXX)
 
 # set project version
 SET( ${PROJECT_NAME}_VERSION_MAJOR 2 )


### PR DESCRIPTION
This avoids that CMake also goes looking for a C compiler and speeds up the cmake stage slightly. More importantly it makes genfit build with spack, where it is marked as a c++ project only at the moment.

See, https://github.com/spack/spack/pull/49993 for the fix from the other side on spack.