### PR TITLE
Update the minimum required version to be able to build with CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,4 @@
-CMAKE_MINIMUM_REQUIRED( VERSION 2.8 )
-if(POLICY CMP0042)
-   # policies not known to CMake 2.8 ...
-   cmake_policy(SET CMP0042 NEW) # Mac OS -rpath behavior
-endif(POLICY CMP0042)
+CMAKE_MINIMUM_REQUIRED( VERSION 3.10 )
 
 # declare the project name
 PROJECT(genfit2 LANGUAGES CXX)


### PR DESCRIPTION
CMake 4.X requires 3.5 but it will complain it is already deprecated, so 3.10 is the minimum without warnings.