### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROOT_VERSION: [root_v6.24.06.Linux-ubuntu22-x86_64-gcc9.3.tar.gz, root_v6.30.02.Linux-ubuntu22.04-x86_64-gcc9.4.tar.gz]
+        ROOT_VERSION: [root_v6.24.08.Linux-ubuntu22-x86_64-gcc9.3.tar.gz, root_v6.30.08.Linux-ubuntu22.04-x86_64-gcc9.4.tar.gz]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -4,11 +4,11 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        ROOT_VERSION: [root_v6.24.06.Linux-ubuntu20-x86_64-gcc9.3.tar.gz, root_v6.30.02.Linux-ubuntu20.04-x86_64-gcc9.4.tar.gz]
+        ROOT_VERSION: [root_v6.24.06.Linux-ubuntu22-x86_64-gcc9.3.tar.gz, root_v6.30.02.Linux-ubuntu22.04-x86_64-gcc9.4.tar.gz]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Install cmake and gtest
+    - name: Install cmake, gtest and other packages
       run: |
-        sudo apt-get install cmake libgtest-dev libglu1-mesa xxhash libglew-dev libgl2ps-dev libftgl-dev libopengl0 libtbb-dev
+        sudo apt-get install cmake libgtest-dev libglu1-mesa xxhash libglew-dev libgl2ps-dev libftgl-dev libopengl0 libtbb-dev nlohmann-json3-dev
         cd /usr/src/gtest
         sudo cmake CMakeLists.txt
         sudo make

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROOT_VERSION: [root_v6.24.08.Linux-ubuntu22-x86_64-gcc9.3.tar.gz, root_v6.30.08.Linux-ubuntu22.04-x86_64-gcc9.4.tar.gz, root_v6.34.08.Linux-ubuntu22.04-x86_64-gcc11.4.tar.gz]
+        ROOT_VERSION: [root_v6.26.16.Linux-ubuntu22-x86_64-gcc11.4.tar.gz, root_v6.30.08.Linux-ubuntu22.04-x86_64-gcc11.4.tar.gz, root_v6.34.08.Linux-ubuntu22.04-x86_64-gcc11.4.tar.gz]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROOT_VERSION: [root_v6.24.08.Linux-ubuntu22-x86_64-gcc9.3.tar.gz, root_v6.30.08.Linux-ubuntu22.04-x86_64-gcc9.4.tar.gz]
+        ROOT_VERSION: [root_v6.24.08.Linux-ubuntu22-x86_64-gcc9.3.tar.gz, root_v6.30.08.Linux-ubuntu22.04-x86_64-gcc9.4.tar.gz, root_v6.34.08.Linux-ubuntu22.04-x86_64-gcc11.4.tar.gz]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,8 +15,7 @@ jobs:
 
     - name: Install cmake and gtest
       run: |
-        sudo apt-get install cmake libgtest-dev libglu1-mesa xxhash libglew-dev libgl2ps-dev libftgl-dev
-        sudo apt install libopengl0 -y
+        sudo apt-get install cmake libgtest-dev libglu1-mesa xxhash libglew-dev libgl2ps-dev libftgl-dev libopengl0 libtbb-dev
         cd /usr/src/gtest
         sudo cmake CMakeLists.txt
         sudo make


### PR DESCRIPTION
- Update runner from Ubuntu 20.04 to Ubuntu 22.04
- Update ROOT 6.24 and 6.30 used for testing to their latest patch versions
- Add ROOT 6.34 to the pipeline

Tagging @TadeasB .