### PR TITLE
Replace std::vector with std::array in StepLimits

### DIFF
--- a/trackReps/include/StepLimits.h
+++ b/trackReps/include/StepLimits.h
@@ -57,7 +57,7 @@ class StepLimits {
   //! Number of step-limit types.
   static constexpr size_t c_nStepLimitTypes = 7;
 
-  StepLimits() : stepSign_(1) {
+  StepLimits() {
     limits_.fill(maxLimit_);
   }
 
@@ -108,7 +108,7 @@ class StepLimits {
   // limits are unsigned (i.e. non-negative)
   std::array<double, c_nStepLimitTypes> limits_;
 
-  signed char stepSign_;
+  signed char stepSign_ = 1;
   static const double maxLimit_;
 
 };

--- a/trackReps/include/StepLimits.h
+++ b/trackReps/include/StepLimits.h
@@ -24,8 +24,8 @@
 #ifndef genfit_StepLimits_h
 #define genfit_StepLimits_h
 
-#include <vector>
-#include <math.h>
+#include <array>
+#include <cmath>
 
 
 namespace genfit {
@@ -44,7 +44,6 @@ enum class EStepLimitType {
   stp_boundary,   // stepsize limited by stepper because material boundary is encountered
   stp_plane,      // stepsize limited because destination plane is reached
 
-  ENUM_NR_ITEMS   // only for internal use
 };
 
 
@@ -54,8 +53,13 @@ enum class EStepLimitType {
 class StepLimits {
 
  public:
-  StepLimits()
-  : limits_(static_cast<double>(EStepLimitType::ENUM_NR_ITEMS), maxLimit_), stepSign_(1) {;}
+
+  //! Number of step-limit types.
+  static constexpr size_t c_nStepLimitTypes = 7;
+
+  StepLimits() : stepSign_(1) {
+    limits_.fill(maxLimit_);
+  }
 
   StepLimits(const StepLimits&) = default;
 
@@ -100,7 +104,10 @@ class StepLimits {
   void Print();
 
  private:
-  std::vector<double> limits_; // limits are unsigned (i.e. non-negative)
+
+  // limits are unsigned (i.e. non-negative)
+  std::array<double, c_nStepLimitTypes> limits_;
+
   signed char stepSign_;
   static const double maxLimit_;
 

--- a/trackReps/src/StepLimits.cc
+++ b/trackReps/src/StepLimits.cc
@@ -31,10 +31,7 @@ const double StepLimits::maxLimit_ = 99.E99;
 
 
 StepLimits& StepLimits::operator=(const StepLimits& other) {
-  for (unsigned int i=1; i<static_cast<unsigned int>(EStepLimitType::ENUM_NR_ITEMS); ++i) {
-    limits_[i] = other.limits_[i];
-  }
-
+  limits_ = other.limits_;
   stepSign_ = other.stepSign_;
 
   return *this;
@@ -46,7 +43,7 @@ std::pair<EStepLimitType, double> StepLimits::getLowestLimit(double margin) cons
   double lowest(maxLimit_);
   unsigned int iLowest(0);
 
-  for (unsigned int i=1; i<static_cast<unsigned int>(EStepLimitType::ENUM_NR_ITEMS); ++i) {
+  for (size_t i = 1; i < c_nStepLimitTypes; ++i) {
 
     // lowest hard limit may exceed lowest soft limit by up to #margin
     if (i == int(EStepLimitType::stp_sMaxArg))
@@ -66,7 +63,7 @@ double StepLimits::getLowestLimitVal(double margin) const {
 
   double lowest(maxLimit_);
 
-  for (unsigned int i=1; i<static_cast<unsigned int>(EStepLimitType::ENUM_NR_ITEMS); ++i) {
+  for (size_t i = 1; i < c_nStepLimitTypes; ++i) {
 
     // lowest hard limit may exceed lowest soft limit by up to #margin
     if (i == int(EStepLimitType::stp_sMaxArg))
@@ -106,7 +103,7 @@ void StepLimits::setStepSign(double signedVal) {
 
 
 void StepLimits::reset() {
-  for (unsigned int i=1; i<static_cast<unsigned int>(EStepLimitType::ENUM_NR_ITEMS); ++i) {
+  for (size_t i = 1; i < c_nStepLimitTypes; ++i) {
     limits_[i] = maxLimit_;
   }
   stepSign_ = 1;
@@ -114,7 +111,7 @@ void StepLimits::reset() {
 
 
 void StepLimits::Print() {
-  for (unsigned int i=0; i<static_cast<unsigned int>(EStepLimitType::ENUM_NR_ITEMS); ++i) {
+  for (size_t i = 0; i < c_nStepLimitTypes; ++i) {
     if (limits_[i] >= maxLimit_)
       continue;
 
@@ -139,8 +136,6 @@ void StepLimits::Print() {
       break;
     case EStepLimitType::stp_plane:
       printOut << "stp_plane (hard limit):  stepsize limited because destination plane is reached";
-      break;
-    case EStepLimitType::ENUM_NR_ITEMS:
       break;
     }
     printOut << "\n";

--- a/trackReps/src/StepLimits.cc
+++ b/trackReps/src/StepLimits.cc
@@ -103,9 +103,7 @@ void StepLimits::setStepSign(double signedVal) {
 
 
 void StepLimits::reset() {
-  for (size_t i = 1; i < c_nStepLimitTypes; ++i) {
-    limits_[i] = maxLimit_;
-  }
+  limits_.fill(maxLimit_);
   stepSign_ = 1;
 }
 


### PR DESCRIPTION
Replace `std::vector` with `std::array` in StepLimits to reduce number of allocations.

Informing also @GiacomoXT 