### PR TITLE
Feature/add math helpers for pow x

### DIFF
--- a/fitters/src/DAF.cc
+++ b/fitters/src/DAF.cc
@@ -27,6 +27,7 @@
 #include "Tools.h"
 #include "Track.h"
 #include "TrackPoint.h"
+#include "MathHelpers.h"
 
 #include <assert.h>
 #include <cmath>
@@ -302,7 +303,7 @@ bool DAF::calcWeights(Track* tr, const AbsTrackRep* rep, double beta) {
         if (hitDim == 2)
           twoPiN *= twoPiN;
         else if (hitDim > 2)
-          twoPiN = pow(twoPiN, hitDim);
+          twoPiN = powN(twoPiN, hitDim);
 
         double chi2 = Vinv.Similarity(resid);
         if (debugLvl_ > 1) {

--- a/measurements/src/WireMeasurement.cc
+++ b/measurements/src/WireMeasurement.cc
@@ -1,5 +1,5 @@
-/* Copyright 2008-2010, Technische Universitaet Muenchen,
-   Authors: Christian Hoeppner & Sebastian Neubert & Johannes Rauch
+/* Copyright 2008-2026, Technische Universitaet Muenchen, DESY
+   Authors: Christian Hoeppner & Sebastian Neubert & Johannes Rauch & Christian Wessel
 
    This file is part of GENFIT.
 
@@ -22,6 +22,7 @@
 
 #include "WireMeasurement.h"
 #include "IO.h"
+#include "MathHelpers.h"
 
 #include <cmath>
 #include <algorithm>
@@ -106,7 +107,7 @@ std::vector<MeasurementOnPlane*> WireMeasurement::constructMeasurementsOnPlane(c
     mopR->setWeight(1);
   }
   else {
-    double val = 0.5 * pow(std::max(0., 1 - mR/maxDistance_), 2.);
+    double val = 0.5 * square(std::max(0., 1 - mR/maxDistance_));
     mopL->setWeight(val);
     mopR->setWeight(val);
   }

--- a/measurements/src/WireMeasurementNew.cc
+++ b/measurements/src/WireMeasurementNew.cc
@@ -1,6 +1,7 @@
 /* Copyright 2008-2010, Technische Universitaet Muenchen,
              2014, Ludwig-Maximilians-Universität München
-   Authors: Tobias Schlüter
+             2026, DESY
+   Authors: Tobias Schlüter, Christian Wessel
 
    This file is part of GENFIT.
 
@@ -22,6 +23,7 @@
  */
 
 #include "WireMeasurementNew.h"
+#include "MathHelpers.h"
 
 #include <cmath>
 #include <algorithm>
@@ -118,7 +120,7 @@ std::vector<MeasurementOnPlane*> WireMeasurementNew::constructMeasurementsOnPlan
     mopR->setWeight(1);
   }
   else {
-    double val = 0.5 * pow(std::max(0., 1 - mR/maxDistance_), 2.);
+    double val = 0.5 * square(std::max(0., 1 - mR/maxDistance_));
     mopL->setWeight(val);
     mopR->setWeight(val);
   }

--- a/measurements/src/WirePointMeasurement.cc
+++ b/measurements/src/WirePointMeasurement.cc
@@ -1,5 +1,5 @@
-/* Copyright 2008-2010, Technische Universitaet Muenchen,
-   Authors: Christian Hoeppner & Sebastian Neubert & Johannes Rauch
+/* Copyright 2008-2026, Technische Universitaet Muenchen, DESY
+   Authors: Christian Hoeppner & Sebastian Neubert & Johannes Rauch & Christian Wessel
 
    This file is part of GENFIT.
 
@@ -18,6 +18,7 @@
 */
 
 #include "WirePointMeasurement.h"
+#include "MathHelpers.h"
 
 #include <Exception.h>
 #include <RKTrackRep.h>
@@ -104,7 +105,7 @@ std::vector<MeasurementOnPlane*> WirePointMeasurement::constructMeasurementsOnPl
     mopR->setWeight(1);
   }
   else {
-    double val = 0.5 * pow(std::max(0., 1 - rawHitCoords_(6)/maxDistance_), 2.);
+    double val = 0.5 * square(std::max(0., 1 - rawHitCoords_(6)/maxDistance_));
     mopL->setWeight(val);
     mopR->setWeight(val);
   }

--- a/test/fitterTests/main.cc
+++ b/test/fitterTests/main.cc
@@ -350,7 +350,7 @@ int main() {
       for (int i = 0; i < 3; ++i)
         covM(i,i) = resolution*resolution;
       for (int i = 3; i < 6; ++i)
-        covM(i,i) = square(resolution / nMeasurements / sqrt(3));
+        covM(i,i) = genfit::square(resolution / nMeasurements / sqrt(3));
 
       if (debug) {
         std::cout << "start values \n";

--- a/test/fitterTests/main.cc
+++ b/test/fitterTests/main.cc
@@ -46,6 +46,7 @@
 #include <EventDisplay.h>
 
 #include <HelixTrackModel.h>
+#include <MathHelpers.h>
 #include <MeasurementCreator.h>
 
 #include <TApplication.h>
@@ -349,7 +350,7 @@ int main() {
       for (int i = 0; i < 3; ++i)
         covM(i,i) = resolution*resolution;
       for (int i = 3; i < 6; ++i)
-        covM(i,i) = pow(resolution / nMeasurements / sqrt(3), 2);
+        covM(i,i) = square(resolution / nMeasurements / sqrt(3));
 
       if (debug) {
         std::cout << "start values \n";

--- a/test/measurementFactoryExample/main.cc
+++ b/test/measurementFactoryExample/main.cc
@@ -137,7 +137,7 @@ int main() {
     for (int i = 0; i < 3; ++i)
       covSeed(i,i) = resolution*resolution;
     for (int i = 3; i < 6; ++i)
-      covSeed(i,i) = square(resolution / nMeasurements / sqrt(3));
+      covSeed(i,i) = genfit::square(resolution / nMeasurements / sqrt(3));
 
 
     // set start values and pdg to cand

--- a/test/measurementFactoryExample/main.cc
+++ b/test/measurementFactoryExample/main.cc
@@ -20,6 +20,7 @@
 #include <EventDisplay.h>
 
 #include <HelixTrackModel.h>
+#include <MathHelpers.h>
 #include <MeasurementCreator.h>
 
 #include <TDatabasePDG.h>
@@ -136,7 +137,7 @@ int main() {
     for (int i = 0; i < 3; ++i)
       covSeed(i,i) = resolution*resolution;
     for (int i = 3; i < 6; ++i)
-      covSeed(i,i) = pow(resolution / nMeasurements / sqrt(3), 2);
+      covSeed(i,i) = square(resolution / nMeasurements / sqrt(3));
 
 
     // set start values and pdg to cand

--- a/test/minimalFittingExample/main.cc
+++ b/test/minimalFittingExample/main.cc
@@ -95,7 +95,7 @@ int main() {
     for (int i = 0; i < 3; ++i)
       covM(i,i) = resolution*resolution;
     for (int i = 3; i < 6; ++i)
-      covM(i,i) = square(resolution / nMeasurements / sqrt(3));
+      covM(i,i) = genfit::square(resolution / nMeasurements / sqrt(3));
 
 
     // trackrep

--- a/test/minimalFittingExample/main.cc
+++ b/test/minimalFittingExample/main.cc
@@ -13,6 +13,7 @@
 #include <EventDisplay.h>
 
 #include <HelixTrackModel.h>
+#include <MathHelpers.h>
 #include <MeasurementCreator.h>
 
 #include <TDatabasePDG.h>
@@ -94,7 +95,7 @@ int main() {
     for (int i = 0; i < 3; ++i)
       covM(i,i) = resolution*resolution;
     for (int i = 3; i < 6; ++i)
-      covM(i,i) = pow(resolution / nMeasurements / sqrt(3), 2);
+      covM(i,i) = square(resolution / nMeasurements / sqrt(3));
 
 
     // trackrep

--- a/test/streamerTest/main.cc
+++ b/test/streamerTest/main.cc
@@ -158,7 +158,7 @@ int main() {
     for (int i = 0; i < 3; ++i)
       covM(i,i) = resolution*resolution;
     for (int i = 3; i < 6; ++i)
-      covM(i,i) = square(resolution / nMeasurements / sqrt(3));
+      covM(i,i) = genfit::square(resolution / nMeasurements / sqrt(3));
 
 
     // trackrep

--- a/test/streamerTest/main.cc
+++ b/test/streamerTest/main.cc
@@ -17,6 +17,7 @@
 #include <EventDisplay.h>
 
 #include <HelixTrackModel.h>
+#include <MathHelpers.h>
 #include <MeasurementCreator.h>
 
 #include <TDatabasePDG.h>
@@ -157,7 +158,7 @@ int main() {
     for (int i = 0; i < 3; ++i)
       covM(i,i) = resolution*resolution;
     for (int i = 3; i < 6; ++i)
-      covM(i,i) = pow(resolution / nMeasurements / sqrt(3), 2);
+      covM(i,i) = square(resolution / nMeasurements / sqrt(3));
 
 
     // trackrep

--- a/test/vertexingTest/main.cc
+++ b/test/vertexingTest/main.cc
@@ -131,7 +131,7 @@ int main() {
       for (int i = 0; i < 3; ++i)
         covM(i,i) = resolution*resolution;
       for (int i = 3; i < 6; ++i)
-        covM(i,i) = square(resolution / nMeasurements / sqrt(3));
+        covM(i,i) = genfit::square(resolution / nMeasurements / sqrt(3));
 
 
       // trackrep

--- a/test/vertexingTest/main.cc
+++ b/test/vertexingTest/main.cc
@@ -13,6 +13,7 @@
 #include <EventDisplay.h>
 
 #include <HelixTrackModel.h>
+#include <MathHelpers.h>
 #include <MeasurementCreator.h>
 
 #include <GFRaveVertexFactory.h>
@@ -130,7 +131,7 @@ int main() {
       for (int i = 0; i < 3; ++i)
         covM(i,i) = resolution*resolution;
       for (int i = 3; i < 6; ++i)
-        covM(i,i) = pow(resolution / nMeasurements / sqrt(3), 2);
+        covM(i,i) = square(resolution / nMeasurements / sqrt(3));
 
 
       // trackrep

--- a/trackReps/src/MaterialEffects.cc
+++ b/trackReps/src/MaterialEffects.cc
@@ -1,5 +1,5 @@
-/* Copyright 2008-2014, Technische Universitaet Muenchen,
-   Authors: Christian Hoeppner & Sebastian Neubert
+/* Copyright 2008-2026, Technische Universitaet Muenchen, DESY
+   Authors: Christian Hoeppner & Sebastian Neubert & Christian Wessel
 
    This file is part of GENFIT.
 
@@ -20,6 +20,7 @@
 #include "MaterialEffects.h"
 #include "Exception.h"
 #include "IO.h"
+#include "MathHelpers.h"
 
 #include <stdexcept>
 #include <string>
@@ -436,7 +437,7 @@ double MaterialEffects::momentumLoss(double stepSign, double mom, bool linear)
     // Step would stop particle (E_kin <= 0).
     return momLoss = mom;
   }
-  else momLoss = mom - sqrt(pow(E0 - dE, 2) - mass_*mass_); // momLoss; positive for positive stepSign
+  else momLoss = mom - sqrt(square(E0 - dE) - mass_*mass_); // momLoss; positive for positive stepSign
 
   if (debugLvl_ > 0) {
     debugOut << "      MaterialEffects::momentumLoss: mom = " << mom << "; E0 = " << E0
@@ -532,9 +533,9 @@ void MaterialEffects::noiseBetheBloch(M7x7& noise, double mom, double betaSquare
         sigmaalpha =  1.975560
                       + 9.898841e-02 * RLAMAX
                       - 2.828670e-04 * RLAMAX * RLAMAX
-                      + 5.345406e-07 * pow(RLAMAX, 3.)
-                      - 4.942035e-10 * pow(RLAMAX, 4.)
-                      + 1.729807e-13 * pow(RLAMAX, 5.);
+                      + 5.345406e-07 * cube(RLAMAX)
+                      - 4.942035e-10 * pow4(RLAMAX)
+                      + 1.729807e-13 * pow5(RLAMAX);
       } else { sigmaalpha = 1.871887E+01 + 1.296254E-02 * RLAMAX; }
       // alpha=54.6  corresponds to a 0.9996 maximum cut
       if (sigmaalpha > 54.6) sigmaalpha = 54.6;
@@ -550,7 +551,7 @@ void MaterialEffects::noiseBetheBloch(M7x7& noise, double mom, double betaSquare
   sigma2E *= 1.E-18; // eV -> GeV
 
   // update noise matrix, using linear error propagation from E to q/p
-  noise[6 * 7 + 6] += charge_*charge_/betaSquare / pow(mom, 4) * sigma2E;
+  noise[6 * 7 + 6] += charge_*charge_/betaSquare / pow4(mom) * sigma2E;
 }
 
 
@@ -777,7 +778,7 @@ double MaterialEffects::dEdxBrems(double mom) const
       if (X > -8.) {
         if (X >= +9.) ETA = 1.;
         else {
-          double W = A1 * X + A3 * pow(X, 3.) + A5 * pow(X, 5.);
+          double W = A1 * X + A3 * cube(X) + A5 * pow5(X);
           ETA = 0.5 + atan(W) / M_PI;
         }
       }
@@ -816,7 +817,7 @@ void MaterialEffects::noiseBrems(M7x7& noise, double momSquare, double betaSquar
   sigma2E = std::max(sigma2E, 0.0); // must be positive
   
   // update noise matrix, using linear error propagation from E to q/p
-  noise[6 * 7 + 6] += charge_*charge_/betaSquare / pow(momSquare, 2) * sigma2E;
+  noise[6 * 7 + 6] += charge_*charge_/betaSquare / square(momSquare) * sigma2E;
 }
 
 

--- a/trackReps/src/RKTrackRep.cc
+++ b/trackReps/src/RKTrackRep.cc
@@ -1,5 +1,5 @@
-/* Copyright 2008-2013, Technische Universitaet Muenchen, Ludwig-Maximilians-Universität München
-   Authors: Christian Hoeppner & Sebastian Neubert & Johannes Rauch & Tobias Schlüter
+/* Copyright 2008-2026, Technische Universitaet Muenchen, Ludwig-Maximilians-Universität München, DESY
+   Authors: Christian Hoeppner & Sebastian Neubert & Johannes Rauch & Tobias Schlüter & Christian Wessel
 
    This file is part of GENFIT.
 
@@ -19,6 +19,7 @@
 
 #include "RKTrackRep.h"
 #include "IO.h"
+#include "MathHelpers.h"
 
 #include <Exception.h>
 #include <FieldManager.h>
@@ -901,7 +902,7 @@ double RKTrackRep::getMomVar(const MeasuredStateOnPlane& state) const {
   // delta means sigma
   // cov(0,0) is sigma^2
 
-  return state.getCov()(0,0) * pow(getCharge(state), 2)  / pow(state.getState()(0), 4);
+  return state.getCov()(0,0) * square(getCharge(state))  / pow4(state.getState()(0));
 }
 
 
@@ -1185,18 +1186,18 @@ void RKTrackRep::setPosMomErr(MeasuredStateOnPlane& state, const TVector3& pos, 
 
   TMatrixDSym& cov(state.getCov());
 
-  cov(0,0) = pow(getCharge(state), 2) / pow(mom.Mag(), 6) *
+  cov(0,0) = square(getCharge(state)) / cube(mom.Mag2()) *
              (mom.X()*mom.X() * momErr.X()*momErr.X()+
               mom.Y()*mom.Y() * momErr.Y()*momErr.Y()+
               mom.Z()*mom.Z() * momErr.Z()*momErr.Z());
 
-  cov(1,1) = pow((U.X()/pw - W.X()*pu/(pw*pw)),2.) * momErr.X()*momErr.X() +
-             pow((U.Y()/pw - W.Y()*pu/(pw*pw)),2.) * momErr.Y()*momErr.Y() +
-             pow((U.Z()/pw - W.Z()*pu/(pw*pw)),2.) * momErr.Z()*momErr.Z();
+  cov(1,1) = square(U.X()/pw - W.X()*pu/(pw*pw)) * momErr.X()*momErr.X() +
+             square(U.Y()/pw - W.Y()*pu/(pw*pw)) * momErr.Y()*momErr.Y() +
+             square(U.Z()/pw - W.Z()*pu/(pw*pw)) * momErr.Z()*momErr.Z();
 
-  cov(2,2) = pow((V.X()/pw - W.X()*pv/(pw*pw)),2.) * momErr.X()*momErr.X() +
-             pow((V.Y()/pw - W.Y()*pv/(pw*pw)),2.) * momErr.Y()*momErr.Y() +
-             pow((V.Z()/pw - W.Z()*pv/(pw*pw)),2.) * momErr.Z()*momErr.Z();
+  cov(2,2) = square(V.X()/pw - W.X()*pv/(pw*pw)) * momErr.X()*momErr.X() +
+             square(V.Y()/pw - W.Y()*pv/(pw*pw)) * momErr.Y()*momErr.Y() +
+             square(V.Z()/pw - W.Z()*pv/(pw*pw)) * momErr.Z()*momErr.Z();
 
   cov(3,3) = posErr.X()*posErr.X() * U.X()*U.X() +
              posErr.Y()*posErr.Y() * U.Y()*U.Y() +

--- a/trackReps/src/TGeoMaterialInterface.cc
+++ b/trackReps/src/TGeoMaterialInterface.cc
@@ -1,5 +1,5 @@
-/* Copyright 2008-2014, Technische Universitaet Muenchen,
-   Authors: Christian Hoeppner & Sebastian Neubert & Johannes Rauch
+/* Copyright 2008-2026, Technische Universitaet Muenchen, DESY
+   Authors: Christian Hoeppner & Sebastian Neubert & Johannes Rauch & Christian Wessel
 
    This file is part of GENFIT.
 
@@ -20,6 +20,7 @@
 #include "TGeoMaterialInterface.h"
 #include "Exception.h"
 #include "IO.h"
+#include "MathHelpers.h"
 
 #include <TGeoMedium.h>
 #include <TGeoMaterial.h>
@@ -136,9 +137,9 @@ TGeoMaterialInterface::findNextBoundary(const RKTrackRep* rep,
 
     // Straight line distance² between extrapolation finish and
     // the end of the previously determined safe segment.
-    double dist2 = (pow(state7[0] - oldState7[0], 2)
-        + pow(state7[1] - oldState7[1], 2)
-        + pow(state7[2] - oldState7[2], 2));
+    double dist2 = (square(state7[0] - oldState7[0])
+        + square(state7[1] - oldState7[1])
+        + square(state7[2] - oldState7[2]));
     // Maximal lateral deviation².
     double maxDeviation2 = 0.25*(step*step - dist2);
 

--- a/utilities/include/MathHelpers.h
+++ b/utilities/include/MathHelpers.h
@@ -66,4 +66,23 @@ namespace genfit {
     return x4 * x2;
   }
 
+  /**
+   * Generalised method
+   */
+  template<typename T>
+  inline constexpr T powN(const T x, const int N)
+  {
+    if (N == 3) {
+      return cube(x);
+    } else if (N == 4) {
+      return pow4(x);
+    } else if (N == 5) {
+      return pow5(x);
+    } else if (N == 6) {
+      return pow6(x);
+    } else {
+      return std::pow(x, static_cast<T>(N));
+    }
+  }
+
 }

--- a/utilities/include/MathHelpers.h
+++ b/utilities/include/MathHelpers.h
@@ -1,0 +1,69 @@
+/* Copyright 2026, DESY
+   Authors: Christian Wessel
+
+   This file is part of GENFIT.
+
+   GENFIT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   GENFIT is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with GENFIT.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+namespace genfit {
+
+  /**
+   * Calculate the square of the input
+   */
+  template<typename T>
+  inline constexpr T square(const T& x)
+  {
+    return x * x;
+  }
+  /**
+   * Calculate the cube of the input
+   */
+  template<typename T>
+  inline constexpr T cube(const T& x)
+  {
+    return x * x * x;
+  }
+  /**
+   * Calculate the fourth power of the input
+   */
+  template<typename T>
+  inline constexpr T pow4(const T& x)
+  {
+    const T x2 = square(x);
+    return x2 * x2;
+  }
+  /**
+   * Calculate the fifth power of the input
+   */
+  template<typename T>
+  inline constexpr T pow5(const T& x)
+  {
+    const T x4 = pow4(x);
+    return x4 * x;
+  }
+  /**
+   * Calculate the sixth power of the input
+   */
+  template<typename T>
+  inline constexpr T pow6(const T& x)
+  {
+    const T x4 = pow4(x);
+    const T x2 = square(x);
+    return x4 * x2;
+  }
+
+}


### PR DESCRIPTION
`std::pow` is designed as a general algorithm and as such e.g. `std::pow(x, 2)` is much slower than directly calculating `x * x`. From some tests using godbolt [0] I found that both gcc/gpp and clang are only capable of simplifying `std::pow(x, 2)` to `x * x` when using the `ffast-math` flag, which we don't use. Additional source in [1]

[0]
gcc with `-O3`: https://godbolt.org/z/4rsvvW39h
gcc with `-O3 -ffast-math`: https://godbolt.org/z/9MM5qEEM7
clang with `-O3`: https://godbolt.org/z/b4Tzqs7Y7
clang with `-O3 -ffast-math`: https://godbolt.org/z/f1fP91afc
[1] https://baptiste-wicht.com/posts/2017/09/cpp11-performance-tip-when-to-use-std-pow.html